### PR TITLE
Move scripts block to the head tag

### DIFF
--- a/src/ralph/ui/templates/ui/base.html
+++ b/src/ralph/ui/templates/ui/base.html
@@ -11,6 +11,25 @@
 <link rel="stylesheet" href="{{ STATIC_URL }}ui/custom.css">
 <link rel="stylesheet" href="{{ STATIC_URL }}ui/datepicker.css">
 <link rel="stylesheet" href="{{ STATIC_URL }}jquery.treegrid.css">
+{% block scripts %}
+<script src="{{ STATIC_URL }}require.js"></script>
+<!-- Use require.js for mustache! -->
+<!-- <script src="{{ STATIC_URL }}mustache.js"></script> -->
+<script src="{{ STATIC_URL }}jquery-1.7.2.min.js"></script>
+<script src="{{ STATIC_URL }}bootstrap/js/bootstrap.min.js"></script>
+<script src="{{ STATIC_URL }}bootstrap/js/bob.js"></script>
+<script src="{{ STATIC_URL }}bootstrap-datepicker.js"></script>
+<script src="{{ STATIC_URL }}jquery.treegrid.js"></script>
+<script src="{{ STATIC_URL }}jquery.treegrid.bootstrap2.js"></script>
+<script src="{{ STATIC_URL }}ui/main.js"></script>
+<script type="text/javascript">
+    requirejs.config({
+        baseUrl: '{{ STATIC_URL }}',
+        paths: {}
+    });
+</script>
+{% endblock %}
+
 {% block extra_headers %}{% endblock %}
 </head><body>
 <div class="container-fluid browser-min-width">
@@ -51,24 +70,6 @@
         {% endblock %}
     </div>
 </div>
-{% block scripts %}
-<script src="{{ STATIC_URL }}require.js"></script>
-<!-- Use require.js for mustache! -->
-<!-- <script src="{{ STATIC_URL }}mustache.js"></script> -->
-<script src="{{ STATIC_URL }}jquery-1.7.2.min.js"></script>
-<script src="{{ STATIC_URL }}bootstrap/js/bootstrap.min.js"></script>
-<script src="{{ STATIC_URL }}bootstrap/js/bob.js"></script>
-<script src="{{ STATIC_URL }}bootstrap-datepicker.js"></script>
-<script src="{{ STATIC_URL }}jquery.treegrid.js"></script>
-<script src="{{ STATIC_URL }}jquery.treegrid.bootstrap2.js"></script>
-<script src="{{ STATIC_URL }}ui/main.js"></script>
-<script type="text/javascript">
-    requirejs.config({
-        baseUrl: '{{ STATIC_URL }}',
-        paths: {}
-    });
-</script>
-{% endblock %}
 </body></html>
 <!--STATS-->
 


### PR DESCRIPTION
Javascript files will be included in head tag instead of the bottom of the body. This change prevents field widgets to load its own jquery.
