### PR TITLE
Fixed ldap sync + minor MySQL tweaks

### DIFF
--- a/docker/createsuperuser.py
+++ b/docker/createsuperuser.py
@@ -1,11 +1,11 @@
 #!/usr/bin/python
 import os
 import django
-from django.contrib.auth import get_user_model
 
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "ralph.settings")
 django.setup()
 
+from django.contrib.auth import get_user_model
 print('Updating superuser info')
 u = get_user_model().objects.get(username='ralph')
 u.set_password('ralph')

--- a/docker/settings_local.py
+++ b/docker/settings_local.py
@@ -10,6 +10,7 @@ DATABASES = {
         'USER': os.environ.get('DB_ENV_MYSQL_USER', 'ralph_ng'),
         'PASSWORD': os.environ.get('DB_ENV_MYSQL_PASSWORD', 'ralph_ng'),
         'HOST': os.environ.get('DB_HOST', 'db'),
+        'OPTIONS': MYSQL_OPTIONS,
     }
 }
 

--- a/src/ralph/accounts/ldap.py
+++ b/src/ralph/accounts/ldap.py
@@ -36,7 +36,9 @@ def manager_country_attribute_populate(
         if profile_map['manager'] in ldap_user.attrs:
             manager_ref = ldap_user.attrs[profile_map['manager']][0]
             # CN=John Smith,OU=TOR,OU=Corp-Users,DC=mydomain,DC=internal
-            cn = str(manager_ref).split(',')[0][3:]
+            if isinstance(manager_ref, bytes):
+                manager_ref = str(manager_ref, 'utf-8')
+            cn = manager_ref.split(',')[0][3:]
             user.manager = cn
     # raw value from LDAP is in profile.country for this reason we assign
     # some correct value
@@ -44,6 +46,8 @@ def manager_country_attribute_populate(
     if 'country' in profile_map:
         if profile_map['country'] in ldap_user.attrs:
             country = ldap_user.attrs[profile_map['country']][0]
+            if isinstance(country, bytes):
+                country = str(country, 'utf-8')
             # assign None if `country` doesn't exist in Country
             try:
                 user.country = Country.id_from_name(country.lower())

--- a/src/ralph/accounts/models.py
+++ b/src/ralph/accounts/models.py
@@ -69,3 +69,12 @@ class RalphUser(AbstractUser):
 
     class Meta(AbstractUser.Meta):
         swappable = 'AUTH_USER_MODEL'
+
+    def save(self, *args, **kwargs):
+        # set default values if None provided
+        for field in ('gender', 'country'):
+            val = getattr(self, field)
+            if val is None:
+                val = self._meta.get_field_by_name(field)[0].default
+                setattr(self, field, val)
+        return super().save(*args, **kwargs)

--- a/src/ralph/settings/base.py
+++ b/src/ralph/settings/base.py
@@ -66,6 +66,15 @@ TEMPLATES = [
 
 WSGI_APPLICATION = 'ralph.wsgi.application'
 
+MYSQL_OPTIONS = {
+    'sql_mode': 'TRADITIONAL',
+    'charset': 'utf8',
+    'init_command': """
+    SET storage_engine=INNODB;
+    SET character_set_connection=utf8,collation_connection=utf8_unicode_ci;
+    SET SESSION TRANSACTION ISOLATION LEVEL READ COMMITTED;
+    """
+}
 DATABASES = {
     'default': {
         'ENGINE': 'django.db.backends.mysql',
@@ -73,17 +82,7 @@ DATABASES = {
         'USER': os.environ.get('DB_ENV_MYSQL_USER', 'ralph_ng'),
         'PASSWORD': os.environ.get('DB_ENV_MYSQL_PASSWORD', 'ralph_ng'),
         'HOST': os.environ.get('DB_HOST', '127.0.0.1'),
-        'OPTIONS': {
-            "init_command": ','.join([
-                "SET storage_engine=INNODB",
-                "character_set_connection=utf8",
-                ";".join([
-                    "collation_connection=utf8_unicode_ci",
-                    "SET SESSION TRANSACTION ISOLATION LEVEL READ COMMITTED",
-                    "",
-                ])
-            ])
-        }
+        'OPTIONS': MYSQL_OPTIONS
     }
 }
 
@@ -114,6 +113,8 @@ MESSAGE_TAGS = {
 DEFAULT_DEPRECATION_RATE = 25
 CHECK_IP_HOSTNAME_ON_SAVE = True
 ASSET_HOSTNAME_TEMPLATE = 'test'
+
+LDAP_SERVER_OBJECT_USER_CLASS = 'user'  # possible values: user, person
 
 ADMIN_SITE_HEADER = 'Ralph 3'
 

--- a/src/ralph/settings/prod.py
+++ b/src/ralph/settings/prod.py
@@ -3,8 +3,6 @@ from ralph.settings import *  # noqa
 STATICFILES_STORAGE = 'django.contrib.staticfiles.storage.ManifestStaticFilesStorage'  # noqa
 STATIC_ROOT = os.path.join(BASE_DIR, 'var', 'static')
 
-LDAP_SERVER_OBJECT_USER_CLASS = 'user'  # possible values: "user, person
-
 # FIXME: when going for full production, change it to False
 
 DEBUG = True

--- a/vagrant/provision.sh
+++ b/vagrant/provision.sh
@@ -10,7 +10,7 @@ sudo DEBIAN_FRONTEND=noninteractive apt-get install -y \
     libmysqlclient-dev \
     libmysqld-dev \
     libsasl2-dev \
-    mysql-server \
+    mysql-server-5.6 \
     python3.4 \
     python3.4-dev \
     redis-server

--- a/vagrant/provisioning_scripts/init_mysql.sh
+++ b/vagrant/provisioning_scripts/init_mysql.sh
@@ -1,5 +1,15 @@
 #!/bin/bash
 
+# apply ralph config
+echo "
+# set STRICT_TRANS_TABLES to allow only valid values for column type
+# check https://dev.mysql.com/doc/refman/5.6/en/sql-mode.html#sqlmode_strict_trans_tables for details
+[mysqld]
+sql_mode=NO_ENGINE_SUBSTITUTION,STRICT_TRANS_TABLES
+" | sudo tee --append /etc/mysql/conf.d/ralph.cnf > /dev/null
+
+sudo service mysql restart
+
 echo "CREATE DATABASE ralph_ng DEFAULT CHARACTER SET 'utf8'" | mysql -u root
 echo "GRANT ALL ON ralph_ng.* TO ralph_ng@'%' IDENTIFIED BY 'ralph_ng'; FLUSH PRIVILEGES" | mysql -u root
 

--- a/vagrant/provisioning_scripts/profile_extensions
+++ b/vagrant/provisioning_scripts/profile_extensions
@@ -3,3 +3,4 @@ source /home/vagrant/bin/activate
 source /home/vagrant/src/ralph/scripts/ralph_bash_completion.sh
 
 export PATH=$PATH:/home/vagrant/src/ralph/node_modules/.bin
+export DJANGO_SETTINGS_MODULE=ralph.settings.local


### PR DESCRIPTION
- fixed conversion from bytes to str in python 3 (see https://docs.python.org/3/library/stdtypes.html#str)
- set at least STRICT_TRANS_TABLES MySQL mode (common for Vagrant (custom mysql config) and docker (by default in mysql-5.6 image))
- fixed creating superuser (move get_user_model import after django setup)
- fixed saving user with None gender or country - default value is set now
- moved LDAP_SERVER_OBJECT_USER_CLASS to base settings
- set DJANGO_SETTINGS_MODULE to ralph.settings.local in Vagrant by default
- mysql version in vagrant bumped to 5.6 (the same minor version)

See http://blog.ionelmc.ro/2014/12/28/terrible-choices-mysql/ for details about mysql config
