### PR TITLE
Add POWER_CONSUMPTION_UNIT to settings

### DIFF
--- a/src/ralph/settings.py
+++ b/src/ralph/settings.py
@@ -209,6 +209,7 @@ SERVER_EMAIL = DEFAULT_FROM_EMAIL
 TIME_ZONE = 'Europe/Warsaw'
 LANGUAGE_CODE = 'en-us'
 CURRENCY = 'PLN'
+POWER_CONSUMPTION_UNIT = 'kWh'
 DATABASES = {
     'default': {
         'ENGINE': 'django.db.backends.sqlite3',


### PR DESCRIPTION
- This option is needed by assets_pricing for display power consumption with correct unit
