### PR TITLE
Fixed bug with service lookup

### DIFF
--- a/src/ralph/cmdb/api.py
+++ b/src/ralph/cmdb/api.py
@@ -130,7 +130,7 @@ class ServiceResource(MResource):
         attrs = ('external_key', 'location', 'state',
                  'it_person', 'it_person_mail', 'business_person',
                  'business_person_mail', 'business_line')
-        ci = CI.objects.get(uid=bundle.data.get('uid'))
+        ci = bundle.obj
         for attr in attrs:
             bundle.data[attr] = getattr(ci.content_object, attr, '')
         return bundle


### PR DESCRIPTION
There is no need to retrieve CI by uid. We have it in the bundle. Trying to retrieve it again caused crash for CIs that had no uid.
