### PR TITLE
Fixed mistake

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ language: python
 python:
   - "2.7"
   - "3.4"
-  - "pypi"
+  - "pypy"
 
 before_install:
     - pip install flake8 --use-mirrors


### PR DESCRIPTION
`pypi` :arrow_right:  `pypy`
