### PR TITLE
Added mechanism for generate demo data

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ install:
 	pip install -e . --use-mirrors --allow-all-external --allow-unverified ipaddr --allow-unverified postmarkup --allow-unverified pysphere
 
 test-unittests:
-	DJANGO_SETTINGS_PROFILE=test-ralph coverage run --source=ralph --omit='*migrations*,*tests*,*__init__*,*wsgi.py,*__main__*,*settings*,*manage.py' '$(VIRTUAL_ENV)/bin/ralph' test ralph
+	DJANGO_SETTINGS_PROFILE=test-ralph coverage run --source=ralph --omit='*migrations*,*tests*,*__init__*,*wsgi.py,*__main__*,*settings*,*manage.py,src/ralph/util/demo/*' '$(VIRTUAL_ENV)/bin/ralph' test ralph
 
 test-doc:
 	# ignore warnings about missing subdirs - cloned from another repositories

--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -5,7 +5,7 @@ Install / Upgrade Ralph
 Prebuilt docker image - recommeneded option
 ===========================================
 
-It is the easiest way to try out Ralph using pre-built docker image with the worker, database, and server all together. 
+It is the easiest way to try out Ralph using pre-built docker image with the worker, database, and server all together.
 We decided to push new images from time to time when we decide it's stable enough to use.
 
 1. Install docker using instructions at https://docs.docker.com/installation/
@@ -72,6 +72,24 @@ Update the settings
 Some new features added to Ralph may require additional settings to work
 properly. In order to enable them in your settings, follow the instructions in
 the :doc:`change log <changes>` for the version you installed.
+
+Example data
+------------
+
+Ralph after instalation doesn't have any example data -- for this reason you
+can run special CLI command for generate some example data such as data for
+visualization.
+
+To generate some data run ``ralph make_demo_data`` and select right option
+from menu.
+
+Available params for command:
+  * ``--flush`` - flush the databases,
+  * ``-d fixture_name`` - execute defined fixture,
+
+Example of use:
+  * ``ralph make_demo_data --flush -d envs -d services`` - flush databases and execute defined fixtures,
+  * ``ralph make_demo_data --flush `` - interactive mode.
 
 
 Installing Ralph - advanced installation

--- a/src/ralph/discovery/tests/util.py
+++ b/src/ralph/discovery/tests/util.py
@@ -25,7 +25,12 @@ from ralph.discovery.models_device import (
     LoadBalancerVirtualServer,
 )
 from ralph.cmdb.tests import utils as cmdb_utils
-from ralph.discovery.models_network import Network, IPAddress
+from ralph.discovery.models_network import (
+    DiscoveryQueue,
+    Environment,
+    IPAddress,
+    Network,
+)
 from ralph_assets.models_dc_assets import DeprecatedRalphDC, DeprecatedRalphRack
 
 
@@ -162,6 +167,18 @@ class DatabaseFactory(DjangoModelFactory):
     database_type = SubFactory(DatabaseTypeFactory)
     parent_device = SubFactory(DeviceFactory)
     name = Sequence(lambda n: 'DB{}'.format(n))
+
+
+class DiscoveryQueueFactory(DjangoModelFactory):
+    FACTORY_FOR = DiscoveryQueue
+
+    name = Sequence(lambda n: 'Queue {}'.format(n))
+
+
+class EnvironmentFactory(DjangoModelFactory):
+    FACTORY_FOR = Environment
+
+    name = Sequence(lambda n: 'Environment {}'.format(n))
 
 
 class MockSSH(object):

--- a/src/ralph/util/demo/__init__.py
+++ b/src/ralph/util/demo/__init__.py
@@ -1,0 +1,67 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
+from collections import defaultdict, Counter
+
+registry = {}
+demo_data = defaultdict(dict)
+
+
+class DemoData(object):
+    required = None
+
+    @property
+    def name():
+        raise NotImplementedError('Please specify name')
+
+    @property
+    def title():
+        raise NotImplementedError('Please specify title')
+
+    def execute(self):
+        print('Create {}.'.format(self.name))
+        demo_data[self.name] = self.generate_data(demo_data)
+        print('Finish created {}.'.format(self.name))
+
+    def generate_data(self, data):
+        raise NotImplementedError('Please override')
+
+
+class DemoRunner(object):
+    """Simple helper class for collection of demo data."""
+    def __init__(self, demo_keys, *args, **kwargs):
+        self.demo_keys = demo_keys
+        super(DemoRunner, self).__init__(*args, **kwargs)
+
+    def run(self):
+        """This method find reqiurement of demo data and call execute method
+        for each demo in demo_keys."""
+        demos = Counter()
+        max_depth = 10
+        default_weight = 10
+
+        def dig_requirements(demo, depth=1):
+            """Method search all requirements for demo and add or update
+            weight (count) in demos counter."""
+            if max_depth <= depth:
+                return
+            demos[demo.name] += default_weight * depth
+            if demo.required:
+                for req in demo.required:
+                    dig_requirements(registry[req], depth + 1)
+
+        for key in self.demo_keys:
+            dig_requirements(registry[key])
+        for key, _ in demos.most_common():
+            registry[key]().execute()
+
+
+def register(demo_klass, **kwargs):
+    if demo_klass.name in registry:
+        raise NameError('This key ({}) already exist.'.format(demo_klass.name))
+    registry[demo_klass.name] = demo_klass
+    return demo_klass

