### PR TITLE
Fix type in DeviceEnvironmentFactory

### DIFF
--- a/src/ralph/cmdb/tests/utils.py
+++ b/src/ralph/cmdb/tests/utils.py
@@ -52,4 +52,6 @@ class ServiceCatalogFactory(CIFactory):
 class DeviceEnvironmentFactory(DjangoModelFactory):
     FACTORY_FOR = models_device.DeviceEnvironment
 
-    name = factory.Sequence(lambda n: 'Device Environment #%s' % n)
+    @factory.lazy_attribute
+    def type(self):
+        return CITypeFactory(name=models_ci.CI_TYPES.ENVIRONMENT)


### PR DESCRIPTION
Change related with https://github.com/allegro/ralph/pull/1044
Due to changes in the model, `DeviceEnvironmentFactory` type must be changed.

This request blocks: https://github.com/allegro/ralph_assets/pull/430
