### PR TITLE
Fixed error during scans Dell

### DIFF
--- a/src/ralph/scan/plugins/idrac.py
+++ b/src/ralph/scan/plugins/idrac.py
@@ -263,17 +263,19 @@ def _get_disks(idrac_manager):
                 "{}{}".format(xmlns_n1, 'Model')
             ).text.strip(),
         )
+        size_in_bytes = record.find(
+            '{}{}'.format(xmlns_n1, 'SizeInBytes'),
+        ).text
+        serial_number = record.find(
+            '{}{}'.format(xmlns_n1, 'SerialNumber'),
+        ).text
         results.append({
             'size': int(
                 int(
-                    record.find(
-                        "{}{}".format(xmlns_n1, 'SizeInBytes'),
-                    ).text.strip(),
+                    size_in_bytes and size_in_bytes.strip() or 0
                 ) / 1024 / 1024 / 1024
             ),
-            'serial_number': record.find(
-                "{}{}".format(xmlns_n1, 'SerialNumber'),
-            ).text.strip(),
+            'serial_number': serial_number and serial_number.strip() or '',
             'label': model_name,
             'model_name': model_name,
             'family': manufacturer,

--- a/src/ralph/scan/tests/plugins/samples/idrac.py
+++ b/src/ralph/scan/tests/plugins/samples/idrac.py
@@ -1202,8 +1202,8 @@ physical_disk_info = """<?xml version="1.0" encoding="UTF-8"?>
           <n1:RollupStatus>1</n1:RollupStatus>
           <n1:SASAddress>50014EE7AAAC1616</n1:SASAddress>
           <n1:SecurityState>0</n1:SecurityState>
-          <n1:SerialNumber>ABC1E32KSCNJ        </n1:SerialNumber>
-          <n1:SizeInBytes>299439751168</n1:SizeInBytes>
+          <n1:SerialNumber></n1:SerialNumber>
+          <n1:SizeInBytes></n1:SizeInBytes>
           <n1:Slot>0</n1:Slot>
           <n1:SupportedEncryptionTypes>None</n1:SupportedEncryptionTypes>
           <n1:UsedSizeInBytes>299439751168</n1:UsedSizeInBytes>

--- a/src/ralph/scan/tests/plugins/test_idrac.py
+++ b/src/ralph/scan/tests/plugins/test_idrac.py
@@ -147,8 +147,8 @@ class IdracPluginTest(TestCase):
                     'family': 'WD',
                     'label': 'WD WD3001BKHG',
                     'model_name': 'WD WD3001BKHG',
-                    'serial_number': 'ABC1E32KSCNJ',
-                    'size': 278,
+                    'serial_number': '',
+                    'size': 0,
                 },
                 {
                     'family': 'WD',


### PR DESCRIPTION
In some cases scaned disks have empty serial number, this changes prevent
error like `'NoneType' object has no attribute 'strip'`.
