### PR TITLE
Improved Xen detection

### DIFF
--- a/src/ralph/discovery/http.py
+++ b/src/ralph/discovery/http.py
@@ -122,6 +122,8 @@ def guess_family(headers, document):
             family = 'ESX'
         elif 'ATEN International Co Ltd.' in document:
             family = 'Thomas-Krenn'
+        elif 'XenServer' in document:
+            family = 'Xen'
     elif family in ('lighttpd',):
         if 'Modular Server Control' in document:
             family = 'Modular'

--- a/src/ralph/discovery/tests/test_http.py
+++ b/src/ralph/discovery/tests/test_http.py
@@ -13,7 +13,23 @@ from ralph.discovery.http import guess_family
 
 class DiscoveryHttpTest(TestCase):
 
-    def test_guess_family(self):
+    def test_guess_family_dell_when_data_from_dell_server(self):
         headers = {}
         family = guess_family(headers, DATA)
         self.assertEqual(family, 'Dell')
+
+    def test_guess_family_xen_when_data_from_xen(self):
+        headers = {}
+        family = guess_family(headers, """
+            <html>
+                <title>XenServer 6.5.0</title>
+                <head>
+                </head>
+                <body>
+                  <p/>Citrix Systems, Inc. XenServer 6.5.0
+                  <p/><a href="XenCenter.iso">XenCenter CD image</a>
+                  <p/><a href="XenCenterSetup.exe">XenCenter installer</a>
+                </body>
+            </html>"""
+        )
+        self.assertEqual(family, 'Xen')

--- a/src/ralph/scan/plugins/ssh_xen.py
+++ b/src/ralph/scan/plugins/ssh_xen.py
@@ -253,9 +253,10 @@ def _ssh_xen(ssh, ip_address):
 
 def scan_address(ip_address, **kwargs):
     snmp_name = kwargs.get('snmp_name', '') or ''
+    http_family = kwargs.get('http_family', '') or ''
     if 'nx-os' in snmp_name.lower():
         raise NoMatchError("Incompatible Nexus found.")
-    if 'xen' not in snmp_name:
+    if 'xen' not in snmp_name and 'xen' not in http_family.lower():
         raise NoMatchError("XEN not found.")
     auths = SETTINGS.get('xen_auths')
     messages = []


### PR DESCRIPTION
The Xen servers > 6.5 don't contain 'xen' string in their snmp_name. We
need to detect them using their HTTP response (looking for 'XenServer'
string in the returned HTML document).

Also - renamed the existing Dell detection test, so new tests can be
added.