--- a/src/ralph/util/demo/assets/__init__.py
+++ b/src/ralph/util/demo/assets/__init__.py
@@ -1,0 +1,4 @@
+# -*- coding: utf-8 -*-
+from ralph.util.demo.assets.assets import *  # noqa
+from ralph.util.demo.assets.supports import *  # noqa
+from ralph.util.demo.assets.dc_models import *  # noqa

--- a/src/ralph/util/demo/assets/assets.py
+++ b/src/ralph/util/demo/assets/assets.py
@@ -1,0 +1,149 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
+from ralph.util.demo import DemoData, register
+from ralph_assets.models_assets import ModelVisualizationLayout
+from ralph_assets.models_dc_assets import Orientation
+from ralph_assets.tests.utils.assets import (
+    AssetModelFactory, DCAssetFactory, AssetManufacturerFactory
+)
+from ralph_assets.models_assets import AssetCategory
+
+
+SAMPLES = {
+    'manufacturers': ['HP', 'IBM', 'DELL'],
+    'models': {
+        'rack-server': ['PowerEdge Rxxx'],
+        'blade-chassis': ['Super Chassis'],
+        'blade-servers': ['DL360', 'DL380p', 'DL380', 'ML10', 'ML10 v21'],
+        'pdu': ['Remote Monitored Power Distribution Unit'],
+    }
+}
+
+
+@register
+class DemoAssetManufacturer(DemoData):
+    name = 'assets_manufacturers'
+    title = 'Asset manufacturers'
+
+    def generate_data(self, data):
+        return {
+            name.lower(): AssetManufacturerFactory(name=name)
+            for name in SAMPLES['manufacturers']
+        }
+
+
+@register
+class DemoAssetCategory(DemoData):
+    name = 'assets_categories'
+    title = 'Asset categories'
+
+    def generate_data(self, data):
+        # loaded from fixtures
+        return {
+            'rack_server': AssetCategory.objects.get(
+                slug='2-2-2-data-center-device-server-rack',
+            ),
+            'blade_chassis': AssetCategory.objects.get(
+                slug='2-2-2-data-center-device-chassis-blade',
+            ),
+            'blade_server': AssetCategory.objects.get(
+                slug='2-2-2-data-center-device-server-blade',
+            ),
+            'pdu': AssetCategory.objects.get(
+                slug='2-2-2-data-center-device-pdu',
+            ),
+        }
+
+
+@register
+class DemoAssetModel(DemoData):
+    name = 'assets_models'
+    title = 'Asset models'
+    required = ['assets_categories', 'assets_manufacturers']
+
+    def generate_data(self, data):
+        return {
+            'rack_server': AssetModelFactory(
+                name=SAMPLES['models']['rack-server'][0],
+                manufacturer=data['assets_manufacturers']['hp'],
+                category=data['assets_categories']['rack_server'],
+            ),
+            'blade_chassis': AssetModelFactory(
+                name=SAMPLES['models']['blade-chassis'][0],
+                manufacturer=data['assets_manufacturers']['hp'],
+                category=data['assets_categories']['blade_chassis'],
+                height_of_device=10,
+                visualization_layout_front=ModelVisualizationLayout.layout_2x8,
+            ),
+            'blade_chassis_ab': AssetModelFactory(
+                name=SAMPLES['models']['blade-chassis'][0],
+                manufacturer=data['assets_manufacturers']['hp'],
+                category=data['assets_categories']['blade_chassis'],
+                height_of_device=10,
+                visualization_layout_front=ModelVisualizationLayout.layout_2x8AB,  # noqa
+            ),
+            'blade_server': AssetModelFactory(
+                name=SAMPLES['models']['blade-servers'][0],
+                manufacturer=data['assets_manufacturers']['hp'],
+                category=data['assets_categories']['blade_server'],
+            ),
+            'pdu_model': AssetModelFactory(
+                name=SAMPLES['models']['pdu'][0],
+                manufacturer=data['assets_manufacturers']['hp'],
+                category=data['assets_categories']['pdu'],
+            ),
+        }
+
+
+@register
+class DemoDCVisualization(DemoData):
+    name = 'assets_dc_assets'
+    title = 'DC assets (with visualization)'
+    required = [
+        'assets_models', 'devices', 'dc', 'racks', 'server_rooms',
+        'services', 'envs'
+    ]
+
+    def generate_data(self, data):
+        blade_location = 3
+        return {
+            'rack_server': DCAssetFactory(
+                model=data['assets_models']['rack_server'],
+                device_info__ralph_device_id=data['devices']['device_1'].id,
+                device_info__data_center=data['dc']['a'],
+                device_info__orientation=Orientation.front,
+                device_info__position=1,
+                device_info__rack=data['racks']['a'],
+                device_info__server_room=data['server_rooms']['a'],
+                device_info__slot_no='',
+                service=data['services']['infrastructure'],
+                device_environment=data['envs']['prod'],
+            ),
+            'blade_chassis': DCAssetFactory(
+                model=data['assets_models']['blade_chassis'],
+                device_info__data_center=data['dc']['a'],
+                device_info__position=blade_location,
+                device_info__rack=data['racks']['a'],
+                device_info__server_room=data['server_rooms']['a'],
+                device_info__slot_no='',
+                service=data['services']['infrastructure'],
+                device_environment=data['envs']['prod'],
+            ),
+            'blade_servers': [
+                DCAssetFactory(
+                    model=data['assets_models']['blade_chassis'],
+                    device_info__data_center=data['dc']['a'],
+                    device_info__position=blade_location,
+                    device_info__rack=data['racks']['a'],
+                    device_info__server_room=data['server_rooms']['a'],
+                    device_info__slot_no=slot_no,
+                    service=data['services']['infrastructure'],
+                    device_environment=data['envs']['prod'],
+                ) for slot_no in xrange(1, 17)
+            ]
+        }

