### PR TITLE
Fix install python-graph

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,7 @@ runserver:
 	ralph runserver
 
 install:
+	pip install https://github.com/chapmanb/python-graph/releases/download/1.8.2/python-graph-core-1.8.2.tar.gz
 	pip install -e . --use-mirrors --allow-all-external --allow-unverified ipaddr --allow-unverified postmarkup --allow-unverified python-graph-core --allow-unverified pysphere
 
 test-unittests:


### PR DESCRIPTION
This fix is only for few days. Everything need back to old version when graph core will release as pypi package. 