### PR TITLE
Set CI.state default value to ACTIVE

### DIFF
--- a/src/ralph/cmdb/models_ci.py
+++ b/src/ralph/cmdb/models_ci.py
@@ -341,7 +341,7 @@ class CI(TimeTrackable):
     content_object = generic.GenericForeignKey('content_type', 'object_id')
     state = models.IntegerField(
         max_length=11, choices=CI_STATE_TYPES(),
-        default=CI_STATE_TYPES.INACTIVE.id, verbose_name=_("state"),
+        default=CI_STATE_TYPES.ACTIVE.id, verbose_name=_("state"),
     )
     status = models.IntegerField(
         max_length=11, choices=CI_STATUS_TYPES(),

--- a/src/ralph/cmdb/tests/unit/tests_ci.py
+++ b/src/ralph/cmdb/tests/unit/tests_ci.py
@@ -63,7 +63,7 @@ class TestCI(TestCase):
         """Test the walk utility."""
 
         def activate(ci):
-            if ci.state == CI_STATE_TYPES.ACTIVE.id:
+            if ci.state == CI_STATE_TYPES.INACTIVE.id:
                 raise AssertionError(
                     'The function applied twice on the same CI during the walk'
                 )
@@ -86,7 +86,7 @@ class TestCI(TestCase):
             self.server_c,
         ]:
             ci = CI.objects.get(pk=ci.id)
-            self.assertEqual(ci.state, CI_STATE_TYPES.INACTIVE.id)
+            self.assertEqual(ci.state, CI_STATE_TYPES.ACTIVE.id)
 
     def test_collect(self):
         """Test the 'collect' utility"""


### PR DESCRIPTION
From now on, each newly  created CI is have ACTIVE state.