### PR TITLE
Add another "model name" for Dells R630 with 10 disks

### DIFF
--- a/src/ralph/discovery/http.py
+++ b/src/ralph/discovery/http.py
@@ -70,6 +70,7 @@ def get_http_info(ip):
 
 
 def guess_family(headers, document):
+    document = document.decode("utf8")
     server = headers.get('server', '')
     if '/' in server:
         server = server.split('/', 1)[0]
@@ -113,13 +114,14 @@ def guess_family(headers, document):
         if 'ERIC_RESPONSE_OK' in document:
             family = 'VTL'
     elif family in ('Mbedthis-Appweb', 'Embedthis-Appweb', 'Embedthis-http'):
-        document = document.decode("utf8")
         if 'sclogin.html' in document:
             family = 'Dell'
         elif 'Juniper' in document:
             family = 'Juniper'
     if 'pve-api-daemon' in family:
         family = 'Proxmox3'
+    if 'sclogin.html' in document:
+        family = 'Dell'
     return family
 
 

--- a/src/ralph/scan/plugins/idrac.py
+++ b/src/ralph/scan/plugins/idrac.py
@@ -243,6 +243,24 @@ def _get_memory(idrac_manager):
     ]
 
 
+def _get_enclosures(idrac_manager):
+    tree = idrac_manager.run_command('DCIM_EnclosureView')
+    xmlns_n1 = XMLNS_N1_BASE % "DCIM_EnclosureView"
+    q = "{}Body/{}EnumerateResponse/{}Items/{}DCIM_EnclosureView".format(
+        XMLNS_S,
+        XMLNS_WSEN,
+        XMLNS_WSMAN,
+        xmlns_n1,
+    )
+    results = []
+    for record in tree.findall(q):
+        slotnumber = record.find(
+            "{}{}".format(xmlns_n1, 'SlotCount'),
+        ).text.strip()
+        results.append(slotnumber)
+    return results
+
+
 def _get_disks(idrac_manager):
     tree = idrac_manager.run_command('DCIM_PhysicalDiskView')
     xmlns_n1 = XMLNS_N1_BASE % "DCIM_PhysicalDiskView"
@@ -335,6 +353,11 @@ def idrac_device_info(idrac_manager):
     fibrechannel_cards = _get_fibrechannel_cards(idrac_manager)
     if fibrechannel_cards:
         device_info['fibrechannel_cards'] = fibrechannel_cards
+    slotnumber = _get_enclosures(idrac_manager)
+    if slotnumber:
+        if (slotnumber[0] == '10'
+                and device_info['model_name'] == 'Dell PowerEdge R630'):
+            device_info.update({'model_name': 'Dell r630 - 10 disks slot'})
     return device_info
 
 


### PR DESCRIPTION
We need to know which servers have 10 or 8 disks. This fix will change
model_name to "Dell r630 - 10 disks slot" if there is 10 disk in chassis.
Added also some fixes for discovery/http.py which repair some problems
with discovery
