### PR TITLE
Removed environments from ServiceAdmin

### DIFF
--- a/src/ralph/assets/admin.py
+++ b/src/ralph/assets/admin.py
@@ -28,6 +28,7 @@ class ServiceEnvironmentAdmin(RalphAdmin):
 @register(Service)
 class ServiceAdmin(RalphAdmin):
 
+    fields = ('name', 'profit_center', 'cost_center')
     search_fields = ['name']
 
 


### PR DESCRIPTION
I removed `enivronments` from admin's page because we manage relation between Service-Environment in `ServiceEnvironment` admin.
