### PR TITLE
New CiscoSSHHandler added to provide better support for Cisco switches.

### DIFF
--- a/src/ralph/scan/tests/plugins/test_ssh_cisco_catalyst.py
+++ b/src/ralph/scan/tests/plugins/test_ssh_cisco_catalyst.py
@@ -221,7 +221,7 @@ class TestCiscoCatalyst(TestCase):
             "show version | include Base ethernet MAC Address",
         )
         command_mock.assert_any_call("show inventory")
-        self.assertEqual(command_mock.call_count, 4)
+        self.assertEqual(command_mock.call_count, 3)
 
     def test_get_subswitches(self):
         correct_ret = [


### PR DESCRIPTION
* New connector added - CiscoSSHHandler
* Change ssh_cisco_catalyst_plugin to use new connetor
* ssh_cisco_catalyst_plugin now does not send `terminal length` command - it's now handled by connector class