### PR TITLE
Fix default param in CMDB create CI by API

### DIFF
--- a/src/ralph/cmdb/api.py
+++ b/src/ralph/cmdb/api.py
@@ -333,7 +333,7 @@ class RelationField(tastypie.fields.ApiField):
         CIRelation.objects.filter(
             Q(child_id=ci.id) | Q(parent_id=ci.id)
         ).delete()
-        for relation_data in bundle.data.get('related'):
+        for relation_data in bundle.data.get('related', []):
             relation = CIRelation()
             try:
                 type_id = CI_RELATION_TYPES.id_from_name(relation_data['type'])


### PR DESCRIPTION
Could not be created CI without specifying the `related` parameter.
