### PR TITLE
Added edit mode to data center view

### DIFF
--- a/src/ralph/ui/static/partials/data_center/data_center_view.html
+++ b/src/ralph/ui/static/partials/data_center/data_center_view.html
@@ -1,31 +1,53 @@
-<div class="rack-info">
-    <h3>Info {{ racks.name }}</h3>
-    <table class="info">
-        <tr>
-            <td>Name</td>
-            <td>{{ info ? info.name : '-' }}</td>
-            <td></td>
-        </tr>
-        <tr>
-            <td>Description</td>
-            <td>{{ info ? info.description : '-' }}</td>
-            <td></td>
-        </tr>
-        <tr>
-            <td>Position</td>
-            <td>column: {{ info ? info.visualization_col : actualX }}<br/> row: {{ info ? info.visualization_row : actualY }}</td>
-            <td></td>
-        </tr>
-    </table>
+<div class="btn-group" role="group" ng-init="mode = 'preview'">
+    <button ng-click="mode = 'preview'" type="button" ng-class="{'active': mode == 'preview'}" class="btn btn-default">Preview</button>
+    <button ng-click="mode = 'edit'" type="button" ng-class="{'active': mode == 'edit'}" class="btn btn-default">Edit mode</button>
+</div>
+
+<div ng-switch on="mode">
+    <div class="rack-info" ng-switch-when="preview">
+        <h3>Info {{ racks.name }}</h3>
+        <table class="info">
+            <tr>
+                <td>Name</td>
+                <td>{{ info ? info.name : '-' }}</td>
+                <td></td>
+            </tr>
+            <tr>
+                <td>Description</td>
+                <td>{{ info ? info.description : '-' }}</td>
+                <td></td>
+            </tr>
+            <tr>
+                <td>Position</td>
+                <td>column: {{ info ? info.visualization_col : actualX }}<br/> row: {{ info ? info.visualization_row : actualY }}</td>
+                <td></td>
+            </tr>
+        </table>
+    </div>
+    <div class="rack-info" ng-switch-when="edit">
+        <h3>Edit {{ rack.name }}</h3>
+        <div class="alert alert-info" ng-hide="rack">
+            Please click <i class="icon-pencil"></i> to edit basic info about rack, click <i class="icon-repeat"></i> to rotate or just use drag and drop to edit position.
+        </div>
+        <div class="form" ng-show="rack">
+            <form ng-submit="updateRack(rack)">
+                <input type="text" ng-model="rack.name">
+                <textarea ng-model="rack.description"></textarea>
+                <input type="submit" value="Save">
+            </form>
+        </div>
+    </div>
 </div>
 <div class="data-center">
-    <div class="grid rows-{{ data_center.visualization_rows_num }} cols-{{ data_center.visualization_cols_num }}">
+    <div class="grid rows-{{ data_center.visualization_rows_num }} cols-{{ data_center.visualization_cols_num }} {{ mode }}">
         <div class="grid_wrapper" ng-mousemove="updatePosition($event)">
             <rack-top
                 ng-mouseleave="setInfo(null)"
                 ng-mouseover="setInfo(rack)"
                 ng-repeat="rack in data_center.rack_set"
                 rack="rack"
+                mode="mode"
+                dc="data_center"
             ></rack-top>
         </div>
     </div>

--- a/src/ralph/ui/static/partials/data_center/rack.html
+++ b/src/ralph/ui/static/partials/data_center/rack.html
@@ -1,5 +1,5 @@
-<div class="rack rotate-{{ rack.orientation }} x-{{ rack.visualization_col }} y-{{ rack.visualization_row }}">
-    <a href="#/rack/{{ rack.id }}" class="wrapper">
+<div class="rack rotate-{{ rack.orientation }} x-{{ rack.visualization_col }} y-{{ rack.visualization_row }}" ng-class="{'move': is_move, 'allowed': can_drop, 'not_allowed': !can_drop}">
+    <a href="#/rack/{{ rack.id }}" class="wrapper" ng-show="mode == 'preview'">
         <div class="name">
             {{ rack.name | clean }}
         </div>
@@ -8,6 +8,14 @@
         </div>
         <div class="progress red" style="width:{{ 100 - (rack.free_u / rack.max_u_height) * 100 }}%;"></div>
         <div class="progress green"></div>
-        </div>
     </a>
