### PR TITLE
Changed order in INSTALLED_APPS

### DIFF
--- a/src/ralph/settings.py
+++ b/src/ralph/settings.py
@@ -58,8 +58,8 @@ ROOT_URLCONF = 'ralph.urls'
 TEMPLATE_DIRS = (CURRENT_DIR + "templates",)
 LOCALE_PATHS = (CURRENT_DIR + "locale",)
 INSTALLED_APPS = [
-    'django.contrib.auth',
     'django.contrib.contenttypes',
+    'django.contrib.auth',
     'django.contrib.sessions',
     'django.contrib.sites',
     'django.contrib.messages',


### PR DESCRIPTION
This changed prevented error like ``Cannot add or update a child row: a
foreign key constraint fails ... FOREIGN KEY (`content_type_id`) REFERENCES
`django_content_type` (`id`))'``.