### PR TITLE
Fixed 'Bulk edit' button on 'Ventures' and 'Racks' views.

### DIFF
--- a/src/ralph/ui/views/common.py
+++ b/src/ralph/ui/views/common.py
@@ -1385,7 +1385,7 @@ class BulkEdit(BaseMixin, TemplateView):
         if not self.devices:
             messages.error(
                 self.request,
-                "You haven't selected any existing (i.e. not deleted) devices.",
+                "You haven't selected any existing devices.",
             )
             return HttpResponseRedirect(self.request.path + '../info/')
         self.edit_fields = self.request.POST.getlist('edit')
@@ -1412,6 +1412,7 @@ class BulkEdit(BaseMixin, TemplateView):
                     self.form.data,
                     self.request.user
                 )
+                messages.success(self.request, 'Changes saved succesfully.')
                 return HttpResponseRedirect(self.request.path + '../info/')
             else:
                 messages.error(self.request, 'Please correct the errors.')
@@ -1420,10 +1421,6 @@ class BulkEdit(BaseMixin, TemplateView):
         return super(BulkEdit, self).get(*args, **kwargs)
 
     def get(self, *args, **kwargs):
-        messages.error(
-            self.request,
-            "You haven't selected any devices.",
-        )
         return HttpResponseRedirect(self.request.path + '../info/')
 
     def get_context_data(self, **kwargs):

--- a/src/ralph/ui/views/racks.py
+++ b/src/ralph/ui/views/racks.py
@@ -144,6 +144,7 @@ class SidebarRacks(BaseRacksMixin):
             'sidebar_selected': _get_identifier(self.rack),
             'section': 'racks',
             'subsection': _get_identifier(self.rack),
+            'show_bulk': True if self.rack else False,
         })
         return ret
 

--- a/src/ralph/ui/views/ventures.py
+++ b/src/ralph/ui/views/ventures.py
@@ -177,6 +177,7 @@ class SidebarVentures(object):
                            self.venture and self.venture != '*' else self.venture),
             'searchform': VentureFilterForm(self.request.GET),
             'searchform_filter': True,
+            'show_bulk': True if self.venture else False,
         })
         return ret
 


### PR DESCRIPTION
This is an extension of pull request #865 onto 'Ventures' and 'Racks' views ('Bulk edit' button shouldn't be visible when nothing has been selected from the ventures/racks tree).

It also resolves the issue #852.
