### PR TITLE
Fix for modular snmp v3 discovery

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -78,7 +78,6 @@ setup(
         'Pillow==2.4.0',
         'pysphere==0.1.8',
         'python-keystoneclient==0.11.0',
-        'stevedore==1.4.0',  # python-keystoneclient requirement in proper version (conflict with pbr)
     ],
     entry_points={
         'console_scripts': [

--- a/src/ralph/scan/tests/plugins/test_snmp_macs.py
+++ b/src/ralph/scan/tests/plugins/test_snmp_macs.py
@@ -168,7 +168,7 @@ class SnmpMacsPluginTest(TestCase):
             )
 
     def test_snmp_modular_macs(self):
-        def macs_side(ip, community, oid, *args, **kwargs):
+        def macs_side(oid, *args, **kwargs):
             return {
                 1: set([
                     u'001E670C5960', u'001E67123169', u'001E67123168',
@@ -209,6 +209,7 @@ class SnmpMacsPluginTest(TestCase):
                     ip_address='127.0.0.1',
                     ip_address_is_management=True,
                     snmp_community='public',
+                    snmp_version='2c',
                 ),
                 [
                     {


### PR DESCRIPTION
Intel Modular has only one snmp v3 user. It is hardcoded into
Management system. This fix change user taken from settings file
to 'snmpv3user'. Authentication protocol and provacy protocol is
not modified.
