### PR TITLE
fixed saving device service and env through api

### DIFF
--- a/src/ralph/discovery/api.py
+++ b/src/ralph/discovery/api.py
@@ -24,14 +24,17 @@ from tastypie.throttle import CacheThrottle
 
 from ralph.account.api_auth import RalphAuthorization
 from ralph.account.models import Perm
+from ralph.cmdb.api import CIResource
 from ralph.discovery.models import (
     ComponentType,
     Device,
+    DeviceEnvironment,
     DeviceModel,
     DeviceType,
     IPAddress,
     Network,
     NetworkKind,
+    ServiceCatalog,
 )
 from ralph.ui.views.common import _get_details
 
@@ -143,6 +146,18 @@ class ModelResource(MResource):
         )
 
 
+class ServiceCatalogResource(CIResource):
+    class Meta:
+        queryset = ServiceCatalog.objects.all()
+        resource_name = 'service_catalog'
+
+
+class DeviceEnvironmentResource(CIResource):
+    class Meta:
+        queryset = DeviceEnvironment.objects.all()
+        resource_name = 'device_environment'
+
+
 class DeviceResource(MResource):
     model = fields.ForeignKey(ModelResource, 'model', null=True, full=True)
     management = fields.ForeignKey(
@@ -176,12 +191,12 @@ class DeviceResource(MResource):
         full=True,
     )
     service = fields.ForeignKey(
-        'ralph.cmdb.api.CIResource',
+        'ralph.discovery.api.ServiceCatalogResource',
         'service',
         null=True,
     )
     device_environment = fields.ForeignKey(
-        'ralph.cmdb.api.CIResource',
+        'ralph.discovery.api.DeviceEnvironmentResource',
         'device_environment',
         null=True,
     )

--- a/src/ralph/urls.py
+++ b/src/ralph/urls.py
@@ -19,6 +19,7 @@ from ralph.business.api import (
 from ralph.deployment.api import DeploymentResource
 from ralph.discovery.api import (
     BladeServerResource,
+    DeviceEnvironmentResource,
     DeviceWithPricingResource,
     DevResource,
     IPAddressResource,
@@ -27,6 +28,7 @@ from ralph.discovery.api import (
     NetworksResource,
     PhysicalServerResource,
     RackServerResource,
+    ServiceCatalogResource,
     VirtualServerResource,
 )
 from ralph.cmdb.api import (
@@ -85,7 +87,9 @@ for r in (
     VirtualServerResource,
     DevResource,
     DeviceWithPricingResource,
-    NetworkKindsResource
+    NetworkKindsResource,
+    DeviceEnvironmentResource,
+    ServiceCatalogResource,
 ):
     v09_api.register(r())
 


### PR DESCRIPTION
Tastypie need ServiceCatalog model (which is proxy to CI and inherit from CI, but because of django magic, isinstance is not working as expected) as field reference - not CI model.
