### PR TITLE
improved performance of CMDB CI view

### DIFF
--- a/src/ralph/cmdb/models_ci.py
+++ b/src/ralph/cmdb/models_ci.py
@@ -609,8 +609,18 @@ CI.business_owners = CIOwnershipDescriptor(CIOwnershipType.business.id)
 CI.technical_owners = CIOwnershipDescriptor(CIOwnershipType.technical.id)
 
 
+class CIOwnerManager(models.Manager):
+    def get_query_set(self):
+        return super(CIOwnerManager, self).get_query_set().select_related(
+            'profile', 'profile__user'
+        )
+
+
 class CIOwner(TimeTrackable, WithConcurrentGetOrCreate):
     profile = models.OneToOneField('account.Profile', null=False)
+
+    objects = CIOwnerManager()
+    objects_raw = models.Manager()
 
     def __unicode__(self):
         return ' '.join([self.first_name, self.last_name])


### PR DESCRIPTION
Overwritten CIOwner manager to join user and user profile every time.

Before:
![screen shot 2015-06-02 at 14 13 22](https://cloud.githubusercontent.com/assets/107437/7937406/1055eff2-0940-11e5-8c7e-d57252754346.png)

After:
![screen shot 2015-06-02 at 14 13 31](https://cloud.githubusercontent.com/assets/107437/7937409/128f1f0a-0940-11e5-9648-e3827570d905.png)