+    <div class="wrapper" ng-show="mode == 'edit'">
+        <div class="name">
+            {{ rack.name | clean }}
+        </div>
+        <div class="tools">
+            <a class="edit" ng-click="edit(rack)"><i class="icon-pencil"></i></a>
+            <i class="icon-repeat" ng-click="rotate(1)"></i>
+        </div>
+    </div>
 </div>

--- a/src/ralph/ui/static/ui/css/data_center.css
+++ b/src/ralph/ui/static/ui/css/data_center.css
@@ -322,6 +322,61 @@
 .data-center .grid.cols-40 {
   width: 1600px;
 }
+.data-center .grid.edit .grid_wrapper {
+  background-color: rgba(255, 255, 255, 0.1);
+}
+.data-center .grid.edit .grid_wrapper .progress,
+.data-center .grid.edit .grid_wrapper .free,
+.data-center .grid.edit .grid_wrapper .display,
+.data-center .grid.edit .grid_wrapper .used {
+  display: none;
+}
+.data-center .grid.edit .grid_wrapper .rack.move {
+  border-style: dashed;
+}
+.data-center .grid.edit .grid_wrapper .rack.move.not_allowed {
+  background-color: red;
+}
+.data-center .grid.edit .grid_wrapper .rack.move.allowed {
+  background-color: #2a3;
+}
+.data-center .grid.edit .grid_wrapper .rack.move .wrapper .tools {
+  display: none !important;
+}
+.data-center .grid.edit .grid_wrapper .rack .wrapper {
+  cursor: initial;
+}
+.data-center .grid.edit .grid_wrapper .rack .wrapper:hover .tools {
+  display: block;
+}
+.data-center .grid.edit .grid_wrapper .rack .wrapper:hover .tools {
+  display: block;
+}
+.data-center .grid.edit .grid_wrapper .rack .wrapper .tools {
+  display: none;
+}
+.data-center .grid.edit .grid_wrapper .rack .wrapper .icon-repeat {
+  font-size: 1.25em;
+  cursor: pointer;
+  font-weight: bold;
+  bottom: 5px;
+  padding: 2px;
+}
+.data-center .grid.edit .grid_wrapper .rack .wrapper .icon-repeat:hover {
+  color: #fff;
+}
+.data-center .grid.edit .grid_wrapper .rack .wrapper .icon-repeat.left {
+  left: 5%;
+}
+.data-center .grid.edit .grid_wrapper .rack .wrapper .icon-repeat.right {
+  right: 5%;
+}
+.data-center .grid.edit .grid_wrapper .rack .wrapper .edit {
+  padding: 2px 0 0 2px;
+}
+.data-center .grid.edit .grid_wrapper .rack .wrapper .name {
+  cursor: move;
+}
 .data-center .grid .grid_wrapper {
   position: relative;
   min-height: 800px;
@@ -604,6 +659,249 @@
 }
 .data-center .grid .grid_wrapper .rack.rotate-bottom .wrapper .progress {
   bottom: 1.4em;
+}
+.data-center .grid .grid_wrapper .rack.rotate-bottom .tools {
+  transform: rotate(180deg);
+}
+.data-center .grid .grid_wrapper .rack.x-1 {
+  left: 40px;
+}
+.data-center .grid .grid_wrapper .rack.x-2 {
+  left: 80px;
+}
+.data-center .grid .grid_wrapper .rack.x-3 {
+  left: 120px;
+}
+.data-center .grid .grid_wrapper .rack.x-4 {
+  left: 160px;
+}
+.data-center .grid .grid_wrapper .rack.x-5 {
+  left: 200px;
+}
+.data-center .grid .grid_wrapper .rack.x-6 {
+  left: 240px;
+}
+.data-center .grid .grid_wrapper .rack.x-7 {
+  left: 280px;
+}
+.data-center .grid .grid_wrapper .rack.x-8 {
+  left: 320px;
+}
+.data-center .grid .grid_wrapper .rack.x-9 {
+  left: 360px;
+}
+.data-center .grid .grid_wrapper .rack.x-10 {
+  left: 400px;
+}
+.data-center .grid .grid_wrapper .rack.x-11 {
+  left: 440px;
+}
+.data-center .grid .grid_wrapper .rack.x-12 {
+  left: 480px;
+}
+.data-center .grid .grid_wrapper .rack.x-13 {
+  left: 520px;
+}
+.data-center .grid .grid_wrapper .rack.x-14 {
+  left: 560px;
+}
+.data-center .grid .grid_wrapper .rack.x-15 {
+  left: 600px;
+}
+.data-center .grid .grid_wrapper .rack.x-16 {
+  left: 640px;
+}
+.data-center .grid .grid_wrapper .rack.x-17 {
+  left: 680px;
+}
+.data-center .grid .grid_wrapper .rack.x-18 {
+  left: 720px;
+}
+.data-center .grid .grid_wrapper .rack.x-19 {
+  left: 760px;
+}
+.data-center .grid .grid_wrapper .rack.x-20 {
+  left: 800px;
+}
+.data-center .grid .grid_wrapper .rack.x-21 {
+  left: 840px;
+}
+.data-center .grid .grid_wrapper .rack.x-22 {
+  left: 880px;
+}
+.data-center .grid .grid_wrapper .rack.x-23 {
+  left: 920px;
+}
+.data-center .grid .grid_wrapper .rack.x-24 {
+  left: 960px;
+}
+.data-center .grid .grid_wrapper .rack.x-25 {
+  left: 1000px;
+}
+.data-center .grid .grid_wrapper .rack.x-26 {
+  left: 1040px;
+}
+.data-center .grid .grid_wrapper .rack.x-27 {
+  left: 1080px;
+}
+.data-center .grid .grid_wrapper .rack.x-28 {
+  left: 1120px;
+}
+.data-center .grid .grid_wrapper .rack.x-29 {
+  left: 1160px;
+}
+.data-center .grid .grid_wrapper .rack.x-30 {
+  left: 1200px;
+}
+.data-center .grid .grid_wrapper .rack.x-31 {
+  left: 1240px;
+}
+.data-center .grid .grid_wrapper .rack.x-32 {
+  left: 1280px;
+}
+.data-center .grid .grid_wrapper .rack.x-33 {
+  left: 1320px;
+}
+.data-center .grid .grid_wrapper .rack.x-34 {
+  left: 1360px;
+}
+.data-center .grid .grid_wrapper .rack.x-35 {
+  left: 1400px;
+}
+.data-center .grid .grid_wrapper .rack.x-36 {
+  left: 1440px;
+}
+.data-center .grid .grid_wrapper .rack.x-37 {
+  left: 1480px;
+}
+.data-center .grid .grid_wrapper .rack.x-38 {
+  left: 1520px;
+}
+.data-center .grid .grid_wrapper .rack.x-39 {
+  left: 1560px;
+}
+.data-center .grid .grid_wrapper .rack.x-40 {
+  left: 1600px;
+}
+.data-center .grid .grid_wrapper .rack.y-1 {
+  top: 40px;
+}
+.data-center .grid .grid_wrapper .rack.y-2 {
+  top: 80px;
+}
+.data-center .grid .grid_wrapper .rack.y-3 {
+  top: 120px;
+}
+.data-center .grid .grid_wrapper .rack.y-4 {
+  top: 160px;
+}
+.data-center .grid .grid_wrapper .rack.y-5 {
+  top: 200px;
+}
+.data-center .grid .grid_wrapper .rack.y-6 {
+  top: 240px;
+}
+.data-center .grid .grid_wrapper .rack.y-7 {
+  top: 280px;
+}
+.data-center .grid .grid_wrapper .rack.y-8 {
+  top: 320px;
+}
+.data-center .grid .grid_wrapper .rack.y-9 {
+  top: 360px;
+}
+.data-center .grid .grid_wrapper .rack.y-10 {
+  top: 400px;
+}
+.data-center .grid .grid_wrapper .rack.y-11 {
+  top: 440px;
+}
+.data-center .grid .grid_wrapper .rack.y-12 {
+  top: 480px;
+}
+.data-center .grid .grid_wrapper .rack.y-13 {
+  top: 520px;
+}
+.data-center .grid .grid_wrapper .rack.y-14 {
+  top: 560px;
+}
+.data-center .grid .grid_wrapper .rack.y-15 {
+  top: 600px;
+}
+.data-center .grid .grid_wrapper .rack.y-16 {
+  top: 640px;
+}
+.data-center .grid .grid_wrapper .rack.y-17 {
+  top: 680px;
+}
+.data-center .grid .grid_wrapper .rack.y-18 {
+  top: 720px;
+}
+.data-center .grid .grid_wrapper .rack.y-19 {
+  top: 760px;
+}
+.data-center .grid .grid_wrapper .rack.y-20 {
+  top: 800px;
+}
+.data-center .grid .grid_wrapper .rack.y-21 {
+  top: 840px;
+}
+.data-center .grid .grid_wrapper .rack.y-22 {
+  top: 880px;
+}
+.data-center .grid .grid_wrapper .rack.y-23 {
+  top: 920px;
+}
+.data-center .grid .grid_wrapper .rack.y-24 {
+  top: 960px;
+}
+.data-center .grid .grid_wrapper .rack.y-25 {
+  top: 1000px;
+}
+.data-center .grid .grid_wrapper .rack.y-26 {
+  top: 1040px;
+}
+.data-center .grid .grid_wrapper .rack.y-27 {
+  top: 1080px;
+}
+.data-center .grid .grid_wrapper .rack.y-28 {
+  top: 1120px;
+}
+.data-center .grid .grid_wrapper .rack.y-29 {
+  top: 1160px;
+}
+.data-center .grid .grid_wrapper .rack.y-30 {
+  top: 1200px;
+}
+.data-center .grid .grid_wrapper .rack.y-31 {
+  top: 1240px;
+}
+.data-center .grid .grid_wrapper .rack.y-32 {
+  top: 1280px;
+}
+.data-center .grid .grid_wrapper .rack.y-33 {
+  top: 1320px;
+}
+.data-center .grid .grid_wrapper .rack.y-34 {
+  top: 1360px;
+}
+.data-center .grid .grid_wrapper .rack.y-35 {
+  top: 1400px;
+}
+.data-center .grid .grid_wrapper .rack.y-36 {
+  top: 1440px;
+}
+.data-center .grid .grid_wrapper .rack.y-37 {
+  top: 1480px;
+}
+.data-center .grid .grid_wrapper .rack.y-38 {
+  top: 1520px;
+}
+.data-center .grid .grid_wrapper .rack.y-39 {
+  top: 1560px;
+}
+.data-center .grid .grid_wrapper .rack.y-40 {
+  top: 1600px;
 }
 .data-center .grid .grid_wrapper .rack:hover {
   background: #bbbbbb;

--- a/src/ralph/ui/static/ui/css/data_center.less
+++ b/src/ralph/ui/static/ui/css/data_center.less
@@ -36,6 +36,50 @@
         background: #555;
         .generate-rows(@grid-count);
         .generate-cols(@grid-count);
+        &.edit {
+            .grid_wrapper {
+                background-color: rgba(255, 255, 255, 0.1);
+                .progress, .free, .display, .used {
+                    display: none;
+                }
+                .rack {
+                    &.move {
+                        border-style: dashed;
+                        &.not_allowed{background-color: red;}
+                        &.allowed{background-color: #2a3;}
+                        .wrapper .tools {display: none !important;} // always hide if rack in the move
+                    }
+                    .wrapper {
+                        cursor: initial;
+                        &:hover {
+                            .tools {display: block;}
+                        }
+                        &:hover {
+                            .tools {display: block;}
+                        }
+                        .tools {display: none;}
+                        .icon-repeat {
+                            font-size: 1.25em;
+                            cursor: pointer;
+                            font-weight: bold;
+                            bottom: 5px;
+                            padding: 2px;
+                            &:hover {
+                                color: #fff;
+                            }
+                            &.left {left:5%}
+                            &.right {right:5%}
+                        }
+                        .edit {
+                            padding: 2px 0 0 2px;
+                        }
+                        .name {
+                            cursor: move;
+                        }
+                    }
+                }
+            }
+        }
         .grid_wrapper {
             position: relative;
             min-height: @grid-size * 20;
@@ -87,7 +131,12 @@
                     .wrapper .progress {
                         bottom: @label-height;
                     }
+                    .tools {
+                        transform: rotate(180deg);
+                    }
                 }
+                .generate-x-position(@grid-count);
+                .generate-y-position(@grid-count);
                 @rack-background: #888;
                 box-sizing: border-box;
                 position: absolute;

--- a/src/ralph/ui/static/ui/css/rack.css
+++ b/src/ralph/ui/static/ui/css/rack.css
@@ -482,6 +482,9 @@
   box-shadow: -1px 0 1px rgba(0, 0, 0, 0.6);
 }
 .racks .rack .wrapper .pdu pdu-item {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
   flex: 1 1 auto;
   margin: 3px 3px 0 3px;
   background: #999999;
@@ -786,6 +789,7 @@
   flex-flow: row wrap;
 }
 .racks .rack .wrapper .devices .device .children [class*="slot-"] {
+  width: 50px;
   box-sizing: border-box;
   font-size: .825em;
   background: rgba(255, 255, 255, 0.3);
@@ -793,6 +797,9 @@
   color: #000;
   display: block;
   text-align: center;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 .racks .rack .wrapper .devices .device .children [class*="slot-"]:hover {
   background: rgba(255, 255, 255, 0.5);
@@ -803,9 +810,6 @@
   color: #222;
   background: rgba(0, 0, 0, 0.3);
   padding: 2px;
-}
-.racks .rack .wrapper .devices .device .children [class*="slot-"] .barcode {
-  line-height: 50px;
 }
 .rack .devices .device.rows-1.cols-2 [class*="slot-"] {
   width: 200px;

--- a/src/ralph/ui/static/ui/css/rack.less
+++ b/src/ralph/ui/static/ui/css/rack.less
@@ -161,6 +161,9 @@
                 &.left {box-shadow: 1px 0 1px rgba(0, 0, 0, 0.6);}
                 &.right {box-shadow: -1px 0 1px rgba(0, 0, 0, 0.6);}
                 pdu-item {
+                    overflow: hidden;
+                    text-overflow: ellipsis;
+                    white-space: nowrap;
                     @background-color: #999;
                     @margin: 3px;
                     @padding: 5px;
@@ -297,6 +300,7 @@
                            -moz-flex-flow: row wrap;
                                 flex-flow: row wrap;
                         [class*="slot-"] {
+                            width: @devices-width-front / 8;
                             box-sizing: border-box;
                             font-size: .825em;
                             background: rgba(255,255,255,.3);
@@ -304,6 +308,9 @@
                             color: #000;
                             display: block;
                             text-align: center;
+                            overflow: hidden;
+                            text-overflow: ellipsis;
+                            white-space: nowrap;
                             &:hover {
                                 background: rgba(255,255,255,.5);
                             }
@@ -313,9 +320,6 @@
                                 color: #222;
                                 background: rgba(0,0,0,.3);
                                 padding: 2px;
-                            }
-                            .barcode {
-                                line-height: @default-slot-height;
                             }
                         }
                     }

--- a/src/ralph/ui/static/ui/js/app/apps.js
+++ b/src/ralph/ui/static/ui/js/app/apps.js
@@ -8,7 +8,10 @@ angular
             'rack.controllers',
         ]
     )
