### PR TITLE
Fixed concurrent_get_or_create for puppet plugin. 

### DIFF
--- a/src/ralph/discovery/hardware.py
+++ b/src/ralph/discovery/hardware.py
@@ -310,7 +310,8 @@ def handle_megaraid(dev, disks, priority=0):
         if disk['product'].lower() in DISK_PRODUCT_BLACKLIST:
             continue
         stor, created = Storage.concurrent_get_or_create(
-            device=dev, sn=disk['serial_number'], mount_point=None)
+            device=dev, sn=disk['serial_number'], mount_point=None,
+        )
         stor.device = dev
         size_value, size_unit, rest = disk['coerced_size'].split(' ', 2)
         size_value = size_value.replace(',', '')
@@ -343,7 +344,8 @@ def handle_hpacu(dev, disks, priority=0):
         if not disk.get('serial_number'):
             continue
         stor, created = Storage.concurrent_get_or_create(
-            device=dev, sn=disk['serial_number'], mount_point=None)
+            device=dev, sn=disk['serial_number'], mount_point=None,
+        )
         stor.device = dev
         size_value, size_unit = disk['size'].split()
         stor.size = int(float(size_value) / units.size_divisor[size_unit])


### PR DESCRIPTION
When mount_point is not known, just ignore unique_together key for (device, mount_point) and use the sn as key.
