### PR TITLE
bugfix with network finding

### DIFF
--- a/src/ralph/discovery/models_network.py
+++ b/src/ralph/discovery/models_network.py
@@ -147,6 +147,13 @@ class AbstractNetwork(db.Model):
     def network(self):
         return ipaddr.IPNetwork(self.address)
 
+    def get_netmask(self):
+        try:
+            mask = self.address.split("/")[1]
+            return int(mask)
+        except (ValueError, IndexError):
+            return None
+
     def clean(self, *args, **kwargs):
         super(AbstractNetwork, self).clean(*args, **kwargs)
         try:

--- a/src/ralph/ui/forms/devices.py
+++ b/src/ralph/ui/forms/devices.py
@@ -324,7 +324,12 @@ class DeviceInfoForm(DeviceForm):
             return
         rack = self.instance.find_rack()
         if rack:
-            for network in rack.network_set.order_by('name'):
+            rack_networks = sorted(
+                rack.network_set.all(),
+                key=lambda net: net.get_netmask(),
+                reverse=True,
+            )
+            for network in rack_networks:
                 next_hostname = get_next_free_hostname(network.data_center)
                 if next_hostname:
                     help_text = 'Next available hostname in this DC: %s' % (


### PR DESCRIPTION
Next hostname in ralph is shown incorrectly. That was because it ordered rack networks by name, which was stupid. Wider network could be based in different datacenter and still turn out as first. Now it is sorted by netmask.
