### PR TITLE
Fix missing bob-ajax-selects static files

### DIFF
--- a/src/ralph/ui/templates/ui/base.html
+++ b/src/ralph/ui/templates/ui/base.html
@@ -12,6 +12,7 @@
             <link rel="stylesheet" href="{{ STATIC_URL }}ui/custom.css">
             <link rel="stylesheet" href="{{ STATIC_URL }}ui/datepicker.css">
             <link rel="stylesheet" href="{{ STATIC_URL }}jquery.treegrid.css">
+            <link rel="stylesheet" href="{{ STATIC_URL }}css/ajax_select.css">
         {% endblock %}
         {% block scripts %}
             <script src="{{ STATIC_URL }}require.js"></script>
@@ -99,6 +100,7 @@
         </div>
         <script src="{{ STATIC_URL }}bootstrap/js/bootstrap.min.js"></script>
         <script src="{{ STATIC_URL }}bootstrap-datepicker.js"></script>
+        <script src="{{ STATIC_URL }}js/ajax_select.js"></script>
     </body>
 </html>
 <!--STATS-->


### PR DESCRIPTION
Moved because Ralph also uses this library and Ralph Assets base html template inherit from Ralph ui/base.html.

is blocked by: https://github.com/allegro/ralph_assets/pull/510
