### PR TITLE
Fixed Integrity error while reconcilating already created cichangegit-s

### DIFF
--- a/src/ralph/cmdb/models_signals.py
+++ b/src/ralph/cmdb/models_signals.py
@@ -140,7 +140,7 @@ def post_create_change(sender, instance, raw, using, **kwargs):
         if chdb.CIChange.objects.filter(
             content_type=ContentType.objects.get_for_model(instance),
             object_id=instance.id,
-        ).count():
+        ).exists():
             # already created parent cichange(e.g while saving for 2 time). Skip it.
             return
         ch = chdb.CIChange()


### PR DESCRIPTION
Integrity error occurs when after registration of git change, a litle bit later record is saved for 2nd time (e.g ci was matched and saved). This triggered creating duplicated cichange.
