### PR TITLE
Hardware information in newer ASAs is different. Small fix for this

### DIFF
--- a/src/ralph/scan/plugins/ssh_cisco_asa.py
+++ b/src/ralph/scan/plugins/ssh_cisco_asa.py
@@ -110,7 +110,7 @@ def scan_address(ip_address, **kwargs):
         ssh.close()
     pairs = parse.pairs(lines=[line.strip() for line in lines])
     sn = pairs.get('Serial Number', None)
-    model, ram, cpu = pairs['Hardware'].split(',')
+    model, ram, cpu = pairs['Hardware'].split(',')[:3]
     boot_firmware = pairs['Boot microcode']
     macs = []
     for i in xrange(99):


### PR DESCRIPTION
Different models have different results:
 Hardware:   ASA5540, 2048 MB RAM, CPU Pentium 4 2000 MHz
 Hardware:   ASA5545, 12288 MB RAM, CPU Lynnfield 2660 MHz, 1 CPU (8 cores)
Change variables: model, ram, cpu to table where more variables can
be stored
