### PR TITLE
Fix for saving an asset assigned to a discovered device.

### DIFF
--- a/src/ralph/ui/views/common.py
+++ b/src/ralph/ui/views/common.py
@@ -1643,6 +1643,7 @@ class VhostRedirectView(RedirectView):
 
 class Scan(BaseMixin, TemplateView):
     template_name = 'ui/scan.html'
+    submodule_name = 'search'
 
     def get(self, *args, **kwargs):
         try:


### PR DESCRIPTION
...and also, assigned ScanStatus (scan results) and Scan views to the 'Search' menu tab.
