### PR TITLE
Fixed getting name of default pool for vserv.

### DIFF
--- a/src/ralph/ui/tests/unit/test_others.py
+++ b/src/ralph/ui/tests/unit/test_others.py
@@ -1,0 +1,23 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
+from django.test import TestCase
+
+from ralph.discovery.tests.util import (
+    DeviceFactory,
+    LoadBalancerVirtualServerFactory,
+)
+from ralph.ui.views.common import _get_balancers
+
+
+class TestAddresses(TestCase):
+
+    def test_got_balancers_when_no_default_pool(self):
+        lbvs = LoadBalancerVirtualServerFactory()
+        self.assertIsNone(lbvs.default_pool)
+        balancers = list(_get_balancers(lbvs.device))
+        self.assertIsNone(balancers[0]['pool'])

--- a/src/ralph/ui/views/common.py
+++ b/src/ralph/ui/views/common.py
@@ -147,7 +147,7 @@ def _get_balancers(dev):
     ).all():
         yield {
             'balancer': dev.name,
-            'pool': vserv.default_pool.name,
+            'pool': vserv.default_pool.name if vserv.default_pool else None,
             'enabled': None,
             'address': vserv.address.address,
             'server': vserv.name,


### PR DESCRIPTION
Getting default pool's name only if pool is assigned.

@andrzej-jankowski 