### PR TITLE
'model group' and 'model' in 'software' tab (fix)

### DIFF
--- a/src/ralph/ui/templates/ui/device_software.html
+++ b/src/ralph/ui/templates/ui/device_software.html
@@ -8,8 +8,6 @@
         <th width="16"></th>
         <th>Label</th>
         <th>Version</th>
-        <th>Model Group</th>
-        <th>Model</th>
     </tr></thead>
     <tbody>
         {% for item in components %}
@@ -26,38 +24,6 @@
             {%  endif %}
             <td>
                 {{ item.version|default:'–' }}
-            </td>
-            <td>
-                {% if item.model.group %}
-                    {% if item.group == 'dev' %}
-                        <a href="{% url 'catalog' 'device' item.model.type item.model.group.id|default:''%}">
-                            {{ item.model.group.name }}
-                        </a>
-                    {% else %}
-                        <a href="{% url 'catalog' 'component' item.model.type  item.model.group.id|default:''%}">
-                            {{ item.model.group.name }}
-                        </a>
-                    {% endif %}
-                {% endif %}
-            </td>
-            <td>
-                {% if item.model.group %}
-                    {% if item.group == 'dev' %}
-                        <a href="{% url 'search' 'component' '' %}?model={{ item.model.name }}">
-                            {{ item.model.name }}
-                        </a>
-                    {% else %}
-                        <a href="{% url 'search' 'component' '' %}?component={{ item.model }}">
-                            {{ item.model }}
-                        </a>
-                    {% endif %}
-                {% else %}
-                    {% if item.model.type %}
-                        <a href="{% url 'catalog' 'component' item.model.type %}">{{ item.model }}</a>
-                    {% else %}
-                        {{ item.model }}
-                    {% endif %}
-                {% endif %}
             </td>
         </tr>
         {% endif %}

--- a/src/ralph/ui/views/catalog.py
+++ b/src/ralph/ui/views/catalog.py
@@ -420,13 +420,13 @@ class CatalogComponent(Catalog):
         else:
             self.query = ComponentModel.objects.filter(
                 type=self.model_type_id).filter(group=None)
-        unassigned_componsents = ComponentModel.objects.filter(
+        unassigned_components = ComponentModel.objects.filter(
             type=self.model_type_id
         ).filter(
             group=None
         )
         unassigned_count = 0
-        for u in unassigned_componsents:
+        for u in unassigned_components:
             unassigned_count = unassigned_count + u.get_count()
         self.unassigned_count = unassigned_count
         groups = list(ComponentModelGroup.objects.filter(


### PR DESCRIPTION
Columns 'Model Group' and 'Model' should not be shown in 'Software' tab (only 'Label' and 'Version' are needed there).

(+ fixed a typo in catalog.py.)
