### PR TITLE
Correctly display role name in device report

### DIFF
--- a/src/ralph/ui/templates/ui/device_reports.html
+++ b/src/ralph/ui/templates/ui/device_reports.html
@@ -60,7 +60,7 @@
                 </tr>
                 <tr>
                     <th>Role</th>
-                    <td>{{ device.role }}</td>
+                    <td>{{ device.venture_role.name }}</td>
                 </tr>
                 <tr>
                     <th>Parent</th>


### PR DESCRIPTION
This should correctly display the role for the device in the "Reports" tab, previously it displayed the old and rather obsolete "old role" field
