### PR TITLE
Remove workaround for installation python-graph-core

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,8 +8,7 @@ runserver:
 	ralph runserver
 
 install:
-	pip install https://github.com/chapmanb/python-graph/releases/download/1.8.2/python-graph-core-1.8.2.tar.gz
-	pip install -e . --use-mirrors --allow-all-external --allow-unverified ipaddr --allow-unverified postmarkup --allow-unverified python-graph-core --allow-unverified pysphere
+	pip install -e . --use-mirrors --allow-all-external --allow-unverified ipaddr --allow-unverified postmarkup --allow-unverified pysphere
 
 test-unittests:
 	DJANGO_SETTINGS_PROFILE=test-ralph coverage run --source=ralph --omit='*migrations*,*tests*,*__init__*,*wsgi.py,*__main__*,*settings*,*manage.py' '$(VIRTUAL_ENV)/bin/ralph' test ralph

--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -321,7 +321,7 @@ If you have pip 1.3.x or 1.4.x use this command::
 
 In case you have newer pip (1.5.x or newer) use slightly longer command::
 
-  (ralph)$ pip install ralph --use-mirrors --allow-all-external --allow-unverified ipaddr --allow-unverified postmarkup --allow-unverified python-graph-core --allow-unverified pysphere
+  (ralph)$ pip install ralph --use-mirrors --allow-all-external --allow-unverified ipaddr --allow-unverified postmarkup --allow-unverified pysphere
 
 That's it.
 


### PR DESCRIPTION
Now python-graph-core package is hosted on https://pypi.python.org/