### PR TITLE
Moved property setting to a separate function

### DIFF
--- a/src/ralph/cmdb/api.py
+++ b/src/ralph/cmdb/api.py
@@ -17,7 +17,6 @@ import operator
 from ralph.cmdb.monkey import method_check
 import tastypie
 from tastypie.resources import Resource
-Resource.method_check = method_check
 
 from django.conf import settings
 from django.contrib.auth.models import User
@@ -51,6 +50,7 @@ from ralph.cmdb import models as db
 from ralph.cmdb.models_ci import CIOwner, CIOwnershipType
 from ralph.cmdb.util import breadth_first_search_ci, can_change_ci_state
 
+Resource.method_check = method_check
 
 THROTTLE_AT = settings.API_THROTTLING['throttle_at']
 TIMEFRAME = settings.API_THROTTLING['timeframe']

--- a/src/ralph/cmdb/importer.py
+++ b/src/ralph/cmdb/importer.py
@@ -42,10 +42,8 @@ from __future__ import print_function
 from __future__ import unicode_literals
 
 import os
-os.environ['DJANGO_SETTINGS_MODULE'] = "ralph.settings"
 
 import logging
-logger = logging.getLogger(__name__)
 
 from django.contrib.contenttypes.models import ContentType
 
@@ -55,6 +53,10 @@ import ralph.business.models as bdb
 import ralph.cmdb.models as cdb
 from django.db import IntegrityError
 from lck.django.common import nested_commit_on_success
+
+
+os.environ['DJANGO_SETTINGS_MODULE'] = "ralph.settings"
+logger = logging.getLogger(__name__)
 
 
 def get_layers_for_ci_type(ci_type_id):

--- a/src/ralph/cmdb/integration/lib/jira.py
+++ b/src/ralph/cmdb/integration/lib/jira.py
@@ -6,9 +6,11 @@ from restkit import Resource, BasicAuth, ResourceNotFound
 from django.utils import simplejson as json
 
 import logging
-logger = logging.getLogger(__name__)
 
 from ralph.cmdb.integration.exceptions import IssueTrackerException
+
+
+logger = logging.getLogger(__name__)
 
 
 class Jira(object):

--- a/src/ralph/discovery/tests/test_models.py
+++ b/src/ralph/discovery/tests/test_models.py
@@ -19,8 +19,12 @@ from ralph.cmdb.tests.utils import (
 from ralph.discovery.tests.util import DeviceFactory, IPAddressFactory
 from ralph.discovery.models import DeviceType, Device, UptimeSupport
 from ralph.discovery.models_history import HistoryChange
+from ralph.ui.tests.global_utils import UserFactory
 from ralph.util.models import fields_synced_signal, ChangeTuple
-from ralph.util.tests.utils import UserFactory
+from ralph.util.tests.utils import (
+    UserFactory, RolePropertyTypeFactory, RolePropertyFactory,
+    VentureRoleFactory,
+)
 from ralph_assets.models import Orientation
 from ralph_assets.tests.utils.assets import DCAssetFactory, DeviceInfoFactory
 
@@ -184,3 +188,27 @@ class DeviceModelTest(TestCase):
         self.assertEqual(dev_2.orientation, 'middle')
         with self.assertRaises(AttributeError):
             dev_2.orientation = Orientation.back.id
+
+
+class DevicePropertiesTest(TestCase):
+
+    def setUp(self):
+        sample_role = VentureRoleFactory()
+        RolePropertyFactory(
+            symbol='my_custom_property_1',
+            type=RolePropertyTypeFactory(symbol='STRING'),
+            role=sample_role,
+        )
+        self.sample_device = DeviceFactory(
+            venture=sample_role.venture, venture_role=sample_role)
+        self.sample_user = UserFactory()
+
+    def test_successful_save(self):
+        self.sample_device.set_property(
+            symbol='my_custom_property_1', value='Test 123',
+            user=self.sample_user,
+        )
+        self.assertEqual(
+            self.sample_device.get_property_set(),
+            {'my_custom_property_1': 'Test 123'}
+        )

--- a/src/ralph/ui/views/racks.py
+++ b/src/ralph/ui/views/racks.py
@@ -201,11 +201,15 @@ class RacksDeviceList(SidebarRacks, BaseMixin, BaseDeviceList):
             depth, item = top.pop()
             c = children[item]
             if sort in ('-position', 'position'):
-                key = lambda x: (x.get_position() or '').rjust(100)
+                def key(x):
+                    return (x.get_position() or '').rjust(100)
                 c.sort(key=key, reverse=not sort.startswith('-'))
             elif sort == '':
-                key = lambda x: (x.model.type if x.model else None,
-                                 (x.get_position() or '').rjust(100))
+                def key(x):
+                    return (
+                        x.model.type if x.model else None,
+                        (x.get_position() or '').rjust(100)
+                    )
                 c.sort(key=key, reverse=True)
             top.extend((depth + 1, i) for i in c)
             item.depth = depth

--- a/src/ralph/util/models.py
+++ b/src/ralph/util/models.py
@@ -18,6 +18,7 @@ from tastypie.models import create_api_key
 
 from ralph.settings import SYNC_FIELD_MIXIN_NOTIFICATIONS_WHITELIST
 
+from django.contrib.auth.tests import models as auth_test_models
 ChangeTuple = namedtuple('ChangeTuple', ['field', 'old_value', 'new_value'])
 
 
@@ -34,7 +35,6 @@ db.signals.post_save.connect(create_api_key_ignore_dberrors, sender=User)
 
 # workaround for a unit test bug in Django 1.4.x
 
-from django.contrib.auth.tests import models as auth_test_models
 del auth_test_models.ProfileTestCase.test_site_profile_not_available
 
 # signal used by SyncFieldMixin for sending notifications on changed fields

--- a/src/ralph/util/tests/utils.py
+++ b/src/ralph/util/tests/utils.py
@@ -10,7 +10,9 @@ import factory
 from factory.django import DjangoModelFactory
 
 from ralph.account.models import Region
-from ralph.business.models import Venture, VentureRole
+from ralph.business.models import (
+    Venture, VentureRole, RolePropertyType, RoleProperty,
+)
 from ralph.cmdb import models_ci
 from ralph.cmdb.tests.utils import CIFactory
 from ralph.ui.tests.global_utils import UserFactory
@@ -95,3 +97,14 @@ class VentureRoleFactory(DjangoModelFactory):
     FACTORY_FOR = VentureRole
     name = factory.Sequence(lambda n: 'Venture role #{}'.format(n))
     venture = factory.SubFactory(VentureFactory)
+
+
+class RolePropertyTypeFactory(DjangoModelFactory):
+    FACTORY_FOR = RolePropertyType
+    symbol = factory.Sequence(lambda n: 'property_type_{}'.format(n))
+
+
+class RolePropertyFactory(DjangoModelFactory):
+    FACTORY_FOR = RoleProperty
+    symbol = factory.Sequence(lambda n: 'property_{}'.format(n))
+    type = factory.SubFactory(RolePropertyTypeFactory)


### PR DESCRIPTION
We want to set device properties from other places than just save() of
the device form. Thus we move the logic to a separate function.