### PR TITLE
[Scan] `management` field saving fix

### DIFF
--- a/src/ralph/scan/data.py
+++ b/src/ralph/scan/data.py
@@ -288,6 +288,8 @@ def get_device_data(device):
         data['data_center'] = device.dc
     if device.rack:
         data['rack'] = device.rack
+    if device.management:
+        data['management'] = device.management.address
     data['memory'] = [
         {
             'label': m.label,
@@ -555,6 +557,10 @@ def set_device_data(device, data, save_priority=SAVE_PRIORITY, warnings=[]):
         _update_addresses(device, data['management_ip_addresses'], True)
     if 'system_ip_addresses' in data:
         _update_addresses(device, data['system_ip_addresses'], False)
+    if 'management' in data:
+        device.management, created = IPAddress.concurrent_get_or_create(
+            address=data['management']
+        )
     if 'fibrechannel_cards' in data:
         _update_component_data(
             device,

--- a/src/ralph/scan/plugins/ssh_proxmox.py
+++ b/src/ralph/scan/plugins/ssh_proxmox.py
@@ -173,7 +173,8 @@ def _get_virtual_machine_info(
         'model_name': 'Proxmox qemu kvm',
         'type': DeviceType.virtual_server.raw,
         'mac_addresses': [MACAddressField.normalize(lan_mac)],
-        'management': master_ip_address,  # ?
+        'management': master_ip_address,  # in this context (VM) it will be
+                                          # cluster master IP address
         'hostname': name,
     }
     detected_disks = []

--- a/src/ralph/scan/tests/test_data.py
+++ b/src/ralph/scan/tests/test_data.py
@@ -254,6 +254,12 @@ class GetDeviceDataTest(TestCase):
         sub = data['subdevices']
         self.assertEqual(len(sub), 3)
 
+    def test_management(self):
+        self.device.management = IPAddress.objects.create(address='10.10.10.1')
+        self.device.save()
+        data = get_device_data(Device.objects.get(sn='123456789'))
+        self.assertEqual(data['management'], '10.10.10.1')
+
 
 class SetDeviceDataTest(TestCase):
 
@@ -278,6 +284,7 @@ class SetDeviceDataTest(TestCase):
             'barcode': '00000',
             'rack': 'i31',
             'chassis_position': '4',
+            'management': '10.10.10.2'
         }
         set_device_data(self.device, data)
         self.device.save()
@@ -288,6 +295,7 @@ class SetDeviceDataTest(TestCase):
         self.assertEqual(device.barcode, '00000')
         self.assertEqual(device.rack, 'i31')
         self.assertEqual(device.chassis_position, 4)
+        self.assertEqual(device.management.address, '10.10.10.2')
 
     def test_model_name(self):
         data = {


### PR DESCRIPTION
Field `management` on Device is using to storing informations about e.g. cluster head node - Scan ignored it...
