### PR TITLE
fix of method Network.from_ip returning widest network

### DIFF
--- a/src/ralph/discovery/models_network.py
+++ b/src/ralph/discovery/models_network.py
@@ -140,7 +140,7 @@ class AbstractNetwork(db.Model):
         nets = cls.objects.filter(
             min_ip__lte=ip_int,
             max_ip__gte=ip_int
-        ).order_by('min_ip', '-max_ip')
+        ).order_by('-min_ip', 'max_ip')
         return nets
 
     @property


### PR DESCRIPTION
Sorting was min_ip ASC and max_ip DESC, so lowest min_ip and highest max_ip was first, therefore widest network.
