### PR TITLE
Adding the possibility of mapping the country to user profile through the attribute in the LDAP

### DIFF
--- a/doc/faq.rst
+++ b/doc/faq.rst
@@ -47,11 +47,15 @@ connecting to an Active Directory service might look like this::
       "department": "department",
       "employee_id": "employeeID",
       "location": "officeName",
+      "country": "ISO-country-code",
   }
 
 Manager is special field and is treated as reference to another user,
 for example "CN=John Smith,OU=TOR,OU=Corp-Users,DC=mydomain,DC=internal"
 is mapped to "John Smith" text.
+
+Country is special field, the value of this field must be a country code in the
+`ISO 3166-1 alfa-2 <https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2>`_ format.
 
 Ralph provides ldap groups to django groups mapping. All what you need to
 do are:

--- a/src/ralph/account/admin.py
+++ b/src/ralph/account/admin.py
@@ -5,6 +5,7 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
 
+from dj.choices import Country
 from django import forms
 from django.contrib import admin
 from django.forms.models import (
@@ -138,6 +139,9 @@ class ProfileAdmin(UserAdmin):
     groups_show.allow_tags = True
     groups_show.short_description = _("groups")
 
+    def country(self):
+        return Country.raw_from_id(self.profile.country)
+
     inlines = [
         ProfileInline,
         ProfileBoundPermInline,
@@ -152,8 +156,9 @@ class ProfileAdmin(UserAdmin):
         'first_name',
         'last_name',
         groups_show,
+        country,
         'is_staff',
-        'is_active'
+        'is_active',
     )
     list_filter = ('is_staff', 'is_superuser', 'is_active', 'groups',)
     save_on_top = True

--- a/src/ralph/account/ldap.py
+++ b/src/ralph/account/ldap.py
@@ -8,6 +8,7 @@ from __future__ import unicode_literals
 
 import logging
 
+from dj.choices import Country
 
 logger = logging.getLogger(__name__)
 
@@ -40,7 +41,7 @@ else:
         user.is_active = 'active' in ldap_user.group_names
 
     @receiver(populate_user_profile)
-    def manager_attribute_populate(sender, profile, ldap_user, **kwargs):
+    def manager_country_attribute_populate(sender, profile, ldap_user, **kwargs):
         try:
             profile_map = settings.AUTH_LDAP_PROFILE_ATTR_MAP
         except AttributeError:
@@ -52,6 +53,11 @@ else:
                 manager_ref = manager_ref.decode('utf-8')
                 cn = manager_ref.split(',')[0][3:]
                 profile.manager = cn
+        if 'country' in profile_map:
+            if profile_map['country'] in ldap_user.attrs:
+                country = ldap_user.attrs[profile_map['country']][0]
+                if len(country) == 2:
+                    profile.country = getattr(Country, country.lower())
 
     class MappedGroupOfNamesType(ActiveDirectoryGroupType):
 


### PR DESCRIPTION
Attribute of the field is a country must be mapped to the ISO code of the country ISO 3166-1 alpha-2
https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2
