### PR TITLE
[DO NOT MERGE] Introducing AutoCompleteCascadeSelectField to ServiceCatalogMixin.

### DIFF
--- a/src/ralph/ui/channels.py
+++ b/src/ralph/ui/channels.py
@@ -6,7 +6,7 @@ from __future__ import unicode_literals
 
 from django.core.exceptions import PermissionDenied
 
-from ajax_select import LookupChannel
+from ajax_select import LookupChannel, CascadeLookupChannel
 from django.db import models as db
 from django.utils.html import escape
 
@@ -77,8 +77,25 @@ class ServiceCatalogLookup(RestrictedLookupChannel):
     model = models_device.ServiceCatalog
 
 
-class DeviceEnvrionment(RestrictedLookupChannel):
+class DeviceEnvironmentLookup(CascadeLookupChannel):
     model = models_device.DeviceEnvironment
+    search_field = 'name'
+
+    def get_cascading_query(self, query, request, parent_pk):
+        print(parent_pk)
+        try:
+            service = models_device.ServiceCatalog.objects.get(id=parent_pk)
+        except models_device.ServiceCatalog.DoesNotExist:
+            return models_device.ServiceCatalog.none()
+        else:
+            envs = service.get_environments()
+            return envs.filter(name__icontains=query)
+
+    # since we don't inherit from RestrictedLookupChannel,
+    # we need to implement 'check_auth' here as well
+    def check_auth(self, request):
+        if not request.user.is_authenticated():
+            raise PermissionDenied
 
 
 class VentureLookup(RestrictedLookupChannel):


### PR DESCRIPTION
It is now possible to make 'cascading selects', i.e. narrowing the results of one autocomplete field according to the value selected in the other (parent/child relationship).

This concept is introduced here with ServiceCatalogMixin, i.e. the possible completions for device environment field are presented according to the value selected in the service catalog field.

[This pull request](https://github.com/quamilek/bob-ajax-selects/pull/15) (in bob-ajax-selects) have to be merged first (otherwise this one won't build)!
