### PR TITLE
Manual prescan (autoscan) shouldn't be run as a separate job.

### DIFF
--- a/src/ralph/scan/management/commands/autoscan.py
+++ b/src/ralph/scan/management/commands/autoscan.py
@@ -23,9 +23,9 @@ from ralph.discovery.models import (
     Network,
 )
 from ralph.scan.autoscan import (
-    autoscan_address,
-    autoscan_environment,
-    autoscan_network,
+    queue_autoscan_address,
+    queue_autoscan_environment,
+    queue_autoscan_network,
 )
 from ralph.scan.errors import Error
 from ralph.scan.util import find_network
@@ -96,7 +96,7 @@ class Command(BaseCommand):
                 for network in [
                     find_network(network_spec) for network_spec in args
                 ]:
-                    autoscan_network(network)
+                    queue_autoscan_network(network)
             except (Error, Network.DoesNotExist) as e:
                 raise SystemExit(e)
         elif kwargs['environment']:
@@ -104,7 +104,7 @@ class Command(BaseCommand):
                 for environment in [
                     Environment.objects.get(name=name) for name in args
                 ]:
-                    autoscan_environment(environment)
+                    queue_autoscan_environment(environment)
             except (Error, Environment.DoesNotExist) as e:
                 raise SystemExit(e)
         elif kwargs['data_center']:
@@ -115,7 +115,7 @@ class Command(BaseCommand):
                     for environment in data_center.environment_set.filter(
                         queue__isnull=False,
                     ):
-                        autoscan_environment(environment)
+                        queue_autoscan_environment(environment)
             except (Error, DataCenter.DoesNotExist) as e:
                 raise SystemExit(e)
         elif kwargs['queue']:
@@ -124,13 +124,13 @@ class Command(BaseCommand):
                     DiscoveryQueue.objects.get(name=name) for name in args
                 ]:
                     for environment in queue.environment_set.all():
-                        autoscan_environment(environment)
+                        queue_autoscan_environment(environment)
             except (Error, DiscoveryQueue.DoesNotExist) as e:
                 raise SystemExit(e)
         else:
             try:
                 addresses = [str(ipaddr.IPAddress(ip)) for ip in args]
                 for address in addresses:
-                    autoscan_address(address)
+                    queue_autoscan_address(address)
             except (Error, ValueError) as e:
                 raise SystemExit(e)

--- a/src/ralph/scan/management/commands/scan.py
+++ b/src/ralph/scan/management/commands/scan.py
@@ -28,9 +28,9 @@ from ralph.discovery.models import (
 )
 from ralph.scan.errors import Error
 from ralph.scan.manual import (
-    scan_address,
-    scan_environment,
-    scan_network,
+    queue_scan_address,
+    queue_scan_environment,
+    queue_scan_network,
 )
 from ralph.scan.util import find_network
 
@@ -139,7 +139,7 @@ class Command(BaseCommand):
                 for network in [
                     find_network(network_spec) for network_spec in args
                 ]:
-                    scan_network(network, plugins)
+                    queue_scan_network(network, plugins)
             except (Error, Network.DoesNotExist) as e:
                 raise SystemExit(e)
         elif kwargs['environment']:
@@ -147,7 +147,7 @@ class Command(BaseCommand):
                 for environment in [
                     Environment.objects.get(name=name) for name in args
                 ]:
-                    scan_environment(environment, plugins)
+                    queue_scan_environment(environment, plugins)
             except (Error, Environment.DoesNotExist) as e:
                 raise SystemExit(e)
         elif kwargs['data_center']:
@@ -158,7 +158,7 @@ class Command(BaseCommand):
                     for environment in data_center.environment_set.filter(
                         queue__isnull=False,
                     ):
-                        scan_environment(environment, plugins)
+                        queue_scan_environment(environment, plugins)
             except (Error, DataCenter.DoesNotExist) as e:
                 raise SystemExit(e)
         elif kwargs['queue']:
@@ -167,7 +167,7 @@ class Command(BaseCommand):
                     DiscoveryQueue.objects.get(name=name) for name in args
                 ]:
                     for environment in queue.environment_set.all():
-                        scan_environment(environment, plugins)
+                        queue_scan_environment(environment, plugins)
             except (Error, DiscoveryQueue.DoesNotExist) as e:
                 raise SystemExit(e)
         else:
@@ -178,7 +178,7 @@ class Command(BaseCommand):
             else:
                 last_message = 0
                 for ip_address in ip_addresses:
-                    job = scan_address(ip_address, plugins)
+                    job = queue_scan_address(ip_address, plugins)
                     while not job.is_finished:
                         job.refresh()
                         last_message = print_job_messages(

--- a/src/ralph/ui/views/common.py
+++ b/src/ralph/ui/views/common.py
@@ -35,7 +35,7 @@ from powerdns.models import Record
 from ralph.discovery.models_component import Ethernet
 from ralph.app import RalphModule
 from ralph.scan.errors import Error as ScanError
-from ralph.scan.manual import scan_address
+from ralph.scan.manual import queue_scan_address
 from ralph.scan.forms import DiffForm
 from ralph.scan.data import (
     append_merged_proposition,
@@ -1494,7 +1494,7 @@ class Scan(BaseMixin, TemplateView):
                 # validation reporter by another view, so be silent here.
                 return HttpResponseRedirect(reverse('search', args=()))
         try:
-            job = scan_address(
+            job = queue_scan_address(
                 ip_address, plugins, automerge=False, called_from_ui=True
             )
         except ScanError as e:


### PR DESCRIPTION
This pull request extends #907. Since single queue is maintained by more than one worker, a manual prescan (autoscan) should be scheduled in the same job as the 'main' scan - otherwise there's a risk that the 'main' scan will be launched before prescan.

And also, all the functions/methods that queue some sort of a scan instead performing it directly, should be named accordingly (I propose `queue_` prefix for that purpose) - otherwise such naming scheme is quite misleading.
