### PR TITLE
Fixed unicode error and empty country by default

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ install:
   - make install
   - pip install coveralls
   - pip install flake8
+  - pip install django-auth-ldap==1.1.3
 
 
 # command to run tests, e.g. python setup.py test

--- a/src/ralph/account/ldap.py
+++ b/src/ralph/account/ldap.py
@@ -50,14 +50,20 @@ else:
             if profile_map['manager'] in ldap_user.attrs:
                 manager_ref = ldap_user.attrs[profile_map['manager']][0]
                 # CN=John Smith,OU=TOR,OU=Corp-Users,DC=mydomain,DC=internal
-                manager_ref = manager_ref.decode('utf-8')
+                # prevent UnicodeEncodeError
+                if not isinstance(manager_ref, unicode):
+                    manager_ref = manager_ref.decode('utf-8')
                 cn = manager_ref.split(',')[0][3:]
                 profile.manager = cn
+        # raw value from LDAP is in profile.country for this reason we assign
+        # some correct value
+        profile.country = None
         if 'country' in profile_map:
             if profile_map['country'] in ldap_user.attrs:
                 country = ldap_user.attrs[profile_map['country']][0]
                 if len(country) == 2:
-                    profile.country = getattr(Country, country.lower())
+                    # assign None if `country` doesn't exist in Country
+                    profile.country = getattr(Country, country.lower(), None)
 
     class MappedGroupOfNamesType(ActiveDirectoryGroupType):
 


### PR DESCRIPTION
Prevent error like ``UnicodeEncodeError: 'ascii' codec can't encode
character``.