### PR TITLE
Fixed error, where importing PIL warned about permission denied

### DIFF
--- a/src/ralph/__main__.py
+++ b/src/ralph/__main__.py
@@ -22,12 +22,12 @@ def ubuntu_1020872_workaround():
         from PIL import Image  # noqa
         """
         Newer version of Pillow doesn't have _imaging module. Use PIL instead.
-        Basically, we need to initialize Pillow, which does internally ctypes.dlopen('libjpeg.so.0.8') 
+        Basically, we need to initialize Pillow, which does internally ctypes.dlopen('libjpeg.so.0.8')
         which further opens /dev/proc/auxv to optimize JPEG decoding.
-        Ralph setup needs currently setcap net_raw on python process, which doesn't works seamlesly 
-        with libjpeg turbo optimization, which produces werid Permission denied error output problem 
+        Ralph setup needs currently setcap net_raw on python process, which doesn't works seamlesly
+        with libjpeg turbo optimization, which produces werid Permission denied error output problem
         from actually library below, not python code at all.
-        What we are trying to do is a workaround to reset error stream 
+        What we are trying to do is a workaround to reset error stream
         (duplicate error output descriptor, and clean-up).
 
         The real solution is just to run rqworker processes as root process or higher level permissions


### PR DESCRIPTION
Newer version of Pillow doesn't have _imaging module. Use PIL instead.

Basically, we need to initialize Pillow, which does internally ctypes.dlopen('libjpeg.so.0.8') which further opens /dev/proc/auxv to optimize JPEG decoding. 

Ralph setup needs currently setcap net_raw on python process, which doesn't works seamlesly with libjpeg turbo optimization, which produces werid `Permission denied` error output problem from actually library below, not python code at all. 

What we are trying to do is a workaround to reset error stream (duplicate error output descriptor, and clean-up).

The real solution is just to _run rqworker processes as root process or higher level permissions_
