### PR TITLE
Fixes for 'force autoscan' routine and for 'ssh_juniper' plugin.

### DIFF
--- a/src/ralph/scan/manual.py
+++ b/src/ralph/scan/manual.py
@@ -335,12 +335,16 @@ def scan_address_job(
                 address=ip_address,
             )
             if not (ip.snmp_name and ip.snmp_community):
-                message = "SNMP name/community is missing. Forcing autoscan."
+                message = ("SNMP name and community is missing. Forcing "
+                           " autoscan.")
                 job.meta['messages'] = [
                     (ip_address, 'ralph.scan', 'info', message)
                 ]
                 job.save()
                 autoscan_address(ip_address)
+                # since autoscan_address can update some fields on IPAddress,
+                # we need to refresh it here
+                ip = IPAddress.objects.get(address=ip_address)
             kwargs = {
                 'snmp_community': ip.snmp_community,
                 'snmp_version': ip.snmp_version,

--- a/src/ralph/scan/plugins/ssh_juniper.py
+++ b/src/ralph/scan/plugins/ssh_juniper.py
@@ -149,8 +149,10 @@ def _ssh_juniper(ssh, ip_address):
 
 
 def scan_address(ip_address, **kwargs):
+    snmp_name = (kwargs.get('snmp_name', '') or '')
     http_family = (kwargs.get('http_family', '') or '')
-    if http_family and http_family.strip().lower() not in ('juniper',):
+    if ((snmp_name and 'juniper' not in snmp_name.lower()) and
+            (http_family and http_family.strip().lower() not in ('juniper',))):
         raise NoMatchError('It is not Juniper.')
     user = SETTINGS.get('user')
     password = SETTINGS.get('password')


### PR DESCRIPTION
'force autoscan' routine: `IPAddress` needs to be re-fetched since `autoscan_address` can update some of its fields.

`ssh_juniper` plugin: `snmp_name` or `http_family` should be enough to proceed further instead of exiting.
