### PR TITLE
Initial database creation in Postgres resolved 

### DIFF
--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -308,13 +308,15 @@ zero configuration options.
 After creating the default config file, let's synchronize the database from
 sources by running the standard ``syncdb`` management command::
 
-  (ralph)$ ralph syncdb
+  (ralph)$ ralph syncdb --all
 
 Django will create some tables, setup some default values and ask whether you
 want to create a superuser. Do so, you will use the credentials given to test
-whether the setup worked. Then migrate the rest of the tables::
+whether the setup worked. The ``--all`` switch to ``syncdb`` created all
+tables, even if there are existing migrations for them. Mark all those
+migrations as done by running::
 
-  (ralph)$ ralph migrate
+  (ralph)$ ralph migrate --fake
 
 Lastly, we need to link the static images, CSS files, JavaScript sources, etc.
 to a common place so the front-end Web server can pick them up. That way the

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ setup (
         'ipaddr==2.1.7',
         'iscconf==1.0.0dev9',
         'jpath==1.2',
-        'lck.django==0.8.9',
+        'lck.django==0.8.10',
         'lxml==2.3.5',
         'mock==0.8.0',
         'MySQL-python==1.2.3',

--- a/src/ralph/util/models.py
+++ b/src/ralph/util/models.py
@@ -13,11 +13,14 @@ from django.db.utils import DatabaseError
 from django.contrib.auth.models import User
 from tastypie.models import create_api_key
 
+
 def create_api_key_ignore_dberrors(*args, **kwargs):
     try:
         return create_api_key(*args, **kwargs)
     except DatabaseError:
-        pass # no such table yet, first syncdb
+        # no such table yet, first syncdb
+        from django.db import transaction
+        transaction.rollback_unless_managed()
 
 db.signals.post_save.connect(create_api_key_ignore_dberrors, sender=User)
 


### PR DESCRIPTION
- lck.django 0.8.10 fixes initial migration dependency resolution for profile-related models, profile sync properly rolls back on initial syncdb on Postgres
- documentation updated to indicate the correct workflow for creating the initial database structure with Postgres
  
  ```
  ralph syncdb --all
  ralph migrate --fake
  ```
  
  This is required because Postgres supports DDL transactions and we currently unfortunately have some bi-directional app1.models <---> app2.models dependencies.
