### PR TITLE
Disk shares in admin are now loading faster.

### DIFF
--- a/src/ralph/discovery/admin.py
+++ b/src/ralph/discovery/admin.py
@@ -442,9 +442,14 @@ class ComponentModelGroupAdmin(ModelAdmin):
 admin.site.register(m.ComponentModelGroup, ComponentModelGroupAdmin)
 
 
-class DiskShareMountInline(admin.TabularInline):
+class DiskShareMountInline(ForeignKeyAutocompleteTabularInline):
     model = m.DiskShareMount
     exclude = ('created', 'modified')
+    related_search_fields = {
+        'device': ['^name'],
+        'server': ['^name'],
+        'address': ['^address'],
+    }
     extra = 0
 
 


### PR DESCRIPTION
...due to certain fields in `DiskShareMountInline` changed from dropdown lists to lookup fields.
