### PR TITLE
Added new commands ({dev, test}_ralph)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -34,6 +34,8 @@ setup(
     entry_points={
         'console_scripts': [
             'ralph = ralph.__main__:main',
+            'dev_ralph = ralph.__main__:dev',
+            'test_ralph = ralph.__main__:test',
         ],
     },
     classifiers=[

--- a/src/ralph/__main__.py
+++ b/src/ralph/__main__.py
@@ -3,13 +3,21 @@ import os
 import sys
 
 
-def main():
-    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "ralph.settings")
+def main(settings_module='ralph.settings'):
+    os.environ.setdefault('DJANGO_SETTINGS_MODULE', settings_module)
 
     from django.core.management import execute_from_command_line
 
     execute_from_command_line(sys.argv)
 
 
-if __name__ == "__main__":
+def dev():
+    main('ralph.settings.dev')
+
+
+def test():
+    main('ralph.settings.test')
+
+
+if __name__ == '__main__':
     main()


### PR DESCRIPTION
This is some shortcut. `ralph_dev` - run ralph with develop settings (`ralph.settings.dev`).
Now you can type for example `ralph_dev runserver_plus` instead of `ralph
runserver_plus --settings=ralph.settings.dev`
