### PR TITLE
loggers for ralph_pricing and ralph_assets

### DIFF
--- a/src/ralph/settings.py
+++ b/src/ralph/settings.py
@@ -142,6 +142,21 @@ LOGGING = {
             'propagate': True,
             'level': 'DEBUG',
         },
+        'ralph_assets': {
+            'handlers': ['file'],
+            'propagate': True,
+            'level': 'DEBUG',
+        },
+        'ralph_pricing': {
+            'handlers': ['file'],
+            'propagate': True,
+            'level': 'DEBUG',
+        },
+        'ralph_pricing.plugins': {
+            'handlers': ['file', 'console'],
+            'propagate': True,
+            'level': 'DEBUG',
+        },
         'critical_only': {
             'handlers': ['file', 'mail_admins'],
             'level': 'CRITICAL',


### PR DESCRIPTION
I've added loggers for ralph_pricing (dedicated logger for ralph_pricing.plugins to log in console) and ralph_assets. It's only temporary solution (to have logging in pricing and assets working right now) - imo we should create seprate settings for pricing and assets, which only extends ralph settings.
