### PR TITLE
Bumped Django version to 1.8.3 and improved docker build performance

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,12 +24,26 @@ RUN $SCRIPTS_PATH/provision.sh
 ADD package.json $RALPH_DIR/package.json
 RUN $SCRIPTS_PATH/provision_js.sh
 
-# install ralph
-ADD . $RALPH_DIR
+# cleanup
+RUN apt-get clean
+
+# install basic requirements
 WORKDIR $RALPH_DIR
+ADD requirements $RALPH_DIR/requirements
+ADD Makefile $RALPH_DIR/Makefile
+# don't install ralph now - only requirements
+RUN sed -i '/\-e ./d' $RALPH_DIR/requirements/test.txt
 # temporary - change to `make install-prod` finally
 RUN make install-dev
+
+# install JS dependencies
+ADD src/ralph/static $RALPH_DIR/src/ralph/static
+ADD gulpfile.js bower.json package.json $RALPH_DIR/
 RUN $SCRIPTS_PATH/init_js.sh
+
+# install ralph
+ADD . $RALPH_DIR
+RUN pip3 install -e .
 RUN make docs
 
 VOLUME $RALPH_DOCS

--- a/docker/provision.sh
+++ b/docker/provision.sh
@@ -3,7 +3,7 @@ set -e
 
 apt-get update
 
-apt-get install -y \
+apt-get install -y --force-yes \
     git \
     libldap2-dev \
     libmysqlclient-dev \

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,4 +1,4 @@
-Django==1.8.2
+Django==1.8.3
 dj.choices==0.10.0
 django-import-export==0.2.7
 django-mptt==0.7.4


### PR DESCRIPTION
- Django version bumped to 1.8.3 after security release: https://www.djangoproject.com/weblog/2015/jul/08/security-releases/
- improved Docker build performance by extrating requirements installation before Ralph installation
