### PR TITLE
Fix for ssh_xen plugin (referencing a non-existing variable).

### DIFF
--- a/src/ralph/scan/plugins/ssh_xen.py
+++ b/src/ralph/scan/plugins/ssh_xen.py
@@ -272,6 +272,7 @@ def scan_address(ip_address, **kwargs):
             try:
                 ssh = _connect_ssh(ip_address, user, password)
             except AuthError:
+                ssh = None
                 continue
             else:
                 break


### PR DESCRIPTION
In case of all credentials being invalid, a non-existing variable will be referenced in line 278 - the following PR fixes this.
