### PR TITLE
Xen dom0 is incorrectly classified as virtual host

### DIFF
--- a/src/ralph/scan/plugins/puppet.py
+++ b/src/ralph/scan/plugins/puppet.py
@@ -213,7 +213,7 @@ def _get_ip_addresses_hostnames_sets(ip):
 
 def _is_host_virtual(facts):
     is_virtual = facts.get('virtual', 'physical') not in (
-        'physical', 'openvz', 'openvzhn',
+        'physical', 'openvz', 'openvzhn', 'xen0',
     )
     if facts.get('manufacturer') == 'Bochs' and not is_virtual:
         facts['virtual'] = 'virtual'


### PR DESCRIPTION
Xen dom0 should be classified as physical machine:

    xen3:~☠ facter -p  |grep -P '(virtual|^productname)' 
    is_virtual => false
    productname => IBM System x3550 -[7978ZBX]-
    virtual => xen0

btw. is there a reason fact 'is_virtual' is not used for that ? Both facts come from same place ( https://github.com/puppetlabs/facter/blob/master/lib/facter/virtual.rb ).
