### PR TITLE
Removed unnecessary skip from one unit test.

### DIFF
--- a/src/ralph/ui/tests/functional/tests_view.py
+++ b/src/ralph/ui/tests/functional/tests_view.py
@@ -62,7 +62,6 @@ class LoginRedirectTest(TestCase):
         )
         self.assertEqual(response.status_code, 403)
 
-    @unittest.skip("remove with the typo 'DeviceEnvrionment' in assets")
     def test_hierarchy(self):
         """
         Because there is no installed scrooge, always show core


### PR DESCRIPTION
This skip is no longer needed since mentioned typo has been fixed in ralph_assets.
