### PR TITLE
[hp_oa plugin] added 'Apache' to known HTTP family names.

### DIFF
--- a/src/ralph/discovery/http.py
+++ b/src/ralph/discovery/http.py
@@ -108,7 +108,10 @@ def guess_family(headers, document):
             family = 'F5'
         elif 'APC Management Web Server' in document:
             family = 'APC'
-        elif 'Hewlett-Packard Development Company' in document:
+        elif any((
+            'Hewlett-Packard Development Company' in document,
+            'HP BladeSystem Onboard Administrator' in document,
+        )):
             family = 'HP'
         elif any((
             'Welcome to VMware ESX Server' in document,

--- a/src/ralph/scan/plugins/hp_oa.py
+++ b/src/ralph/scan/plugins/hp_oa.py
@@ -203,8 +203,7 @@ def scan_address(ip_address, **kwargs):
     snmp_name = (kwargs.get('snmp_name', '') or '').lower()
     if snmp_name and "onboard administrator" not in snmp_name:
         raise NoMatchError('It is not HP OA.')
-    if kwargs.get('http_family', '') not in ('Unspecified', 'RomPager', 'HP',
-                                             'Apache'):
+    if kwargs.get('http_family', '') not in ('Unspecified', 'RomPager', 'HP'):
         raise NoMatchError('It is not HP OA.')
     messages = []
     result = get_base_result_template('hp_oa', messages)


### PR DESCRIPTION
Some HP OA systems report `Apache` as the `http_family`, causing `hp_oa` plugin to not recognize them properly - the following PR fixes this.
