### PR TITLE
Moved the settings in settings.py

### DIFF
--- a/src/ralph/settings.py
+++ b/src/ralph/settings.py
@@ -410,6 +410,14 @@ for cfg_loc in [local_settings,
         execfile(cfg_loc)
         break
 
+# url to page where user requests permission to module (eg. assets)
+# REQUEST_PERM_URL = 'http://tickets.office/request/ralph_module/permission'
+DEFAULT_REGION_NAME = 'Default region'
+
+# a list of object's fields (e.g. Asset, Device) for which notification of
+# changed value should be send (see ralph.util.models.SyncFieldMixin)
+SYNC_FIELD_MIXIN_NOTIFICATIONS_WHITELIST = ['service', 'device_environment']
+
 import pluggableapp
 pluggableapp.initialize(locals())
 
@@ -780,10 +788,3 @@ RQ_TIMEOUT = 3000
 from django.core.urlresolvers import reverse_lazy
 LOGIN_REDIRECT_URL = reverse_lazy('find_user_home')
 
-# url to page where user requests permission to module (eg. assets)
-# REQUEST_PERM_URL = 'http://tickets.office/request/ralph_module/permission'
-DEFAULT_REGION_NAME = 'Default region'
-
-# a list of object's fields (e.g. Asset, Device) for which notification of
-# changed value should be send (see ralph.util.models.SyncFieldMixin)
-SYNC_FIELD_MIXIN_NOTIFICATIONS_WHITELIST = ['service', 'device_environment']


### PR DESCRIPTION
Some settings must be put before pluggable apps initialization. If not,
then the plugins that use ralph will crash trying to import things from
ralph.