### PR TITLE
Fix for MAC detecting in IDRAC plugin.

### DIFF
--- a/src/ralph/scan/plugins/idrac.py
+++ b/src/ralph/scan/plugins/idrac.py
@@ -159,16 +159,21 @@ def _get_mac_addresses(idrac_manager):
         XMLNS_WSMAN,
         xmlns_n1,
     )
-    mac_addresses = [
-        record.find(
-            "{}{}".format(xmlns_n1, 'CurrentMACAddress'),
-        ).text.strip() for record in tree.findall(q)
-    ]
-    return [
-        MACAddressField.normalize(mac)
-        for mac in mac_addresses
-        if mac.replace(':', '').upper()[:6] not in MAC_PREFIX_BLACKLIST
-    ]
+    mac_addresses = []
+    for record in tree.findall(q):
+        try:
+            mac = record.find(
+                "{}{}".format(xmlns_n1, 'CurrentMACAddress'),
+            ).text
+        except AttributeError:
+            continue
+        if not mac:
+            continue
+        mac = MACAddressField.normalize(mac)
+        if mac[:6] in MAC_PREFIX_BLACKLIST:
+            continue
+        mac_addresses.append(mac)
+    return mac_addresses
 
 
 def _get_processors(idrac_manager):

--- a/src/ralph/scan/tests/plugins/samples/idrac.py
+++ b/src/ralph/scan/tests/plugins/samples/idrac.py
@@ -517,6 +517,87 @@ nic_info = """<?xml version="1.0" encoding="UTF-8"?>
           <n1:WWPN xsi:nil="true"/>
           <n1:iScsiOffloadMode>3</n1:iScsiOffloadMode>
         </n1:DCIM_NICView>
+        <n1:DCIM_NICView>
+          <n1:AutoNegotiation>2</n1:AutoNegotiation>
+          <n1:BusNumber>1</n1:BusNumber>
+          <n1:ControllerBIOSVersion xsi:nil="true"/>
+          <n1:CurrentMACAddress></n1:CurrentMACAddress>
+          <n1:DataBusWidth>0002</n1:DataBusWidth>
+          <n1:DeviceNumber>0</n1:DeviceNumber>
+          <n1:EFIVersion xsi:nil="true"/>
+          <n1:FCoEOffloadMode>3</n1:FCoEOffloadMode>
+          <n1:FCoEWWNN xsi:nil="true"/>
+          <n1:FQDD>NIC.Integrated.1-2-1</n1:FQDD>
+          <n1:FamilyVersion>13.5.6</n1:FamilyVersion>
+          <n1:FunctionNumber>1</n1:FunctionNumber>
+          <n1:InstanceID>NIC.Integrated.1-2-1</n1:InstanceID>
+          <n1:LastSystemInventoryTime>20121129101647.000000+000</n1:LastSystemInventoryTime>
+          <n1:LastUpdateTime>20121129101636.000000+000</n1:LastUpdateTime>
+          <n1:LinkDuplex>1</n1:LinkDuplex>
+          <n1:LinkSpeed>3</n1:LinkSpeed>
+          <n1:MaxBandwidth>0</n1:MaxBandwidth>
+          <n1:MediaType>1</n1:MediaType>
+          <n1:MinBandwidth>0</n1:MinBandwidth>
+          <n1:NicMode>3</n1:NicMode>
+          <n1:PCIDeviceID>1521</n1:PCIDeviceID>
+          <n1:PCISubDeviceID>1f60</n1:PCISubDeviceID>
+          <n1:PCISubVendorID>1028</n1:PCISubVendorID>
+          <n1:PCIVendorID>8086</n1:PCIVendorID>
+          <n1:PermanentFCOEMACAddress/>
+          <n1:PermanentMACAddress>BC:30:FB:F1:33:01</n1:PermanentMACAddress>
+          <n1:PermanentiSCSIMACAddress/>
+          <n1:ProductName>Intel(R) Gigabit 4P I350-t rNDC - BC:30:FB:F1:33:01</n1:ProductName>
+          <n1:ReceiveFlowControl>2</n1:ReceiveFlowControl>
+          <n1:SlotLength>0002</n1:SlotLength>
+          <n1:SlotType>0002</n1:SlotType>
+          <n1:TransmitFlowControl>3</n1:TransmitFlowControl>
+          <n1:VendorName>Intel Corp</n1:VendorName>
+          <n1:VirtWWN xsi:nil="true"/>
+          <n1:VirtWWPN xsi:nil="true"/>
+          <n1:WWN>BC:30:FB:F1:33:01</n1:WWN>
+          <n1:WWPN xsi:nil="true"/>
+          <n1:iScsiOffloadMode>3</n1:iScsiOffloadMode>
+        </n1:DCIM_NICView>
+        <n1:DCIM_NICView>
+          <n1:AutoNegotiation>2</n1:AutoNegotiation>
+          <n1:BusNumber>1</n1:BusNumber>
+          <n1:ControllerBIOSVersion xsi:nil="true"/>
+          <n1:DataBusWidth>0002</n1:DataBusWidth>
+          <n1:DeviceNumber>0</n1:DeviceNumber>
+          <n1:EFIVersion xsi:nil="true"/>
+          <n1:FCoEOffloadMode>3</n1:FCoEOffloadMode>
+          <n1:FCoEWWNN xsi:nil="true"/>
+          <n1:FQDD>NIC.Integrated.1-2-1</n1:FQDD>
+          <n1:FamilyVersion>13.5.6</n1:FamilyVersion>
+          <n1:FunctionNumber>1</n1:FunctionNumber>
+          <n1:InstanceID>NIC.Integrated.1-2-1</n1:InstanceID>
+          <n1:LastSystemInventoryTime>20121129101647.000000+000</n1:LastSystemInventoryTime>
+          <n1:LastUpdateTime>20121129101636.000000+000</n1:LastUpdateTime>
+          <n1:LinkDuplex>1</n1:LinkDuplex>
+          <n1:LinkSpeed>3</n1:LinkSpeed>
+          <n1:MaxBandwidth>0</n1:MaxBandwidth>
+          <n1:MediaType>1</n1:MediaType>
+          <n1:MinBandwidth>0</n1:MinBandwidth>
+          <n1:NicMode>3</n1:NicMode>
+          <n1:PCIDeviceID>1521</n1:PCIDeviceID>
+          <n1:PCISubDeviceID>1f60</n1:PCISubDeviceID>
+          <n1:PCISubVendorID>1028</n1:PCISubVendorID>
+          <n1:PCIVendorID>8086</n1:PCIVendorID>
+          <n1:PermanentFCOEMACAddress/>
+          <n1:PermanentMACAddress>BC:30:FB:F1:33:01</n1:PermanentMACAddress>
+          <n1:PermanentiSCSIMACAddress/>
+          <n1:ProductName>Intel(R) Gigabit 4P I350-t rNDC - BC:30:FB:F1:33:01</n1:ProductName>
+          <n1:ReceiveFlowControl>2</n1:ReceiveFlowControl>
+          <n1:SlotLength>0002</n1:SlotLength>
+          <n1:SlotType>0002</n1:SlotType>
+          <n1:TransmitFlowControl>3</n1:TransmitFlowControl>
+          <n1:VendorName>Intel Corp</n1:VendorName>
+          <n1:VirtWWN xsi:nil="true"/>
+          <n1:VirtWWPN xsi:nil="true"/>
+          <n1:WWN>BC:30:FB:F1:33:01</n1:WWN>
+          <n1:WWPN xsi:nil="true"/>
+          <n1:iScsiOffloadMode>3</n1:iScsiOffloadMode>
+        </n1:DCIM_NICView>
       </wsman:Items>
       <wsen:EnumerationContext/>
       <wsman:EndOfSequence/>


### PR DESCRIPTION
For some configurations IDRAC plugin does not work because an error in MAC detecting function occurs. This function was changed to provide more stable detection. Also our tests sample data was updated.