### PR TITLE
Test database engine depends on environment variable

### DIFF
--- a/src/ralph/settings-test-assets.py
+++ b/src/ralph/settings-test-assets.py
@@ -1,17 +1,29 @@
 #
 # A testing profile.
 #
-DATABASES = {
-    'default': {
-        'ENGINE': 'django.db.backends.sqlite3',
-        'NAME': ':memory:',
-        'USER': '',
-        'PASSWORD': '',
-        'HOST': '',
-        'PORT': '',
-        'OPTIONS': {},
+import os
+
+if os.environ.get('TEST_DATABASE_ENGINE') == 'mysql':
+    DATABASES = {
+        'default': {
+            'ENGINE': 'django.db.backends.mysql',
+            'NAME': 'ralph',
+            'USER': 'root',
+            'HOST': 'localhost',
+        },
     }
-}
+else:
+    DATABASES = {
+        'default': {
+            'ENGINE': 'django.db.backends.sqlite3',
+            'NAME': ':memory:',
+            'USER': '',
+            'PASSWORD': '',
+            'HOST': '',
+            'PORT': '',
+            'OPTIONS': {},
+        }
+    }
 
 PLUGGABLE_APPS = ['cmdb', 'assets']
 


### PR DESCRIPTION
Is required by `.travis.yml` in assets.
