### PR TITLE
Fix device info page, when model is empty - error 500

### DIFF
--- a/src/ralph/ui/tests/functional/tests_view.py
+++ b/src/ralph/ui/tests/functional/tests_view.py
@@ -11,8 +11,10 @@ from django.core.urlresolvers import reverse
 from django.test import TestCase
 
 from ralph.account.models import Perm, BoundPerm
+from ralph.discovery.tests.util import DeviceFactory
 from ralph.ui.tests.global_utils import (
     login_as_user,
+    login_as_su,
     GroupFactory,
     UserFactory,
 )
@@ -93,3 +95,18 @@ class LoginRedirectTest(TestCase):
                     response.request['PATH_INFO'],
                     reverse('search', args=('info', '')),
                 )
+
+
+class DeviceViewRegressionTest(TestCase):
+
+    def setUp(self):
+        self.client = login_as_su()
+
+    def test_model_is_empty(self):
+        device = DeviceFactory()
+        url = reverse(
+            'search', kwargs={'device': device.id, 'details': 'info'},
+        )
+        self.assertEqual(device.model, None)
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)

--- a/src/ralph/ui/views/common.py
+++ b/src/ralph/ui/views/common.py
@@ -598,7 +598,10 @@ class Info(DeviceUpdateView):
             elif not (
                 not assets_imported or
                 DeviceInfo.objects.filter(ralph_device_id=self.object.pk) or
-                self.object.model.type == DeviceType.virtual_server
+                (
+                    self.object.model and
+                    self.object.model.type == DeviceType.virtual_server
+                )
             ):
                 deploy_disable_reason = _(
                     "This device is not linked to an asset."


### PR DESCRIPTION
The device info view generate server error 500, when model is empty.