-    .config(['$routeProvider', function($routeProvider) {
+    .config(['$routeProvider', '$httpProvider', function($routeProvider, $httpProvider) {
+        $httpProvider.defaults.xsrfCookieName = 'csrftoken';
+        $httpProvider.defaults.xsrfHeaderName = 'X-CSRFToken';
+        $httpProvider.defaults.headers.common['X-Requested-With'] = 'XMLHttpRequest';
         $routeProvider
             .when('/', {
                 templateUrl: '/static/partials/data_center/data_center_view.html',

--- a/src/ralph/ui/static/ui/js/app/data_center/controllers.js
+++ b/src/ralph/ui/static/ui/js/app/data_center/controllers.js
@@ -4,10 +4,11 @@ angular
     .module('data_center.controllers', [
             'ngCookies',
             'data_center.services',
-            'data_center.directives'
+            'data_center.directives',
+            'rack.services'
         ]
     )
-    .controller('DataCenterController', ['$scope', '$cookies', 'DataCenterModel', function ($scope, $cookies, DataCenterModel) {
+    .controller('DataCenterController', ['$scope', '$cookies', 'DataCenterModel', 'RackModel', function ($scope, $cookies, DataCenterModel, RackModel) {
         var gridSize = 40;
         $scope.data_center = DataCenterModel.get({dcId: $cookies.data_center_id});
 
@@ -21,4 +22,12 @@ angular
             $scope.actualX = (offsetX - (offsetX % gridSize)) / gridSize;
             $scope.actualY = (offsetY - (offsetY % gridSize)) / gridSize;
         };
+
+        $scope.updateRack = function(rack) {
+            new RackModel(rack).$update();
+        };
+
+        $scope.$on('edit_rack', function (event, rack) {
+            $scope.rack = rack;
+        });
     }]);

--- a/src/ralph/ui/static/ui/js/app/data_center/directives.js
+++ b/src/ralph/ui/static/ui/js/app/data_center/directives.js
@@ -1,13 +1,70 @@
 'use strict';
 
 angular
-    .module('data_center.directives', [])
-    .directive('rackTop', function () {
+    .module('data_center.directives', ['rack.services'])
+    .directive('rackTop', ['$document', 'RackModel', function ($document, RackModel) {
         return {
             restrict: 'E',
             templateUrl: '/static/partials/data_center/rack.html',
             scope: {
                 rack: '=',
+                mode: '=',
+                dc: '='
+            },
+            link: function(scope, element) {
+                var gridSize = 40;
+                var startX = 0, startY = 0;
+                var offset;
+                scope.is_move = false;
+                element.on('mousedown', function(event) {
+                    event.preventDefault();
+                    offset = element.offset();
+                    startX = event.pageX - offset.left;
+                    startY = event.pageY - offset.top;
+                    if (scope.mode == 'edit') {
+                        $document.on('mousemove', mousemove);
+                        $document.on('mouseup', mouseup);
+                        scope.is_move = true;
+                    }
+                });
+                function mousemove(event) {
+                    var can_drop = true;
+                    var x = event.pageX - offset.left;
+                    var y = event.pageY - offset.top;
+                    var position_x = (x - (x % gridSize)) / gridSize;
+                    var position_y = (y - (y % gridSize)) / gridSize;
+                    angular.forEach(scope.dc.rack_set, function(value) {
+                        if(value.id !== scope.rack.id && value.visualization_col == position_x && value.visualization_row == position_y)
+                            can_drop = false;
+                    });
+                    if(can_drop) {
+                        scope.rack.visualization_col = position_x;
+                        scope.rack.visualization_row = position_y;
+                    }
+                    scope.can_drop = can_drop;
+                }
+                function mouseup() {
+                    $document.unbind('mousemove', mousemove);
+                    $document.unbind('mouseup', mouseup);
+                    new RackModel(scope.rack).$update();
+                    scope.is_move = false;
+                }
+
+                scope.rotate = function(direction) {
+                    var orientations = ['top', 'right', 'bottom', 'left'];
+                    var index = orientations.indexOf(scope.rack.orientation) + direction;
+                    if (index < 0) {
+                        index = orientations.length -1;
+                    }
+                    if (index > orientations.length -1) {
+                        index = 0;
+                    }
+                    scope.rack.orientation = orientations[index];
+                };
+
+                scope.edit = function(rack) {
+                    scope.$emit('edit_rack', rack);
+                };
             }
         };
-    });
+    }]);

--- a/src/ralph/ui/static/ui/js/app/data_center/services.js
+++ b/src/ralph/ui/static/ui/js/app/data_center/services.js
@@ -6,5 +6,5 @@ angular
         ]
     )
     .factory('DataCenterModel', ['$resource', function($resource){
-        return $resource('/assets/api/data_center/:dcId/');
+        return $resource('/assets/api/data_center/:dcId/', {dcId: '@id'});
     }]);

--- a/src/ralph/ui/static/ui/js/app/rack/services.js
+++ b/src/ralph/ui/static/ui/js/app/rack/services.js
@@ -6,5 +6,14 @@ angular
         ]
     )
     .factory('RackModel', ['$resource', function($resource){
-        return $resource('/assets/api/rack/:rackId/', {rackId: '@id'});
+        return $resource('/assets/api/rack/:rackId/',
+            {
+                rackId: '@id'
+            },
+            {
+                update: {
+                    method: 'PUT',
+                }
+            }
+        );
     }]);


### PR DESCRIPTION
![edit](https://cloud.githubusercontent.com/assets/351535/5703476/5dffb546-9a67-11e4-96f6-3bc03b291fc0.gif)

Changes:
- added modes - ``preview`` and ``edit``
![modes](https://cloud.githubusercontent.com/assets/351535/5703210/1b2be3be-9a64-11e4-96a5-7deabd68aae9.png)

- preview mode:
 - no changes,
- edit mode:
 - each rack can be move by drag and drop method
![green](https://cloud.githubusercontent.com/assets/351535/5703272/e287e2fa-9a64-11e4-8566-74ad27c196a0.png)

 - drag and drop validation
![validation](https://cloud.githubusercontent.com/assets/351535/5703343/c0fcddba-9a65-11e4-8380-8c625849aee4.png)

 - each rack can be rotate
![rotate](https://cloud.githubusercontent.com/assets/351535/5703292/136b9cf4-9a65-11e4-9e1e-f1cb073922d2.png)

 - name and description of each rack can be edited
![edit](https://cloud.githubusercontent.com/assets/351535/5703319/648916a2-9a65-11e4-9938-dd8e6b9bc5e5.png)