### PR TITLE
Correct encoding name

### DIFF
--- a/src/ralph/discovery/tests/__init__.py
+++ b/src/ralph/discovery/tests/__init__.py
@@ -1,4 +1,4 @@
-# -*- coding: utf8 -*-
+# -*- coding: utf-8 -*-
 
 from ralph.discovery.tests.plugins import *
 from ralph.discovery.tests.model_tests import ModelsTest


### PR DESCRIPTION
Use correct encoding name otherwise gettext will fail, when trying to parse this file
