### PR TITLE
minor improvements related to SyncFieldMixin and Device.save()

### DIFF
--- a/src/ralph/discovery/models_device.py
+++ b/src/ralph/discovery/models_device.py
@@ -917,10 +917,13 @@ class Device(
             else:
                 name = filename
             self.saving_plugin = name
-        return super(Device, self).save(
-            *args,
-            **kwargs
-        )
+        # In case you'd notice that some of the changed fields are mysteriously
+        # not saved, check 'save_priorities' property on the device that you're
+        # trying to save - if such field is there, and the value associated
+        # with it is higher than your current save priority (i.e. 'priority' in
+        # kwargs or settings.DEFAULT_SAVE_PRIORITY, in that order), then that's
+        # the reason (for more, see the source code of SavePrioritized).
+        return super(Device, self).save(*args, **kwargs)
 
     def get_asset(self):
         asset = None

--- a/src/ralph/settings.py
+++ b/src/ralph/settings.py
@@ -780,3 +780,7 @@ LOGIN_REDIRECT_URL = reverse_lazy('find_user_home')
 # url to page where user requests permission to module (eg. assets)
 # REQUEST_PERM_URL = 'http://tickets.office/request/ralph_module/permission'
 DEFAULT_REGION_NAME = 'Default region'
+
+# a list of object's fields (e.g. Asset, Device) for which notification of
+# changed value should be send (see ralph.util.models.SyncFieldMixin)
+SYNC_FIELD_MIXIN_NOTIFICATIONS_WHITELIST = ['service', 'device_environment']


### PR DESCRIPTION
The actual behavior of `Device.save()` is rather confusing, mostly because of the `SavePrioritized` mixin (some changes are silently dropped, which is hard to track if you're unaware of this mechanism) - therefore, I think it's good to provide some explaination for this in the source code.

Also, I've improved the description of `SyncFieldMixin` and moved some hard-coded stuff to settings.