### PR TITLE
Fixed the bug with effective fields

### DIFF
--- a/src/ralph/cmdb/api.py
+++ b/src/ralph/cmdb/api.py
@@ -181,7 +181,7 @@ class OwnershipField(tastypie.fields.RelatedField):
         self.owner_type = owner_type.id
         self.owner_type_name = owner_type.name
         self.effective = effective
-
+        kwargs['readonly'] = self.effective
         args = (
             'ralph.cmdb.api.CIOwnersResource',
             self.get_attribute_name(),


### PR DESCRIPTION
The 'effective_*_owners' fields were overwriting the corresponding fields. The effect was that 'technical_owners' was empty (due to the dict ordering). The 'readonly' flag causes tastypie to skip saving the field thus fixing the bug.
