### PR TITLE
Removed lck.activitylog from Ralph

### DIFF
--- a/src/ralph/account/admin.py
+++ b/src/ralph/account/admin.py
@@ -17,7 +17,6 @@ from django.contrib.auth.admin import UserAdmin, GroupAdmin
 from django.contrib.auth.models import User, Group
 from django.utils.translation import ugettext_lazy as _
 
-from lck.django.activitylog.admin import IPInline, UserAgentInline
 from lck.django.common.admin import (
     ForeignKeyAutocompleteTabularInline,
     ModelAdmin,
@@ -30,7 +29,6 @@ from ralph.account.models import BoundPerm, Profile, Region
 
 class ProfileInline(admin.StackedInline):
     model = Profile
-    readonly_fields = ('last_active',)
     max_num = 1
     can_delete = False
 
@@ -53,22 +51,6 @@ class ProfileBoundPermInline(ForeignKeyAutocompleteTabularInline):
     def __init__(self, parent_model, admin_site):
         self.fk_name = 'profile'
         super(ProfileBoundPermInline, self).__init__(Profile, admin_site)
-
-
-class ProfileIPInline(IPInline):
-    formset = ProfileInlineFormSet
-
-    def __init__(self, parent_model, admin_site):
-        self.fk_name = 'profile'
-        super(ProfileIPInline, self).__init__(Profile, admin_site)
-
-
-class ProfileUserAgentInline(UserAgentInline):
-    formset = ProfileInlineFormSet
-
-    def __init__(self, parent_model, admin_site):
-        self.fk_name = 'profile'
-        super(ProfileUserAgentInline, self).__init__(Profile, admin_site)
 
 
 class ApiKeyInline(admin.StackedInline):
@@ -147,8 +129,6 @@ class ProfileAdmin(UserAdmin):
         ProfileBoundPermInline,
         RegionInline,
         ApiKeyInline,
-        ProfileIPInline,
-        ProfileUserAgentInline,
     ]
     list_display = (
         'username',

--- a/src/ralph/account/models.py
+++ b/src/ralph/account/models.py
@@ -18,7 +18,6 @@ from django.utils.translation import ugettext_lazy as _
 
 from dj.choices import Choices
 from dj.choices.fields import ChoiceField
-from lck.django.activitylog.models import MonitoredActivity
 from lck.django.common.models import EditorTrackable, Named, TimeTrackable
 from lck.django.profile.models import (
     BasicInfo,
@@ -94,8 +93,7 @@ class Region(Named):
         return self.name
 
 
-class Profile(BasicInfo, ActivationSupport, GravatarSupport,
-              MonitoredActivity):
+class Profile(BasicInfo, ActivationSupport, GravatarSupport):
 
     class Meta:
         verbose_name = _("profile")

--- a/src/ralph/settings.py
+++ b/src/ralph/settings.py
@@ -50,7 +50,6 @@ MIDDLEWARE_CLASSES = (
     'django.middleware.csrf.CsrfViewMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
-    'lck.django.activitylog.middleware.ActivityMiddleware',
     'lck.django.common.middleware.ForceLanguageCodeMiddleware',
     'ralph.middleware.RegionMiddleware',
 )
@@ -68,7 +67,6 @@ INSTALLED_APPS = [
     'django_rq',
     'south',
     'lck.django.common',
-    'lck.django.activitylog',
     'lck.django.profile',
     'lck.django.score',
     'lck.django.tags',
@@ -187,7 +185,6 @@ MESSAGE_STORAGE = 'django.contrib.messages.storage.session.SessionStorage'
 # activity middleware settings
 CURRENTLY_ONLINE_INTERVAL = 300
 RECENTLY_ONLINE_INTERVAL = 900
-ACTIVITYLOG_PROFILE_MODEL = AUTH_PROFILE_MODULE
 # lck.django.common models
 EDITOR_TRACKABLE_MODEL = AUTH_PROFILE_MODULE
 # lck.django.score models


### PR DESCRIPTION
Basically nobody analyzes traffic in Ralph by lck.activitylog. This change
reduce number of DB queries about 12 per each request.