### PR TITLE
Validation for IPWithHostnameField

### DIFF
--- a/src/ralph/ui/forms/addresses.py
+++ b/src/ralph/ui/forms/addresses.py
@@ -8,6 +8,7 @@ import ipaddr
 
 from bob.forms import AutocompleteWidget
 from django import forms
+from django.core.exceptions import ValidationError
 from django.template import Context
 from django.template.loader import get_template
 from django.utils.translation import ugettext_lazy as _
@@ -388,6 +389,10 @@ class IPWithHostField(forms.MultiValueField):
     widget = IPWithHostWidget()
 
     def compress(self, value):
+        if value:
+            hostname, ip_number = value
+            if not ip_number:
+                raise ValidationError(_('IP Address is required'))
         return value
 
 

--- a/src/ralph/ui/templates/ui/device_addresses.html
+++ b/src/ralph/ui/templates/ui/device_addresses.html
@@ -114,7 +114,7 @@
         <form class="form form-inline" action="" method="POST">
             {% csrf_token %}
 
-            {{ ip_management_form }}
+            {% form ip_management_form %}
 
             {% if canedit %}
                 <div class="buttons pull-right">

--- a/src/ralph/ui/tests/unit/test_fields.py
+++ b/src/ralph/ui/tests/unit/test_fields.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+"""Tests for special fields."""
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
+from django.forms import ValidationError
+from django.test import TestCase
+
+from ralph.ui.forms.addresses import IPWithHostField
+
+
+class TestIPWithHostnameField(TestCase):
+    """Tests for ``IPWithHostField``"""
+
+    def test_field_invalid_when_ip_number_missing(self):
+        with self.assertRaises(ValidationError):
+            IPWithHostField().compress(['example.com', ''])

--- a/src/ralph/ui/views/common.py
+++ b/src/ralph/ui/views/common.py
@@ -941,9 +941,10 @@ class Addresses(DeviceDetailView):
             else:
                 messages.error(self.request, "Errors in the addresses form.")
         elif 'management' in self.request.POST:
-            form = IPManagementForm(self.request.POST)
-            if form.is_valid():
-                self.object.management_ip = form.cleaned_data['management_ip']
+            self.ip_management_form = IPManagementForm(self.request.POST)
+            if self.ip_management_form.is_valid():
+                self.object.management_ip =\
+                    self.ip_management_form.cleaned_data['management_ip']
                 self.object.save()
                 messages.success(
                     self.request, "Management IP address updated."


### PR DESCRIPTION
The IPWithHostname field should always require IP Address, or else the
IPAddress object creation will fail.