### PR TITLE
Bumped packages version 

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,7 @@ setup (
         'pysnmp==4.2.2',
         'PyYAML==3.10',
         'python-graph-core==1.8.2',
-        'pytz==2012b',
+        'pytz==2013b',
         'pyzabbix>=0.1',
         'requests>=0.14.2',
         'RestKit==4.2.0',


### PR DESCRIPTION
- Django from 1.4.5 to 1.4.6
- dnspython from 1.10.0 to 1.11.0
- pytz from 2012b to 2013b