--- a/src/ralph/util/demo/assets/dc_models.py
+++ b/src/ralph/util/demo/assets/dc_models.py
@@ -1,0 +1,80 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
+from ralph.util.demo import DemoData, register
+
+from ralph_assets.tests.utils.assets import (
+    DataCenterFactory,
+    RackFactory,
+    ServerRoomFactory,
+)
+
+
+@register
+class DemoDataCenter(DemoData):
+    name = 'dc'
+    title = 'DC'
+    required = ['deprecated_dc']
+
+    def generate_data(self, data):
+        return {
+            'a': DataCenterFactory.create(
+                name='DC A',
+                deprecated_ralph_dc=data['deprecated_dc']['a'],
+            ),
+            'b': DataCenterFactory.create(
+                name='DC B',
+                deprecated_ralph_dc=data['deprecated_dc']['b'],
+            ),
+        }
+
+
+@register
+class DemoServerRoom(DemoData):
+    name = 'server_rooms'
+    title = 'Server rooms'
+    required = ['dc']
+
+    def generate_data(self, data):
+        dc = data['dc']['a']
+        return {
+            'a': ServerRoomFactory(
+                name='Server Room A',
+                data_center=dc,
+            ),
+            'b': ServerRoomFactory(
+                name='Server Room B',
+                data_center=dc,
+            ),
+        }
+
+
+@register
+class DemoRack(DemoData):
+    name = 'racks'
+    title = 'Racks'
+    required = ['deprecated_racks', 'dc', 'server_rooms']
+
+    def generate_data(self, data):
+        return {
+            'a': RackFactory(
+                name=data['deprecated_racks']['a'].name,
+                data_center=data['dc']['a'],
+                server_room=data['server_rooms']['a'],
+                deprecated_ralph_rack=data['deprecated_racks']['a'],
+                visualization_row=1,
+                visualization_col=1,
+            ),
+            'b': RackFactory(
+                name=data['deprecated_racks']['b'].name,
+                data_center=data['dc']['b'],
+                server_room=data['server_rooms']['b'],
+                deprecated_ralph_rack=data['deprecated_racks']['b'],
+                visualization_row=1,
+                visualization_col=2,
+            ),
+        }

