### PR TITLE
Fixed collectstatic in docker

### DIFF
--- a/docker/upgrade.sh
+++ b/docker/upgrade.sh
@@ -5,6 +5,6 @@ cd $RALPH_DIR
 make docs
 
 $RALPH_EXEC migrate --noinput
-$RALPH_EXEC collectstatic -l --noinput
+$RALPH_EXEC collectstatic --noinput
 
 make menu


### PR DESCRIPTION
Use copying files instead of linking in docker collectstatic (nginx could not resolve links on mounted volume)
