### PR TITLE
Fixes for 'ralph_permission' decorator...

### DIFF
--- a/src/ralph/business/views.py
+++ b/src/ralph/business/views.py
@@ -10,7 +10,6 @@ from django.conf import settings
 from django.views.generic import TemplateView
 from lck.django.common import render, redirect
 
-from ralph.account.models import ralph_permission
 from ralph.business.models import Venture
 
 
@@ -24,7 +23,6 @@ class Index(TemplateView):
         return {'CURRENCY': settings.CURRENCY}
 
 
-@ralph_permission()
 def show_ventures(request, venture_id=None):
     if venture_id == 'search':
         if request.method != 'POST':

--- a/src/ralph/cmdb/rest/rest.py
+++ b/src/ralph/cmdb/rest/rest.py
@@ -8,13 +8,11 @@ from __future__ import unicode_literals
 
 from django.views.decorators.csrf import csrf_exempt
 
-from ralph.account.models import ralph_permission
 from ralph.cmdb.integration.puppet import PuppetAgentsImporter
 from ralph.discovery.tasks import run_chain
 from ralph.util.views import jsonify
 
 
-@ralph_permission()
 @csrf_exempt
 @jsonify
 def notify_puppet_agent(request):
@@ -24,7 +22,6 @@ def notify_puppet_agent(request):
     return {'ok': True}
 
 
-@ralph_permission()
 @csrf_exempt
 @jsonify
 def commit_hook(request):

--- a/src/ralph/cmdb/views_changes.py
+++ b/src/ralph/cmdb/views_changes.py
@@ -567,7 +567,6 @@ class Dashboard(ChangesBase):
         return ret
 
     @staticmethod
-    @ralph_permission()
     def get_ajax(*args, **kwargs):
         """Thin wrapper for Ajax subreports data"""
         data = {}
@@ -785,7 +784,6 @@ class TimeLine(BaseCMDBView):
         return ret
 
     @staticmethod
-    @ralph_permission()
     def get_ajax(self):
         interval = self.GET.get('interval')
         get_start_date = self.GET.get('start', datetime.datetime.now())

--- a/src/ralph/deployment/views.py
+++ b/src/ralph/deployment/views.py
@@ -11,8 +11,7 @@ import json
 
 from django.conf import settings
 from django.template import Template, Context
-from django.http import (HttpResponse, HttpResponseNotFound,
-                         HttpResponseForbidden, Http404)
+from django.http import HttpResponse, HttpResponseNotFound, Http404
 from django.db.models import Q
 from lck.django.common import remote_addr
 
@@ -25,7 +24,6 @@ from ralph.deployment.models import (
 )
 from ralph.discovery.models import IPAddress, Device
 from ralph.discovery.tasks import run_next_plugin
-from ralph.util import api
 
 
 def get_current_deployment(request):
@@ -114,17 +112,14 @@ def _preboot_view(request, file_name=None, file_type=None):
     return HttpResponseNotFound(message)
 
 
-@ralph_permission()
 def preboot_raw_view(request, file_name):
     return _preboot_view(request, file_name=file_name)
 
 
-@ralph_permission()
 def preboot_type_view(request, file_type):
     return _preboot_view(request, file_type=file_type)
 
 
-@ralph_permission()
 def preboot_complete_view(request):
     deployment = get_current_deployment(request)
     if not deployment:
@@ -157,8 +152,6 @@ def preboot_complete_view(request):
 
 @ralph_permission()
 def puppet_classifier(request):
