### PR TITLE
iDRAC autoscan fix

### DIFF
--- a/src/ralph/discovery/http.py
+++ b/src/ralph/discovery/http.py
@@ -59,11 +59,18 @@ def get_http_info(ip):
                 headers, content = response.headers, response.content
             except requests.exceptions.RequestException as e:
                 logger.error("Exception: {} for url: {}".format(e, url))
+                url = "https://{}/login.html".format(ip)
+                try:
+                    response = http_get_method(session, url)
+                    response.raise_for_status()
+                    headers, content = response.headers, response.content
+                except requests.exceptions.RequestException as e:
+                    logger.error("Exception: {} for url: {}".format(e, url))
     return headers, content
 
 
 def guess_family(headers, document):
-    server = headers.get('Server', '')
+    server = headers.get('server', '')
     if '/' in server:
         server = server.split('/', 1)[0]
     family = FAMILIES.get(server, server)
@@ -105,15 +112,14 @@ def guess_family(headers, document):
     elif family in ('Thomas-Krenn',):
         if 'ERIC_RESPONSE_OK' in document:
             family = 'VTL'
-    elif family in ('Mbedthis-Appweb', 'Embedthis-Appweb'):
-        if '/sclogin.html?console' in document:
+    elif family in ('Mbedthis-Appweb', 'Embedthis-Appweb', 'Embedthis-http'):
+        document = document.decode("utf8")
+        if 'sclogin.html' in document:
             family = 'Dell'
         elif 'Juniper' in document:
             family = 'Juniper'
     if 'pve-api-daemon' in family:
         family = 'Proxmox3'
-    if '/sclogin.html?console' in document:
-        family = 'Dell'
     return family
 
 

--- a/src/ralph/discovery/tests/test_http.py
+++ b/src/ralph/discovery/tests/test_http.py
@@ -14,7 +14,11 @@ from ralph.discovery.http import guess_family
 class DiscoveryHttpTest(TestCase):
 
     def test_guess_family_dell_when_data_from_dell_server(self):
-        headers = {}
+        headers = {'accept-ranges': 'bytes',
+                   'connection': 'Keep-Alive',
+                   'content-length': '38457',
+                   'content-type': 'text/html',
+                   'server': 'Embedthis-http', }
         family = guess_family(headers, DATA)
         self.assertEqual(family, 'Dell')
 
@@ -30,6 +34,5 @@ class DiscoveryHttpTest(TestCase):
                   <p/><a href="XenCenter.iso">XenCenter CD image</a>
                   <p/><a href="XenCenterSetup.exe">XenCenter installer</a>
                 </body>
-            </html>"""
-        )
+            </html>""")
         self.assertEqual(family, 'Xen')


### PR DESCRIPTION
iDRAC 1.57.57 returns header server as Embedthis-http. Added this
to discovery.http.guess_family(). Fixed bug with decoding response
from server (UnicodeDecodeError). discovery.http.get_http_info() is
able to discover http family for iDRAC.
