### PR TITLE
Validation Service in CMDB.

### DIFF
--- a/src/ralph/cmdb/api.py
+++ b/src/ralph/cmdb/api.py
@@ -29,12 +29,15 @@ from tastypie import fields
 from tastypie.fields import ForeignKey as TastyForeignKey, ToOneField
 from tastypie.resources import ModelResource as MResource
 from tastypie.throttle import CacheThrottle
+from tastypie.validation import Validation
 
 from ralph.account.api_auth import RalphAuthorization
 from ralph.account.models import Perm, Profile
 from ralph.cmdb.models import (
     CI,
-    CIType,
+    CI_RELATION_TYPES,
+    CIAttribute,
+    CIAttributeValue,
     CIChange,
     CIChangeCMDBHistory,
     CIChangeGit,
@@ -42,13 +45,11 @@ from ralph.cmdb.models import (
     CIChangeZabbixTrigger,
     CILayer,
     CIRelation,
-    CI_RELATION_TYPES,
-    CIAttribute,
-    CIAttributeValue,
+    CIType,
 )
 from ralph.cmdb import models as db
 from ralph.cmdb.models_ci import CIOwner, CIOwnershipType
-from ralph.cmdb.util import breadth_first_search_ci
+from ralph.cmdb.util import breadth_first_search_ci, can_change_ci_state
 
 
 THROTTLE_AT = settings.API_THROTTLING['throttle_at']
@@ -361,6 +362,24 @@ class RelationField(tastypie.fields.ApiField):
         pass
 
 
+class CIResourceValidation(Validation):
+
+    def is_valid(self, bundle, request=None):
+        errors = {}
+        if not bundle.obj.pk:
+            return errors
+        try:
+            ci = CI.objects.get(pk=bundle.obj.pk)
+        except CI.DoesNotExist:
+            return {'__all__': 'This object does not exist.'}
+        changed_state = bundle.data.get('state')
+        if not can_change_ci_state(ci, changed_state):
+            message = """You can not change state because this service has
+            linked devices."""
+            errors['state'] = ' '.join(message.split())
+        return errors
+
+
 class CIResource(MResource):
 
     ci_link = LinkField(view='ci_view_main', as_qs=False)
@@ -421,6 +440,7 @@ class CIResource(MResource):
             timeframe=TIMEFRAME,
             expiration=EXPIRATION,
         )
+        validation = CIResourceValidation()
 
 
 class CIResourceV010(CIResource):

--- a/src/ralph/cmdb/forms.py
+++ b/src/ralph/cmdb/forms.py
@@ -13,14 +13,20 @@ from bob.forms.dependency import Dependency, DependencyForm, SHOW
 from bob.forms.dependency_conditions import MemberOf as MemberOfCondition
 from django import forms
 from django.contrib.admin.widgets import FilteredSelectMultiple
+from django.core.urlresolvers import reverse
+from django.utils.safestring import mark_safe
 from django.utils.translation import ugettext_lazy as _
 
 from ralph.cmdb import models
 from ralph.cmdb import models as db
 from ralph.cmdb.models import CIType
 from ralph.cmdb.models_ci import (
-    CIAttribute, CI_ATTRIBUTE_TYPES, CIAttributeValue,
+    CI_ATTRIBUTE_TYPES,
+    CI_STATE_TYPES,
+    CIAttribute,
+    CIAttributeValue,
 )
+from ralph.cmdb.util import can_change_ci_state
 from ralph.ui.widgets import (
     ReadOnlyWidget,
     ReadOnlyMultipleChoiceWidget,
@@ -162,6 +168,22 @@ class CIEditForm(DependencyForm, forms.ModelForm):
                         attribute,
                     )
                     self[field_name].field.initial = attribute_value.value
+
+    def clean_state(self, *args, **kwargs):
+        state = self.instance.state
+        changed_state = self.cleaned_data.get('state')
+        if (
+            self.instance.id
+            and not can_change_ci_state(self.instance, changed_state)
+        ):
+            message = """You can not change state to {}, because this service
+            has linked devices. Click <a href="{}" target="_blank">here</a> to
+            see it.""".format(
+                CI_STATE_TYPES.NameFromID(changed_state),
+                reverse('search') + '?service_catalog=' + self.instance.name,
+            )
+            raise forms.ValidationError(mark_safe(message))
+        return state
 
     def save(self, *args, **kwargs):
         instance = super(CIEditForm, self).save(*args, **kwargs)

--- a/src/ralph/cmdb/tests/functional/test_rest_api.py
+++ b/src/ralph/cmdb/tests/functional/test_rest_api.py
@@ -1,0 +1,43 @@
+# -*- coding: utf-8 -*-
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
+import json
+
+from ralph.cmdb.models import CI, CI_STATE_TYPES
+from ralph.cmdb.tests.utils import ServiceCatalogFactory
+from ralph.discovery.tests.util import DeviceFactory
+from ralph.ui.tests.global_utils import UserTestCase
+
+
+class CMDBApiTest(UserTestCase):
+
+    def test_change_service_state(self):
+        """Change Service state from active to another state when Service have
+        connected Devices"""
+        data = json.dumps({'state': CI_STATE_TYPES.INACTIVE.id})
+        service = ServiceCatalogFactory(state=CI_STATE_TYPES.ACTIVE.id)
+        device = DeviceFactory(service=service)
+
+        response = self.patch(
+            '/api/v0.9/ci/{}/'.format(service.id),
+            data,
+            CONTENT_TYPE='application/json',
+        )
+        self.assertEqual(
+            json.loads(response.content)['ci']['state'],
+            'You can not change state because this service has linked devices.',
+        )
+
+        device.service = None
+        device.save()
+
+        response = self.patch(
+            '/api/v0.9/ci/{}/'.format(service.id),
+            data,
+            CONTENT_TYPE='application/json',
+        )
+        chenged_service = CI.objects.get(id=service.id)
+        self.assertEqual(chenged_service.state, CI_STATE_TYPES.INACTIVE.id)

--- a/src/ralph/cmdb/tests/unit/tests_api.py
+++ b/src/ralph/cmdb/tests/unit/tests_api.py
@@ -404,7 +404,6 @@ class CMDBApiTest(UserTestCase):
             type=CI_RELATION_TYPES.CONTAINS.id,
         )
 
-
     def test_get_attribute(self):
         path = "/api/v0.9/ci/{0}/".format(self.ci1.id)
         response = self.get(path)

--- a/src/ralph/cmdb/util.py
+++ b/src/ralph/cmdb/util.py
@@ -9,7 +9,8 @@ from __future__ import unicode_literals
 from bob.data_table import DataTableColumn
 from django.db.models import Q
 
-from ralph.cmdb.models import CI
+from ralph.cmdb.models import CI, CI_STATE_TYPES, CI_TYPES
+from ralph.discovery.models import Device
 
 
 def report_filters(cls, order, filters=None):
@@ -211,3 +212,15 @@ def register_event(ci, event):
     def set_event(current_ci):
         event.cis.add(current_ci)
     walk(ci, set_event, up=False)
+
+
+def can_change_ci_state(ci, changed_state):
+    if (
+        changed_state
+        and ci.type.id == CI_TYPES.SERVICE
+        and ci.state == CI_STATE_TYPES.ACTIVE
+        and changed_state in (CI_STATE_TYPES.INACTIVE, CI_STATE_TYPES.WAITING)
+        and Device.objects.filter(service=ci).count() > 0
+    ):
+        return False
+    return True


### PR DESCRIPTION
Preventing a change `Service` status in from `active` to another, when `Service` has connected devices.
Changes were made in the editing form and api.
