### PR TITLE
Allowed ralph plugins without menu entry and urls

### DIFF
--- a/src/ralph/app.py
+++ b/src/ralph/app.py
@@ -18,9 +18,8 @@ class RalphModule(pluggableapp.PluggableApp):
         of API."""
         return []
 
-    @abc.abstractproperty
-    def url_prefix(self):
-        """The first part of paths for this application."""
+    url_prefix = None
+    has_menu = True
 
     @abc.abstractproperty
     def module_name(self):
@@ -40,6 +39,8 @@ class RalphModule(pluggableapp.PluggableApp):
 
     def __init__(self, *args, **kwargs):
         super(RalphModule, self).__init__(*args, **kwargs)
+        if not self.url_prefix:
+            return
         self.register_pattern(
             '',
             r'^{}/'.format(self.url_prefix),

--- a/src/ralph/ui/views/common.py
+++ b/src/ralph/ui/views/common.py
@@ -232,7 +232,8 @@ class MenuMixin(object):
         for app in pluggableapp.app_dict.values():
             if (
                 not isinstance(app, RalphModule) or
-                app.module_name in settings.HIDE_MENU
+                app.module_name in settings.HIDE_MENU or
+                not app.has_menu
             ):
                 continue
             menu_module = importlib.import_module(


### PR DESCRIPTION
Some apps might not need an entry in menu or their own views (and hence
their own urls.py). This fix will cause them not to crash.