### PR TITLE
Juniper devices ignored in Cisco plugin scan

### DIFF
--- a/src/ralph/scan/plugins/ssh_cisco_catalyst.py
+++ b/src/ralph/scan/plugins/ssh_cisco_catalyst.py
@@ -99,6 +99,8 @@ def get_subswitches(switch_version, hostname, ip_address):
 
 
 def scan_address(ip_address, **kwargs):
+    if 'juniper' in (kwargs.get('snmp_name') or '').lower():
+        raise NoMatchError('Incompatible Juniper found.')
     if 'nx-os' in (kwargs.get('snmp_name', '') or '').lower():
         raise NoMatchError('Incompatible Nexus found.')
     if kwargs.get('http_family') not in ('Unspecified', 'Cisco'):


### PR DESCRIPTION
Because of 'while True' in CiscoSSHHandler, on Juniper devices plugin sometimes sends command and waits for Cisco specific prompt forever. Checking if device is Juniper switch avoids this behavior.

Searching for 'cisco' in SNMP name can be another way to solve this problem but then we 'lose' switches with proper SSH configuration and some SNMP issues.