### PR TITLE
Fix button toogle on scan form.

### DIFF
--- a/src/ralph/ui/templates/ui/base.html
+++ b/src/ralph/ui/templates/ui/base.html
@@ -99,9 +99,9 @@
                 </footer>
             </div>
         </div>
+        <script src="{{ STATIC_URL }}js/ajax_select.js"></script>
         <script src="{{ STATIC_URL }}bootstrap/js/bootstrap.min.js"></script>
         <script src="{{ STATIC_URL }}bootstrap-datepicker.js"></script>
-        <script src="{{ STATIC_URL }}js/ajax_select.js"></script>
         {% include 'ui/angular_scripts.html' %}
     </body>
 </html>


### PR DESCRIPTION
Change the order of loading ajax_select.js file. 
jquery_ui.js loaded from ajax_select.js must be loaded before the bootstrap.js, another order causes error.