### PR TITLE
reverse fixes

### DIFF
--- a/src/ralph/discovery/models_network.py
+++ b/src/ralph/discovery/models_network.py
@@ -365,7 +365,7 @@ class Network(Named, AbstractNetwork, TimeTrackable,
         return "{} ({})".format(self.name, self.address)
 
     def get_absolute_url(self):
-        args = [urllib.quote(self.name, ''), 'info']
+        args = [urllib.quote(self.name.encode('utf-8'), ''), 'info']
         return reverse("networks", args=args)
 
 

--- a/src/ralph/ui/views/networks.py
+++ b/src/ralph/ui/views/networks.py
@@ -49,7 +49,10 @@ def network_tree_menu(networks, details, get_params, show_ip=False, status=''):
     items = []
 
     def get_href(view_args):
-        view_args = map(lambda arg: urllib.quote(arg, ''), view_args)
+        view_args = map(
+            lambda arg: urllib.quote(arg.encode('utf-8'), ''),
+            view_args,
+        )
         url = reverse("networks", args=view_args)
         return '%s?%s' % (
             url,


### PR DESCRIPTION
When slash or other special characters apeared in network name, reverse raised error.
