### PR TITLE
Changes in deployments plugins order.

### DIFF
--- a/src/ralph/deployment/plugins/change_status.py
+++ b/src/ralph/deployment/plugins/change_status.py
@@ -11,7 +11,7 @@ from ralph.util import plugin
 
 
 @plugin.register(chain='deployment',
-                 requires=['dns', 'dhcp', 'role'],
+                 requires=['dns', 'dhcp', 'role', 'clean'],
                  priority=0)
 def change_status(deployment_id):
     deployment = Deployment.objects.get(id=deployment_id)

--- a/src/ralph/deployment/plugins/clean.py
+++ b/src/ralph/deployment/plugins/clean.py
@@ -80,8 +80,6 @@ def clean(deployment_id):
         return True
     do_clean(deployment.device, deployment.user)
     deployment.device.name = deployment.hostname
-    deployment.device.venture = deployment.venture
-    deployment.device.venture_role = deployment.venture_role
     deployment.device.save()
     ip, created = IPAddress.concurrent_get_or_create(address=deployment.ip)
     ip.device = deployment.device

--- a/src/ralph/deployment/plugins/dhcp.py
+++ b/src/ralph/deployment/plugins/dhcp.py
@@ -12,7 +12,7 @@ from ralph.dnsedit.util import reset_dhcp
 from ralph.deployment.models import Deployment
 
 
-@plugin.register(chain='deployment', requires=['dns'], priority=0)
+@plugin.register(chain='deployment', requires=['dns', 'clean'], priority=0)
 def dhcp(deployment_id):
     deployment = Deployment.objects.get(id=deployment_id)
     try:

--- a/src/ralph/deployment/plugins/dns.py
+++ b/src/ralph/deployment/plugins/dns.py
@@ -11,7 +11,7 @@ from ralph.dnsedit.util import reset_dns
 from ralph.deployment.models import Deployment
 
 
-@plugin.register(chain='deployment', requires=['role'], priority=0)
+@plugin.register(chain='deployment', requires=['role', 'clean'], priority=0)
 def dns(deployment_id):
     deployment = Deployment.objects.get(id=deployment_id)
     reset_dns(deployment.hostname, deployment.ip)

--- a/src/ralph/deployment/plugins/role.py
+++ b/src/ralph/deployment/plugins/role.py
@@ -10,7 +10,7 @@ from ralph.util import plugin
 from ralph.deployment.models import Deployment
 
 
-@plugin.register(chain='deployment', requires=[], priority=0)
+@plugin.register(chain='deployment', requires=['clean'], priority=0)
 def role(deployment_id):
     deployment = Deployment.objects.get(id=deployment_id)
     deployment.device.venture = deployment.venture

--- a/src/ralph/deployment/tests/plugins/test_clean.py
+++ b/src/ralph/deployment/tests/plugins/test_clean.py
@@ -22,13 +22,11 @@ from ralph.discovery.models import (
 )
 from ralph.deployment.models import Deployment
 from ralph.deployment.plugins.clean import clean
-from ralph.util.tests.utils import VentureRoleFactory
 
 
 class CleanPluginTest(TestCase):
 
     def setUp(self):
-        self.venture_role = VentureRoleFactory()
         device = Device.create(
             ethernets=[('', 'deadbeefcafe', 0)],
             model_name='HAL 9000',
@@ -42,8 +40,6 @@ class CleanPluginTest(TestCase):
             mac='deadbeefcafe',
             device=device,
             preboot=None,
-            venture=self.venture_role.venture,
-            venture_role=self.venture_role,
         )
         self.deployment.save()
         self.ip = IPAddress(address='127.0.0.1', device=device)
@@ -70,8 +66,6 @@ class CleanPluginTest(TestCase):
         self.assertEquals(device.ipaddress_set.count(), 1)
         self.assertEquals(device.ipaddress_set.all()[0].address, '127.0.0.1')
         self.assertEquals(device.name, 'discovery.one')
-        self.assertEquals(device.venture, self.venture_role.venture)
-        self.assertEquals(device.venture_role, self.venture_role)
         self.assertFalse(device.diskshare_set.exists())
         self.assertFalse(device.disksharemount_set.exists())
         self.assertFalse(device.software_set.exists())


### PR DESCRIPTION
Added clean plugin as required to each other plugins to make sure that
new venture and role will be assigned to deployed server.
Removed venture and role assignation form clean plugin - it's now not
required.