### PR TITLE
Fixes related to 'unknown' model_type and empty values in scan results form.

### DIFF
--- a/src/ralph/scan/data.py
+++ b/src/ralph/scan/data.py
@@ -279,8 +279,7 @@ def get_device_data(device):
         data['hostname'] = device.name
     if device.model is not None:
         data['model_name'] = device.model.name
-        if device.model.type != DeviceType.unknown:
-            data['type'] = DeviceType.from_id(device.model.type).raw
+        data['type'] = DeviceType.from_id(device.model.type).raw
     if device.sn is not None:
         data['serial_number'] = device.sn
     if device.chassis_position:
@@ -443,8 +442,8 @@ def set_device_data(device, data, save_priority=SAVE_PRIORITY, warnings=[]):
             )
         except DeviceModel.DoesNotExist:
             model = DeviceModel(
-                type=model_type,
                 name=data['model_name'],
+                type=model_type,
             )
             try:
                 model.save()

--- a/src/ralph/scan/diff.py
+++ b/src/ralph/scan/diff.py
@@ -126,7 +126,7 @@ def _compare_lists(*args):
         return True
     compared_item = set(args[0])
     for item in args[1:]:
-        if compared_item - set(item):
+        if compared_item != set(item):
             return False
     return True
 
@@ -178,10 +178,10 @@ def diff_results(data, ignored_fields=set(['device', 'model_name'])):
             continue  # skipped because this is not component...
         db_results_key = _find_database_key(results)
         if not db_results_key:
-            continue  # uncomplete data
+            continue  # incomplete data
         diff_result = {
             'is_equal': False,
-            'meta': {},
+            'meta': {'no_value': []},
         }
         if component not in UNIQUE_FIELDS_FOR_MERGER:
             if isinstance(results[db_results_key], list):
@@ -195,6 +195,9 @@ def diff_results(data, ignored_fields=set(['device', 'model_name'])):
                     component_values = _sanitize_component_values(
                         component_values
                     )
+                elif (component == 'type' and
+                      set(component_values) == set(['unknown'])):
+                    diff_result['meta']['no_value'].append(component)
                 diff_result.update({
                     'is_equal': _compare_strings(*tuple(component_values)),
                     'type': 'strings',

--- a/src/ralph/scan/templates/scan/widgets/diff_select.html
+++ b/src/ralph/scan/templates/scan/widgets/diff_select.html
@@ -3,14 +3,16 @@
 
 <div class="diff-select-widget" id="{{ name }}__diff_select_widget" data-role="diff_select_widget">
     {% if diff %}
-        <div class="alert alert-{% if diff.is_equal %}success{% else %}info{% endif %}">
-            {% if not diff.is_equal %}
+    <div class="alert alert-{%if name in diff.meta.no_value %}warning{% elif diff.is_equal %}success{% else %}info{% endif %}">
+            {% if name in diff.meta.no_value %}
+              No sensible value can be determined for this component. To specify custom value, use "Advanced mode".
+            {% elif not diff.is_equal %}
                 {% if diff.type == "dicts" %}
                     <span class="badge badge-success">{{ diff.meta.add_items_count }}</span> item{% if diff.meta.add_items_count == 1 %} was{% else %}s were{% endif %} added.&nbsp;
                     <span class="badge badge-important">{{ diff.meta.remove_items_count }}</span> item{% if diff.meta.remove_items_count == 1 %} was{% else %}s were{% endif %} removed.&nbsp;
                     <span class="badge badge-warning">{{ diff.meta.change_items_count }}</span> item{% if diff.meta.change_items_count == 1 %} was{% else %}s were{% endif %} changed.&nbsp;
                 {% else %}
-                    Some changes were detected. To edit current value, use advanced mode.
+                    Some changes were detected. To edit current value, use "Advanced mode".
                 {% endif %}
             {% else %}
                 Without changes.
@@ -61,8 +63,8 @@
         {% for option, label in choices %}
             {% if option != "custom" %}
                 <label class="radio">
-                    <input type="radio" name="{{ name }}" value="{{ option }}" {% if value == option or value in option %}checked="on"{% endif %}>
-                    {{ label }}<br>
+                      <input type="radio" name="{{ name }}" value="{{ option }}" {% if value == option or value in option %}checked="on"{% endif %}>
+                    {% if not label %}None<br>{% else %}{{ label }}<br>{% endif %}
                     <i>({% with option|split:", " as sources %}
                         {% for source in sources %}
                             {% if source == 'database' %}previous value{% else %}{{ source }}{% endif %}


### PR DESCRIPTION
User should be forced to specify custom value for model_type when there's only 'unknown' value for this field in db or scan results.

Empty values should be displayed as 'None' instead of an empty string.

Fixed comparison of lists in diff_results.