--- a/src/ralph/util/demo/assets/supports.py
+++ b/src/ralph/util/demo/assets/supports.py
@@ -1,0 +1,46 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
+from ralph.util.demo import DemoData, register
+
+from ralph_assets.tests.utils.supports import DCSupportFactory
+from ralph_assets.tests.utils.licences import (
+    LicenceFactory,
+    LicenceAssetFactory,
+)
+
+
+@register
+class DemoSupports(DemoData):
+    name = 'assets_supports'
+    title = 'Assets supports'
+    required = ['assets_dc_assets']
+
+    def generate_data(self, data):
+        dc_support = DCSupportFactory()
+        dc_support.assets.add(data['assets_dc_assets']['rack_server'])
+        dc_support.assets.add(data['assets_dc_assets']['blade_servers'])
+        return {
+            'dc_support': dc_support
+        }
+
+
+@register
+class DemoLicences(DemoData):
+    name = 'assets_licences'
+    title = 'Assets licences'
+    required = ['assets_dc_assets']
+
+    def generate_data(self, data):
+        licence = LicenceFactory()
+        LicenceAssetFactory(
+            licence=licence,
+            asset=data['assets_dc_assets']['rack_server'],
+        )
+        return {
+            'licence': licence,
+        }

--- a/src/ralph/util/demo/core/__init__.py
+++ b/src/ralph/util/demo/core/__init__.py
@@ -1,0 +1,3 @@
+# -*- coding: utf-8 -*-
+from ralph.util.demo.core.discovery import *  # noqa
+from ralph.util.demo.core.cmdb import *  # noqa

--- a/src/ralph/util/demo/core/cmdb.py
+++ b/src/ralph/util/demo/core/cmdb.py
@@ -1,0 +1,71 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
+from ralph.util.demo import DemoData, register
+from ralph.cmdb.models_ci import CIType
+
+from ralph.cmdb.tests.utils import (
+    CIRelationFactory,
+    DeviceEnvironmentFactory,
+    ServiceCatalogFactory,
+)
+from ralph.cmdb.models import CI_RELATION_TYPES
+
+
+@register
+class DemoDeviceEnvironment(DemoData):
+    name = 'envs'
+    title = 'Environments'
+
+    def generate_data(self, data):
+        # CITypes loaded from fixtures
+        ci_type = CIType.objects.get(id=11)
+        envs = [('prod', 'Prod'), ('test', 'Test'), ('dev', 'Dev')]
+        return {
+            slug: DeviceEnvironmentFactory(name=name, type=ci_type)
+            for slug, name in envs
+        }
+
+
+@register
+class DemoServices(DemoData):
+    name = 'services'
+    title = 'Services'
+
+    def generate_data(self, data):
+        # CITypes loaded from fixtures
+        ci_type = CIType.objects.get(id=7)
+        return {
+            'infrastructure': ServiceCatalogFactory.create(
+                type=ci_type,
+                name='Infrastructure',
+            ),
+            'python_developers': ServiceCatalogFactory.create(
+                type=ci_type,
+                name='Python developers',
+            ),
+            'java_developers': ServiceCatalogFactory.create(
+                type=ci_type,
+                name='Java developers',
+            ),
+        }
+
+
+@register
+class DemoRelations(DemoData):
+    name = 'relations'
+    title = 'Relations'
+    required = ['services', 'envs']
+
+    def generate_data(self, data):
+        for service in data['services'].values():
+            for env in data['envs'].values():
+                CIRelationFactory.create(
+                    parent=service,
+                    child=env,
+                    type=CI_RELATION_TYPES.HASROLE,
+                )

