### PR TITLE
Taking serial number from 'show inventory' instead of 'show version'

### DIFF
--- a/src/ralph/scan/tests/plugins/test_ssh_cisco_asa.py
+++ b/src/ralph/scan/tests/plugins/test_ssh_cisco_asa.py
@@ -20,7 +20,7 @@ from ralph.scan.plugins import ssh_cisco_asa
 
 
 def cisco_asa_ssh_mock(command):
-    if command == "show version | grep (^Hardware|Boot microcode|^Serial|address is)":
+    if command == "show version | grep (^Hardware|Boot microcode|address is)":
         return [
             u'Hardware:   SOME_ASA_MODEL, 12288 MB RAM, CPU AMD Opteron 2600 MHz\r',
             u'                             Boot microcode   : SOME-BOOT-FIRMWARE\r',
@@ -37,7 +37,7 @@ def cisco_asa_ssh_mock(command):
     elif command == "show inventory":
         return [
             u'Name: "Chassis", DESCR: "ASA 5580-40 Adaptive Security Appliance"\r',
-            u'PID: ASA5580-40        , VID: V01     , SN: SOME-SN\r',
+            u'PID: ASA5580-40        , VID: V01     , SN: SOME-CH-SN\r',
             u'\r',
             u'Name: "module 5", DESCR: "ASA 5580 2 port 10GE SR Fiber Interface Card"\r',
             u'PID: ASA5580-2X10GE-SR , VID: E1572805, SN: def113de4567\r',
@@ -77,7 +77,7 @@ class TestCiscoASA(TestCase):
             'device': {
                 'model_name': 'Cisco SOME_ASA_MODEL',
                 'type': 'firewall',
-                'serial_number': 'SOME-SN',
+                'serial_number': 'SOME-CH-SN',
                 'mac_addresses': [
                     u'AB12BC235556',
                     u'AB12BC235558',
@@ -104,6 +104,6 @@ class TestCiscoASA(TestCase):
         correct_ret['date'] = ret['date']  # assuming datetime is working.
         self.assertEqual(ret, correct_ret)
         command_mock.assert_any_call(
-            "show version | grep (^Hardware|Boot microcode|^Serial|address is)",
+            "show version | grep (^Hardware|Boot microcode|address is)",
         )
-        self.assertEqual(command_mock.call_count, 1)
+        self.assertEqual(command_mock.call_count, 2)


### PR DESCRIPTION
Serial number from 'show version' gives SN of processor. Serial number
from 'show inventory' gives you serial numbers of chassis, power unit
and other subdevices. This fix returns only serial number for chassis.
It is possible to retrieve information about other modules from device.
Change is needed because on ASA5545 SN of chassis and processor might
be diffrent. We use chassis SN to recognize devices.
