### PR TITLE
Added 'Go to initial device view' button to scan results.

### DIFF
--- a/src/ralph/ui/templates/ui/device_info.html
+++ b/src/ralph/ui/templates/ui/device_info.html
@@ -17,7 +17,7 @@
         <p><strong>Scan detected changes for the following IP addresses (click to see the change):</strong></p>
         <ul class="unstyled">
             {% for ip in changed_addresses %}
-                <li><a href="/ui/scan/status/{{ ip.address }}/" class="btn btn-link">
+                <li><a href="/ui/scan/status/{{ ip.address }}?initial_device_id={{ device.id }}" class="btn btn-link">
                     {{ ip|address_icon }}&nbsp;{{ ip.address }}</a>
                 </li>
             {% endfor %}

--- a/src/ralph/ui/templates/ui/scan-list.html
+++ b/src/ralph/ui/templates/ui/scan-list.html
@@ -39,7 +39,11 @@
   {% table_header columns url_query %}
   {% for scan_summary in bob_page %}
   <tr>
-    <td><a href="{%url scan_results scan_summary.job_id%}">
+    {% if scan_summary.device %}
+        <td><a href="{%url scan_results scan_summary.job_id%}?initial_device_id={{ scan_summary.device.id }}">
+    {% else %}
+        <td><a href="{%url scan_results scan_summary.job_id%}">
+    {% endif %}
         {{ scan_summary.ipaddress }}
     </a></td>
     {% if change_type == 'existing' and scan_summary.device %}

--- a/src/ralph/ui/templates/ui/scan-status.html
+++ b/src/ralph/ui/templates/ui/scan-status.html
@@ -130,6 +130,13 @@
                     </div>
                     {% endif %}
                 {% endfor %}
+                {% if initial_device_id %}
+                    <div class="controls">
+                        <a href="{% url 'search' details initial_device_id %}">
+                            Go to device from which you've initiated your scan
+                        </a>
+                    </div>
+                {% endif %}
                 <div class="form-actions">
                     <button
                         type="submit"
@@ -143,6 +150,12 @@
                             {% icon 'fugue-wand-hat' %}&nbsp;Create
                         {% endif %}
                     </button>
+                    {% if initial_device_id %}
+                        {% url 'search' details='scan' device=initial_device_id as initial_url %}
+                    {% else %}
+                        {% url 'search' as initial_url %}
+                    {% endif %}
+                        <a class="btn" href="{{ initial_url }}">Cancel</a>
                 </div>
                 </form>
             </div>
@@ -164,4 +177,3 @@
     {{ block.super }}
     <script src="{{ STATIC_URL }}scan.js"></script>
 {% endblock scripts %}
-

--- a/src/ralph/ui/templates/ui/scan.html
+++ b/src/ralph/ui/templates/ui/scan.html
@@ -38,6 +38,9 @@
                 </div>
             </div>
             {% endfor %}
+            {% if initial_device_id %}
+                <input type="hidden" value="{{ initial_device_id }}" name="initial_device_id">
+            {% endif %}
         </fieldset>
         <div class="form-actions">
             <button type="submit" class="btn btn-primary" value="scan">
@@ -93,4 +96,3 @@
     {{ block.super }}
     <script src="{{ STATIC_URL }}scan.js"></script>
 {% endblock scripts %}
-


### PR DESCRIPTION
Currently, If you scan some device, you get the scan results without the possibility to easily go back to such device's info tab (except from going back to the main page and manually searching this device, which is rather tedious and annoying). This pull request addresses this by adding a convenient "Go to initial device view" button, which appears when scanned device's IP address is already linked to some device (otherwise it doesn't make sense, though).