### PR TITLE
Information column about depreciation in prices, costs and purchase tab

### DIFF
--- a/src/ralph/ui/templates/ui/device_list.html
+++ b/src/ralph/ui/templates/ui/device_list.html
@@ -42,7 +42,7 @@
         {% include 'ui/column-header.html' with label='Purchase Date' name='purchase' type='date' %}
         {% include 'ui/column-header.html' with label='Warranty Expiration' name='warranty' type='date' %}
         {% include 'ui/column-header.html' with label='Support Expiration' name='support' type='date' %}
-        {% include 'ui/column-header.html' with label='Depreciation' name='depreciation' %}
+        {% include 'ui/column-header.html' with label='Deprecation' name='deprecation' %}
         {% endspaceless %}
     </tr></thead>
     <tbody>

--- a/src/ralph/ui/templates/ui/device_row.html
+++ b/src/ralph/ui/templates/ui/device_row.html
@@ -104,15 +104,15 @@
     {% if 'support' in columns %}
     <td>{{ d.support_expiration_date|date:'Y-m-d H:i'|default:'' }}</td>
     {% endif %}
-    {% if 'depreciation' in columns %}
+    {% if 'deprecation' in columns %}
     <td>
-        {% if  d.purchase_date %}
+        {% if d.purchase_date %}
             {% if now > d.deprecation_date %}
-                <i class="fugue-icon fugue-baggage-cart"></i> after depreciation
+                <i class="fugue-icon fugue-baggage-cart"></i> after deprecation
             {% else %}
-                <i class="fugue-icon fugue-baggage-cart-box"></i> during depreciation
+                <i class="fugue-icon fugue-baggage-cart-box"></i> during deprecation
             {% endif %}
-        {% elif d.model.type == 204 or d.model.type == 203 %}
+        {% elif d.model.type == device_types.cloud_server.id or d.model.type == device_types.virtual_server.id %}
         —
         {% else %}
             <i class="fugue-icon fugue-exclamation"></i> no purchase date

--- a/src/ralph/ui/views/devices.py
+++ b/src/ralph/ui/views/devices.py
@@ -15,6 +15,7 @@ from django.utils.translation import ugettext as _
 from django.views.generic import ListView
 
 from ralph.account.models import Perm
+from ralph.discovery.models_device import DeviceType
 from ralph.util import csvutil
 
 
@@ -75,11 +76,11 @@ class BaseDeviceList(ListView):
     details_columns = {
         'info': ['venture', 'model', 'position', 'remarks'],
         'components': ['model', 'barcode', 'sn'],
-        'prices': ['venture', 'margin', 'deprecation', 'price', 'cost', 'depreciation'],
+        'prices': ['venture', 'margin', 'deprecation', 'price', 'cost', 'deprecation'],
         'addresses': ['ips', 'management'],
-        'costs': ['venture', 'cost', 'depreciation'],
+        'costs': ['venture', 'cost', 'deprecation'],
         'history': ['created', 'lastseen'],
-        'purchase': ['purchase', 'warranty', 'support', 'depreciation'],
+        'purchase': ['purchase', 'warranty', 'support', 'deprecation'],
         'discover': ['lastseen'],
         'cmdb': [],
         'reports': ['venture', 'remarks'],
@@ -182,6 +183,7 @@ class BaseDeviceList(ListView):
             'show_tabs': _get_show_tabs(self.request, self.venture, None),
             'sort': self.sort,
             'now': datetime.datetime.now(),
+            'device_types': DeviceType,
         })
         return ret
 


### PR DESCRIPTION
In column displayed information one of the four:
- after depreciation,
- during depreciation,
- no purchase date,
- — (long dash) - when device is virtual or cloud server,

http://ralph.allegrogroup.com/buildbot/builders/unittest-ralph-quamilek/builds/180
