### PR TITLE
[UI] unlock-filed view - only POST method is proper

### DIFF
--- a/src/ralph/ui/tests/functional/test_ui_utils.py
+++ b/src/ralph/ui/tests/functional/test_ui_utils.py
@@ -1,0 +1,44 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
+from django.test import TestCase
+
+from ralph.discovery.models import Device
+from ralph.ui.tests.global_utils import login_as_su
+
+
+class TestUnlockField(TestCase):
+
+    def setUp(self):
+        self.client = login_as_su()
+
+    def test_not_allowed_request(self):
+        response = self.client.get('/ui/unlock-field/', follow=True)
+        self.assertEqual(response.status_code, 405)
+
+    def test_correct_request(self):
+        # prepare sample device
+        dev = Device(
+            name='sample.dc',
+            sn='sn123123123_1'
+        )
+        dev.dc = 'DC'
+        dev.save(priority=215)
+
+        # test it
+        response = self.client.post(
+            '/ui/unlock-field/',
+            {
+                'device': dev.pk,
+                'field': 'dc'
+            },
+            follow=True
+        )
+        self.assertEqual(response.status_code, 200)
+        dev = Device.objects.get(pk=dev.pk)
+        priorities = dev.get_save_priorities()
+        self.assertEqual(priorities['dc'], 0)

--- a/src/ralph/ui/views/__init__.py
+++ b/src/ralph/ui/views/__init__.py
@@ -5,7 +5,7 @@ from __future__ import print_function
 from __future__ import unicode_literals
 
 from django.shortcuts import get_object_or_404
-from django.http import Http404
+from django.http import Http404, HttpResponseNotAllowed
 
 from django.views.decorators.csrf import csrf_exempt
 from ralph.util.views import jsonify
@@ -32,6 +32,8 @@ def typeahead_roles(request):
 @csrf_exempt
 @jsonify
 def unlock_field(request):
+    if request.method != 'POST':
+        return HttpResponseNotAllowed(['POST'])
     device_id = request.POST.get('device', '')
     device = get_object_or_404(Device, id=device_id)
     field_name = request.POST.get('field', '')

--- a/src/ralph/util/views.py
+++ b/src/ralph/util/views.py
@@ -9,7 +9,9 @@ from __future__ import unicode_literals
 import functools
 import cStringIO as StringIO
 
-from django.http import HttpResponse, HttpResponseRedirect
+from django.http import (
+    HttpResponse, HttpResponseRedirect, HttpResponseNotAllowed
+)
 from django.utils import simplejson as json
 
 from bob import csvutil
@@ -20,6 +22,8 @@ def jsonify(func):
     def wrapper(*args, **kwargs):
         reply = func(*args, **kwargs)
         if isinstance(reply, HttpResponseRedirect):
+            return reply
+        if isinstance(reply, HttpResponseNotAllowed):
             return reply
         return HttpResponse(json.dumps(reply),
                             mimetype="application/javascript")


### PR DESCRIPTION
Only POST method is proper for unlock-field view, otherwise return 405 code.
