### PR TITLE
Bumped requirements packages version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,8 +32,8 @@ setup(
     package_dir={'': 'src'},
     zip_safe=False,  # because templates are loaded from file path
     install_requires=[
-        'bob-ajax-selects==1.4.0',
-        'django-bob==1.8.0',
+        'bob-ajax-selects==1.4.1',
+        'django-bob==1.8.1',
         'django-powerdns-dnssec==0.9.3',
         'django-tastypie==0.9.16',
         'django-rq==0.4.5',


### PR DESCRIPTION
- `bob-ajax-selects` to 1.4.1,
- `django-bob` to 1.8.1,
