### PR TITLE
Fixes issue #495: adding a user from admin fails

### DIFF
--- a/src/ralph/account/admin.py
+++ b/src/ralph/account/admin.py
@@ -109,9 +109,12 @@ class ProfileAdmin(UserAdmin):
 
         See: https://github.com/allegro/ralph/issues/495
         """
-        if obj:
-            for inline in self.get_inline_instances(request):
-                yield inline.get_formset(request, obj)
+        if not obj:
+            return
+        for formset in super(ProfileAdmin, self).get_formsets(
+            request, obj=obj,
+        ):
+            yield formset
 
 
 admin.site.unregister(User)


### PR DESCRIPTION
By dropping inlines from the user admin we mitigate the chicken and egg problem of User + Profile model dependencies.
