### PR TITLE
Show customfields only on give types

### DIFF
--- a/src/ralph/cmdb/forms.py
+++ b/src/ralph/cmdb/forms.py
@@ -101,7 +101,7 @@ class CIEditForm(DependencyForm, forms.ModelForm):
 
     def _add_customattribute_fields(self):
         self.dependencies = self.dependencies or []
-        for attribute in CIAttribute.objects.all():
+        for attribute in CIAttribute.objects.filter(ci_types=self.initial.get('type')):
             field_name = self._get_custom_attribute_field_name(attribute)
             FieldType = self.CUSTOM_ATTRIBUTE_FIELDS[attribute.attribute_type]
             kwargs = {
@@ -136,7 +136,7 @@ class CIEditForm(DependencyForm, forms.ModelForm):
             attribute_values = dict(
                 ((av.attribute.name, av) for av in attribute_values)
             )
-            for attribute in CIAttribute.objects.all():
+            for attribute in CIAttribute.objects.filter(ci_types=self.initial.get('type')):
                 attribute_value = attribute_values.get(attribute.name)
                 if attribute_value is not None:
                     field_name = self._get_custom_attribute_field_name(


### PR DESCRIPTION
Fixed bug where CI Attributes shows on all citypes, instead of given type