--- a/src/ralph/util/demo/core/discovery.py
+++ b/src/ralph/util/demo/core/discovery.py
@@ -1,0 +1,95 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
+from ralph.discovery.tests.util import (
+    DeprecatedDataCenterFactory,
+    DeprecatedRackFactory,
+    DeviceFactory,
+    DiscoveryQueueFactory,
+)
+from ralph.util.demo import DemoData, register
+
+
+@register
+class DemoDiscoveryQueue(DemoData):
+    name = 'discovery_queue'
+    title = 'Discovery queue'
+
+    def generate_data(self, data):
+        return {
+            'a': DiscoveryQueueFactory.create(name='Queue A'),
+            'b': DiscoveryQueueFactory.create(name='Queue B')
+        }
+
+
+@register
+class DemoDeprecatedDataCenter(DemoData):
+    name = 'deprecated_dc'
+    title = '[Deprecated] DC'
+    required = ['discovery_queue', 'services', 'envs']
+
+    def generate_data(self, data):
+        return {
+            'a': DeprecatedDataCenterFactory(
+                name=data['discovery_queue']['a'].name,
+                service=data['services']['infrastructure'],
+                device_environment=data['envs']['prod'],
+            ),
+            'b': DeprecatedDataCenterFactory(
+                name=data['discovery_queue']['b'].name,
+                service=data['services']['infrastructure'],
+                device_environment=data['envs']['prod'],
+            ),
+        }
+
+
+@register
+class DemoDeprecatedRack(DemoData):
+    name = 'deprecated_racks'
+    title = '[Deprecated] Rack'
+    required = ['deprecated_dc', 'services', 'envs']
+
+    def generate_data(self, data):
+        return {
+            'a': DeprecatedRackFactory(
+                parent=data['deprecated_dc']['a'],
+                dc=data['deprecated_dc']['a'].name,
+                service=data['services']['infrastructure'],
+                device_environment=data['envs']['prod'],
+            ),
+            'b': DeprecatedRackFactory(
+                parent=data['deprecated_dc']['b'],
+                dc=data['deprecated_dc']['b'].name,
+                service=data['services']['infrastructure'],
+                device_environment=data['envs']['prod'],
+            ),
+        }
+
+
+@register
+class DemoDevices(DemoData):
+    name = 'devices'
+    title = 'Devices'
+    required = ['deprecated_dc', 'deprecated_racks', 'services', 'envs']
+
+    def generate_data(self, data):
+        return {
+            'device_1': DeviceFactory(
+                parent=data['deprecated_dc']['a'],
+                dc=data['deprecated_dc']['a'].name,
+                rack=data['deprecated_racks']['a'].name,
+                service=data['services']['infrastructure'],
+                device_environment=data['envs']['prod'],
+            ),
+            'device_2': DeviceFactory(
+                parent=data['deprecated_dc']['b'],
+                dc=data['deprecated_dc']['b'].name,
+                rack=data['deprecated_racks']['b'].name,
+                service=data['services']['infrastructure'],
+                device_environment=data['envs']['prod'],
+            ),
+        }

--- a/src/ralph/util/management/commands/make_demo_data.py
+++ b/src/ralph/util/management/commands/make_demo_data.py
@@ -1,0 +1,82 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
+import pkgutil
+import textwrap
+from optparse import make_option
+
+from django.core.management import call_command
+from django.core.management.base import BaseCommand
+
+from ralph.util import demo as demo_package
+from ralph.util.demo import registry, DemoRunner
+
+
+class Command(BaseCommand):
+    """Create a example data."""
+
+    help = textwrap.dedent(__doc__).strip()
+    # TODO: add database option
+    option_list = BaseCommand.option_list + (
+        make_option(
+            '--flush',
+            action='store_true',
+            dest='flush',
+            default=False,
+            help='Flush database before generate.'
+        ),
+        make_option(
+            '-d',
+            dest='fixtures',
+            action='append',
+            type='str',
+            default=[],
+            help='Fixtures to apply',
+        )
+    )
+
+    def handle(self, *args, **options):
+        flush = options.get('flush')
+        fixtures = options.get('fixtures')
+        modules = pkgutil.iter_modules(
+            path=demo_package.__path__, prefix=demo_package.__name__ + '.'
+        )
+        demo = None
+
+        for loader, mod_name, ispkg in modules:
+            __import__(mod_name)
+        if flush:
+            self.flush()
+        if not fixtures:
+            selected = self.select_demos()
+            if not selected:
+                return
+            demo = DemoRunner(selected)
+        else:
+            demo = DemoRunner(fixtures)
+        if demo:
+            demo.run()
+
+    def select_demos(self):
+        """Helper method for interactive mode. User select demo data by
+        simple menu."""
+        keys = []
+        for pos, (key, demo) in enumerate(sorted(registry.items())):
+            self.stdout.write('{}) {} ({}), required: {}\n'.format(
+                pos, demo.title, demo.name, ', '.join(demo.required or [])
+            ))
+            keys.append(key)
+        choices = input('Please select demo data (eg.: 1, 4, 6): ')
+        if isinstance(choices, int):
+            choices = [choices]
+        return [keys[idx] for idx in choices]
+
+    def flush(self):
+        # TODO: select database to flush
+        self.stdout.write('Flush database..\n')
+        call_command('flush', interactive=False)
+        self.stdout.write('Flush finished.\n')


### PR DESCRIPTION
I added new CLI command. Now, if you want to generate some example data use
``ralph make_demo_data``.
Available params for command:
 - --flush - flush the databases,
 - -d - execute fixture.

Example of use:
 - ``ralph make_demo_data --flush -d envs -d services`` - flush databases and execute defined fixtures
 - ``ralph make_demo_data --flush`` - interactive mode.