-    if not api.is_authenticated(request):
-        return HttpResponseForbidden('API key required.')
     hostname = request.GET.get('hostname', '').strip()
     qs = Device.objects.filter(
         Q(name=hostname) |

--- a/src/ralph/dnsedit/views.py
+++ b/src/ralph/dnsedit/views.py
@@ -23,7 +23,6 @@ from ralph.dnsedit.dhcp_conf import (
     generate_dhcp_config_head,
     generate_dhcp_config_networks,
 )
-from ralph.util import api
 
 
 DHCP_DISABLE_NETWORKS_VALIDATION = getattr(
@@ -33,8 +32,6 @@ DHCP_DISABLE_NETWORKS_VALIDATION = getattr(
 
 @ralph_permission()
 def dhcp_synch(request):
-    if not api.is_authenticated(request):
-        return HttpResponseForbidden('API key required.')
     address = remote_addr(request)
     server = get_object_or_404(DHCPServer, ip=address)
     server.last_synchronized = datetime.datetime.now()
@@ -58,8 +55,6 @@ def _get_params(request):
 
 @ralph_permission()
 def dhcp_config_entries(request):
-    if not api.is_authenticated(request):
-        return HttpResponseForbidden('API key required.')
     dc_names, env_names = _get_params(request)
     if dc_names and env_names:
         return HttpResponseForbidden('Only DC or ENV mode available.')
@@ -95,8 +90,6 @@ def dhcp_config_entries(request):
 
 @ralph_permission()
 def dhcp_config_networks(request):
-    if not api.is_authenticated(request):
-        return HttpResponseForbidden('API key required.')
     dc_names, env_names = _get_params(request)
     if dc_names and env_names:
         return HttpResponseForbidden('Only DC or ENV mode available.')
@@ -131,8 +124,6 @@ def dhcp_config_networks(request):
 
 @ralph_permission()
 def dhcp_config_head(request):
-    if not api.is_authenticated(request):
-        return HttpResponseForbidden('API key required.')
     server_address = request.GET.get('server')
     if not server_address:
         server_address = remote_addr(request)

--- a/src/ralph/integration/views.py
+++ b/src/ralph/integration/views.py
@@ -6,12 +6,10 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
 
-from ralph.account.models import ralph_permission
 from ralph.discovery.models import Device
 from ralph.util.views import jsonify
 
 
-@ralph_permission()
 @jsonify
 def servertree(request, hostname=None):
     response = []

--- a/src/ralph/ui/tests/unit/test_acl_inheritance.py
+++ b/src/ralph/ui/tests/unit/test_acl_inheritance.py
@@ -38,28 +38,28 @@ class ACLInheritanceTest(TestCase):
             ('delete_job', 'django_rq.views'),
             ('requeue_job_view', 'django_rq.views'),
 
-            #('show_ventures', 'ralph.business.views'),
+            ('show_ventures', 'ralph.business.views'),
 
-            #('servertree', 'ralph.integration.views'),
+            ('servertree', 'ralph.integration.views'),
 
             ('logout', 'ralph.ui.views'),
             ('AddVM', 'ralph.ui.views.deploy'),  # checks permissions on its own
-            # ('typeahead_roles', 'ralph.ui.views'),
-            # ('unlock_field', 'ralph.ui.views'),
+            ('typeahead_roles', 'ralph.ui.views'),
+            ('unlock_field', 'ralph.ui.views'),
 
-            # ('dhcp_synch', 'ralph.dnsedit.views'),  # api key required
-            # ('dhcp_config_entries', 'ralph.dnsedit.views'),  # api key required
-            # ('dhcp_config_networks', 'ralph.dnsedit.views'),  # api key required
-            # ('dhcp_config_head', 'ralph.dnsedit.views'),  # api key required
+            # ('dhcp_synch', 'ralph.dnsedit.views'),
+            # ('dhcp_config_entries', 'ralph.dnsedit.views'),
+            # ('dhcp_config_networks', 'ralph.dnsedit.views'),
+            # ('dhcp_config_head', 'ralph.dnsedit.views'),
 
             ('get_ajax', 'ralph.cmdb.views_changes'),  # static methods in Dashboard / TimeLine
-            # ('commit_hook', 'ralph.cmdb.rest.rest'),
-            # ('notify_puppet_agent', 'ralph.cmdb.rest.rest'),
+            ('commit_hook', 'ralph.cmdb.rest.rest'),
+            ('notify_puppet_agent', 'ralph.cmdb.rest.rest'),
 
-            # ('preboot_type_view', 'ralph.deployment.views'),
-            # ('preboot_raw_view', 'ralph.deployment.views'),
-            # ('preboot_complete_view', 'ralph.deployment.views'),
-            # ('puppet_classifier', 'ralph.deployment.views'),  # api key required
+            ('preboot_type_view', 'ralph.deployment.views'),
+            ('preboot_raw_view', 'ralph.deployment.views'),
+            ('preboot_complete_view', 'ralph.deployment.views'),
+            # ('puppet_classifier', 'ralph.deployment.views'),
         ]
 
         # constructing a list of URL patterns for testing

--- a/src/ralph/ui/views/__init__.py
+++ b/src/ralph/ui/views/__init__.py
@@ -12,12 +12,10 @@ from ralph.util.views import jsonify
 from django.contrib import auth
 from django.http import HttpResponseRedirect
 
-from ralph.account.models import ralph_permission
 from ralph.business.models import Venture
 from ralph.discovery.models_device import Device
 
 
-@ralph_permission()
 @csrf_exempt
 @jsonify
 def typeahead_roles(request):
@@ -31,7 +29,6 @@ def typeahead_roles(request):
     }
 
 
-@ralph_permission()
 @csrf_exempt
 @jsonify
 def unlock_field(request):

--- a/src/ralph/util/api.py
+++ b/src/ralph/util/api.py
@@ -9,11 +9,19 @@ from __future__ import unicode_literals
 from django.contrib.auth.models import User
 
 
-def is_authenticated(request):
-    username = request.GET.get('username')
-    api_key = request.GET.get('api_key')
+def get_user(request):
+    username = request.REQUEST.get('username')
     try:
         user = User.objects.get(username=username)
     except User.DoesNotExist:
         user = None
-    return user and user.api_key.key == api_key
+    return user
+
+
+def is_authenticated(user, request):
+    api_key = request.REQUEST.get('api_key')
+    if user and user.api_key.key == api_key:
+        is_authenticated = True
+    else:
+        is_authenticated = False
+    return is_authenticated


### PR DESCRIPTION
...related to API endpoints not handled by Tastypie.

And also, `@ralph_permission` wasn't necessary on some of the function-based views.
