### PR TITLE
Improve imports - cleanup and add sort imports checker

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,0 +1,6 @@
+[settings]
+line_length=80
+indent='    '
+multi_line_output=3
+skip=migrations
+forced_separate=ralph

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ python:
     - "3.4"
 
 before_install:
-    - pip install flake8 --use-mirrors
+    - pip install flake8 isort --use-mirrors
     - make flake
 
 install:

--- a/Makefile
+++ b/Makefile
@@ -26,10 +26,13 @@ install-dev:
 install-docs:
 	pip3 install -r requirements/docs.txt
 
+isort:
+	isort --recursive --check-only src
+
 test: clean
 	test_ralph test $(TEST)
 
-flake: clean
+flake: clean isort
 	flake8 src/ralph
 
 clean:

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -6,3 +6,4 @@ pyinotify
 pudb
 ipython
 ipdb
+isort==4.0.0

--- a/src/ralph/accounts/admin.py
+++ b/src/ralph/accounts/admin.py
@@ -1,8 +1,5 @@
 # -*- coding: utf-8 -*-
-from django.contrib.auth.admin import (
-    GroupAdmin,
-    UserAdmin,
-)
+from django.contrib.auth.admin import GroupAdmin, UserAdmin
 from django.contrib.auth.models import Group
 from django.utils.translation import ugettext_lazy as _
 

--- a/src/ralph/accounts/ldap.py
+++ b/src/ralph/accounts/ldap.py
@@ -2,11 +2,8 @@
 from dj.choices import Country
 from django.conf import settings
 from django.dispatch import receiver
-from django_auth_ldap.backend import (
-    LDAPSettings,
-    populate_user,
-)
 from django.utils.encoding import force_text
+from django_auth_ldap.backend import LDAPSettings, populate_user
 from django_auth_ldap.config import ActiveDirectoryGroupType
 
 # Add default value to LDAPSetting dict. It will be replaced by

--- a/src/ralph/accounts/management/commands/ldap_sync.py
+++ b/src/ralph/accounts/management/commands/ldap_sync.py
@@ -8,7 +8,6 @@ from django.contrib.auth import get_user_model
 from django.core.management.base import BaseCommand
 from ldap.controls import SimplePagedResultsControl
 
-
 logger = logging.getLogger(__name__)
 LDAP_RESULTS_PAGE_SIZE = 100
 

--- a/src/ralph/accounts/models.py
+++ b/src/ralph/accounts/models.py
@@ -1,9 +1,6 @@
 # -*- coding: utf-8 -*-
 
-from dj.choices import (
-    Country,
-    Gender,
-)
+from dj.choices import Country, Gender
 from django.contrib.auth.models import AbstractUser
 from django.db import models
 from django.utils.translation import ugettext_lazy as _

--- a/src/ralph/admin/__init__.py
+++ b/src/ralph/admin/__init__.py
@@ -1,10 +1,3 @@
-# -*- coding: utf-8 -*-
-
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
-
 from ralph.admin.sites import ralph_site
 from ralph.admin.mixins import RalphAdmin
 from ralph.admin.decorators import register

--- a/src/ralph/admin/autocomplete.py
+++ b/src/ralph/admin/autocomplete.py
@@ -3,7 +3,7 @@ from functools import reduce
 
 from django.conf.urls import url
 from django.db.models import Q
-from django.http import JsonResponse, HttpResponseBadRequest, Http404
+from django.http import Http404, HttpResponseBadRequest, JsonResponse
 from django.views.generic import View
 
 QUERY_PARAM = 'q'

--- a/src/ralph/admin/decorators.py
+++ b/src/ralph/admin/decorators.py
@@ -6,12 +6,11 @@ from django.db.models import Model
 
 from ralph.admin.sites import ralph_site
 from ralph.admin.views.extra import (
-    RalphExtraViewMixin,
     CHANGE,
     LIST,
     VIEW_TYPES,
+    RalphExtraViewMixin
 )
-
 
 register = partial(django_register, site=ralph_site)
 

--- a/src/ralph/admin/mixins.py
+++ b/src/ralph/admin/mixins.py
@@ -7,13 +7,11 @@ from django.conf import settings
 from django.contrib.admin.templatetags.admin_static import static
 from django.db import models
 from django.views.generic import TemplateView
-
 from import_export.admin import ImportExportModelAdmin
 from reversion import VersionAdmin
 
 from ralph.admin import widgets
 from ralph.admin.autocomplete import AjaxAutocompleteMixin
-
 
 FORMFIELD_FOR_DBFIELD_DEFAULTS = {
     models.DateField: {'widget': widgets.AdminDateWidget},

--- a/src/ralph/admin/sitetrees.py
+++ b/src/ralph/admin/sitetrees.py
@@ -2,14 +2,11 @@
 from django.conf import settings
 from django.utils.translation import ugettext_lazy as _
 from django.utils.translation import activate
-
 from sitetree.sitetreeapp import register_i18n_trees
-from sitetree.utils import (
-    tree,
-    item,
-)
+from sitetree.utils import item, tree
 
 from ralph.admin.sites import ralph_site
+
 # To generate and display the menu, use the command:
 # ralph sitetreeload
 # ralph sitetree_resync_apps

--- a/src/ralph/admin/templatetags/admin_change_list.py
+++ b/src/ralph/admin/templatetags/admin_change_list.py
@@ -1,14 +1,6 @@
-# -*- coding: utf-8 -*-
-
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
-
 from django.contrib.admin.views.main import PAGE_VAR
 from django.template import Library
 from django.utils.html import format_html
-
 
 register = Library()
 

--- a/src/ralph/admin/templatetags/ralph_tags.py
+++ b/src/ralph/admin/templatetags/ralph_tags.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 from django.template import Library
 
-
 register = Library()
 
 

--- a/src/ralph/admin/tests/tests_functional.py
+++ b/src/ralph/admin/tests/tests_functional.py
@@ -1,8 +1,7 @@
 # -*- coding: utf-8 -*-
-from ddt import ddt, data, unpack
-
-from django.test import TestCase, RequestFactory
+from ddt import data, ddt, unpack
 from django.core.urlresolvers import reverse
+from django.test import RequestFactory, TestCase
 from django.views.generic import View
 
 from ralph.admin import RalphAdmin
@@ -12,7 +11,7 @@ from ralph.admin.views.extra import RalphDetailView, RalphListView
 from ralph.admin.views.main import RalphChangeList
 from ralph.tests.admin import CarAdmin
 from ralph.tests.mixins import ClientMixin, ReloadUrlsMixin
-from ralph.tests.models import Foo, Car
+from ralph.tests.models import Car, Foo
 
 
 class ExtraListView(RalphListView, View):

--- a/src/ralph/admin/views/extra.py
+++ b/src/ralph/admin/views/extra.py
@@ -6,7 +6,6 @@ from django.shortcuts import get_object_or_404
 from ralph.admin.mixins import RalphAdmin, RalphTemplateView
 from ralph.admin.sites import ralph_site
 
-
 VIEW_TYPES = CHANGE, LIST = ('change', 'list')
 
 

--- a/src/ralph/admin/widgets.py
+++ b/src/ralph/admin/widgets.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 import os
-from itertools import groupby, chain
+from itertools import chain, groupby
 from urllib import parse
 
 from django import forms
@@ -11,12 +11,11 @@ from django.core.urlresolvers import reverse
 from django.forms.utils import flatatt
 from django.template import loader
 from django.template.context import RenderContext
-from django.template.defaultfilters import title, slugify
+from django.template.defaultfilters import slugify, title
 from django.utils.safestring import mark_safe
 from django.utils.translation import ugettext as _
 
-from ralph.admin.autocomplete import QUERY_PARAM, DETAIL_PARAM
-
+from ralph.admin.autocomplete import DETAIL_PARAM, QUERY_PARAM
 
 ReadOnlyWidget = forms.TextInput(attrs={'readonly': 'readonly'})
 

--- a/src/ralph/assets/admin.py
+++ b/src/ralph/assets/admin.py
@@ -11,10 +11,7 @@ from ralph.assets.models.assets import (
     Service,
     ServiceEnvironment
 )
-from ralph.assets.models.components import (
-    ComponentModel,
-    GenericComponent
-)
+from ralph.assets.models.components import ComponentModel, GenericComponent
 from ralph.data_importer import resources
 from ralph.lib.permissions.admin import PermissionAdminMixin
 

--- a/src/ralph/assets/models/assets.py
+++ b/src/ralph/assets/models/assets.py
@@ -1,29 +1,25 @@
 # -*- coding: utf-8 -*-
 from dateutil.relativedelta import relativedelta
+from django.conf import settings
+from django.core.exceptions import ImproperlyConfigured, ValidationError
+from django.core.urlresolvers import reverse
+from django.db import models
+from django.template import Context, Template
+from django.utils.translation import ugettext_lazy as _
 from mptt.models import MPTTModel, TreeForeignKey
 
-from django.db import models
-from django.core.exceptions import (
-    ImproperlyConfigured,
-    ValidationError
-)
-from django.core.urlresolvers import reverse
-from django.conf import settings
-from django.utils.translation import ugettext_lazy as _
-from django.template import Context, Template
-
-from ralph.assets.models.choices import (
-    AssetStatus,
-    AssetSource,
-    ObjectModelType,
-    ModelVisualizationLayout
-)
 from ralph.assets.models.base import BaseObject
+from ralph.assets.models.choices import (
+    AssetSource,
+    AssetStatus,
+    ModelVisualizationLayout,
+    ObjectModelType
+)
 from ralph.assets.overrides import Country
 from ralph.lib.mixins.models import (
     AdminAbsoluteUrlMixin,
     NamedMixin,
-    TimeStampMixin,
+    TimeStampMixin
 )
 from ralph.lib.permissions import PermByFieldMixin
 

--- a/src/ralph/assets/overrides.py
+++ b/src/ralph/assets/overrides.py
@@ -1,12 +1,4 @@
-# -*- coding: utf-8 -*-
-
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
-
 from dj.choices import Country as ChoiceCountry
-
 
 ISO_3166 = (
     ('AF', 'AFG'), ('AX', 'ALA'), ('AL', 'ALB'), ('DZ', 'DZA'), ('AS', 'ASM'),

--- a/src/ralph/back_office/admin.py
+++ b/src/ralph/back_office/admin.py
@@ -6,7 +6,7 @@ from ralph.back_office.models import BackOfficeAsset, Warehouse
 from ralph.back_office.views import (
     BackOfficeAssetComponents,
     BackOfficeAssetLicence,
-    BackOfficeAssetSoftware,
+    BackOfficeAssetSoftware
 )
 from ralph.data_importer import resources
 from ralph.lib.permissions.admin import PermissionAdminMixin

--- a/src/ralph/back_office/apps.py
+++ b/src/ralph/back_office/apps.py
@@ -1,11 +1,3 @@
-# -*- coding: utf-8 -*-
-
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
-
-
 from django.apps import AppConfig
 
 

--- a/src/ralph/back_office/models.py
+++ b/src/ralph/back_office/models.py
@@ -5,10 +5,7 @@ from django.db import models
 from django.utils.translation import ugettext_lazy as _
 
 from ralph.assets.models.assets import Asset
-from ralph.lib.mixins.models import (
-    NamedMixin,
-    TimeStampMixin
-)
+from ralph.lib.mixins.models import NamedMixin, TimeStampMixin
 
 
 class Warehouse(NamedMixin, TimeStampMixin, models.Model):

--- a/src/ralph/data_center/admin.py
+++ b/src/ralph/data_center/admin.py
@@ -4,17 +4,15 @@ from django.utils.translation import ugettext_lazy as _
 
 from ralph.admin import RalphAdmin, register
 from ralph.admin.views.extra import RalphDetailViewAdmin
-from ralph.data_importer import resources
 from ralph.data_center.forms.network import NetworkInlineFormset
-from ralph.data_center.models.virtual import (
-    CloudProject,
-    Database,
-    VIP,
-    VirtualServer
-)
-from ralph.data_center.models.components import (
-    DiskShare,
-    DiskShareMount
+from ralph.data_center.models.components import DiskShare, DiskShareMount
+from ralph.data_center.models.networks import (
+    DiscoveryQueue,
+    IPAddress,
+    Network,
+    NetworkEnvironment,
+    NetworkKind,
+    NetworkTerminator
 )
 from ralph.data_center.models.physical import (
     Connection,
@@ -22,22 +20,21 @@ from ralph.data_center.models.physical import (
     DataCenterAsset,
     Rack,
     RackAccessory,
-    ServerRoom,
+    ServerRoom
 )
-from ralph.data_center.models.networks import (
-    DiscoveryQueue,
-    IPAddress,
-    Network,
-    NetworkEnvironment,
-    NetworkKind,
-    NetworkTerminator,
+from ralph.data_center.models.virtual import (
+    VIP,
+    CloudProject,
+    Database,
+    VirtualServer
 )
 from ralph.data_center.views.ui import (
     DataCenterAssetComponents,
     DataCenterAssetLicence,
     DataCenterAssetSecurityInfo,
-    DataCenterAssetSoftware,
+    DataCenterAssetSoftware
 )
+from ralph.data_importer import resources
 from ralph.lib.permissions.admin import PermissionAdminMixin
 
 

--- a/src/ralph/data_center/models/networks.py
+++ b/src/ralph/data_center/models/networks.py
@@ -9,11 +9,7 @@ from django.utils.translation import ugettext_lazy as _
 from ralph.assets.models.assets import Asset
 from ralph.data_center.models.physical import DataCenter, Rack
 from ralph.lib import network
-from ralph.lib.mixins.models import (
-    LastSeenMixin,
-    NamedMixin,
-    TimeStampMixin,
-)
+from ralph.lib.mixins.models import LastSeenMixin, NamedMixin, TimeStampMixin
 
 
 def network_validator(value):

--- a/src/ralph/data_center/models/physical.py
+++ b/src/ralph/data_center/models/physical.py
@@ -6,15 +6,11 @@ from itertools import chain
 from django.db import models
 from django.utils.translation import ugettext_lazy as _
 
-from ralph.assets.models.assets import (
-    AdminAbsoluteUrlMixin,
-    Asset,
-    NamedMixin,
-)
+from ralph.assets.models.assets import AdminAbsoluteUrlMixin, Asset, NamedMixin
 from ralph.data_center.models.choices import (
     ConnectionType,
     Orientation,
-    RackOrientation,
+    RackOrientation
 )
 
 

--- a/src/ralph/data_center/serializers/models_serializer.py
+++ b/src/ralph/data_center/serializers/models_serializer.py
@@ -1,9 +1,7 @@
 # -*- coding: utf-8 -*-
 from rest_framework import serializers
 
-from ralph.data_center.models.physical import (
-    DataCenterAsset,
-)
+from ralph.data_center.models.physical import DataCenterAsset
 
 
 class DataCenterAssetSerializer(serializers.ModelSerializer):

--- a/src/ralph/data_center/tests/factories.py
+++ b/src/ralph/data_center/tests/factories.py
@@ -1,10 +1,3 @@
-# -*- coding: utf-8 -*-
-
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
-
 import factory
 from factory.django import DjangoModelFactory
 
@@ -14,7 +7,7 @@ from ralph.data_center.models.physical import (
     DataCenterAsset,
     Rack,
     RackAccessory,
-    ServerRoom,
+    ServerRoom
 )
 
 

--- a/src/ralph/data_center/tests/test_models.py
+++ b/src/ralph/data_center/tests/test_models.py
@@ -1,17 +1,9 @@
-# -*- coding: utf-8 -*-
-
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
-
-from ralph.tests import RalphTestCase
-
 from ralph.data_center.models.networks import (
-    get_network_tree,
     IPAddress,
     Network,
+    get_network_tree
 )
+from ralph.tests import RalphTestCase
 
 
 class NetworkTest(RalphTestCase):

--- a/src/ralph/data_center/urls/api.py
+++ b/src/ralph/data_center/urls/api.py
@@ -2,10 +2,7 @@
 from django.conf.urls import include, url
 from rest_framework import routers
 
-from ralph.data_center.views.api import (
-    DataCenterAssetViewSet,
-)
-
+from ralph.data_center.views.api import DataCenterAssetViewSet
 
 router = routers.DefaultRouter()
 router.register(r'data-center-assets', DataCenterAssetViewSet)

--- a/src/ralph/data_center/views/api.py
+++ b/src/ralph/data_center/views/api.py
@@ -2,12 +2,9 @@
 
 from rest_framework import viewsets
 
-from ralph.data_center.models.physical import (
-    DataCenterAsset,
-)
-from ralph.data_center.serializers.models_serializer import (
-    DataCenterAssetSerializer,
-)
+from ralph.data_center.models.physical import DataCenterAsset
+from ralph.data_center.serializers.models_serializer import \
+    DataCenterAssetSerializer
 
 
 class DataCenterAssetViewSet(viewsets.ModelViewSet):

--- a/src/ralph/data_importer/management/commands/importer.py
+++ b/src/ralph/data_importer/management/commands/importer.py
@@ -4,20 +4,16 @@ import glob
 import logging
 import os
 import tempfile
-import tablib
 import zipfile
 
-
+import tablib
 from django.apps import apps
 from django.conf import settings
-from django.core.management.base import (
-    BaseCommand,
-    CommandError
-)
+from django.core.management.base import BaseCommand, CommandError
 from import_export import resources
+
 from ralph.data_importer import resources as ralph_resources
 from ralph.data_importer.resources import DefaultResource
-
 
 APP_MODELS = {model._meta.model_name: model for model in apps.get_models()}
 logger = logging.getLogger(__name__)

--- a/src/ralph/data_importer/mixins.py
+++ b/src/ralph/data_importer/mixins.py
@@ -1,11 +1,9 @@
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
+
 
 from django.conf import settings
 from django.contrib.contenttypes.models import ContentType
+
 from ralph.data_importer.models import ImportedObjects
 
 

--- a/src/ralph/data_importer/models.py
+++ b/src/ralph/data_importer/models.py
@@ -1,12 +1,5 @@
-# -*- coding: utf-8 -*-
-
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
-
-from django.db import models
 from django.contrib.contenttypes.models import ContentType
+from django.db import models
 
 from ralph.lib.mixins.models import TimeStampMixin
 

--- a/src/ralph/data_importer/resources.py
+++ b/src/ralph/data_importer/resources.py
@@ -1,42 +1,25 @@
-# -*- coding: utf-8 -*-
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
-
-from import_export import fields
-from import_export import resources
 from django.contrib.auth import get_user_model
+from import_export import fields, resources
 
-from ralph.assets.models import (
-    assets,
-    base,
-)
-from ralph.data_center.models import networks
-from ralph.data_center.models import physical
+from ralph.assets.models import assets, base
+from ralph.back_office.models import BackOfficeAsset, Warehouse
+from ralph.data_center.models import networks, physical
+from ralph.data_importer.mixins import ImportForeignKeyMixin
 from ralph.data_importer.widgets import (
     AssetServiceEnvWidget,
     BaseObjectManyToManyWidget,
     BaseObjectWidget,
     ImportedForeignKeyWidget,
-    UserWidget,
-)
-from ralph.data_importer.mixins import ImportForeignKeyMixin
-from ralph.back_office.models import (
-    BackOfficeAsset,
-    Warehouse,
+    UserWidget
 )
 from ralph.licences.models import (
     BaseObjectLicence,
     Licence,
-    LicenceUser,
     LicenceType,
-    SoftwareCategory,
+    LicenceUser,
+    SoftwareCategory
 )
-from ralph.supports.models import (
-    Support,
-    SupportType,
-)
+from ralph.supports.models import Support, SupportType
 
 
 class DefaultResource(ImportForeignKeyMixin, resources.ModelResource):

--- a/src/ralph/data_importer/tests/test_commands.py
+++ b/src/ralph/data_importer/tests/test_commands.py
@@ -1,15 +1,8 @@
-# -*- coding: utf-8 -*-
-
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
-
 import os
 
+from django.contrib.contenttypes.models import ContentType
 from django.core import management
 from django.test import TestCase
-from django.contrib.contenttypes.models import ContentType
 
 from ralph.assets.models.assets import (
     AssetModel,
@@ -18,21 +11,12 @@ from ralph.assets.models.assets import (
     ServiceEnvironment
 )
 from ralph.assets.models.choices import ObjectModelType
-from ralph.back_office.models import (
-    BackOfficeAsset,
-    Warehouse
-)
-from ralph.data_center.models.physical import (
-    DataCenter,
-    Rack,
-    ServerRoom
-)
-from ralph.data_center.tests.factories import (
-    DataCenterFactory
-)
+from ralph.back_office.models import BackOfficeAsset, Warehouse
+from ralph.data_center.models.physical import DataCenter, Rack, ServerRoom
+from ralph.data_center.tests.factories import DataCenterFactory
 from ralph.data_importer.management.commands import importer
-from ralph.data_importer.resources import AssetModelResource
 from ralph.data_importer.models import ImportedObjects
+from ralph.data_importer.resources import AssetModelResource
 
 
 class DataImporterTestCase(TestCase):

--- a/src/ralph/data_importer/widgets.py
+++ b/src/ralph/data_importer/widgets.py
@@ -1,20 +1,13 @@
-# -*- coding: utf-8 -*-
-
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
-
 import logging
+
 from django.contrib.auth import get_user_model
 from django.contrib.contenttypes.models import ContentType
 from import_export import widgets
 
 from ralph.assets.models.assets import ServiceEnvironment
-from ralph.data_center.models.physical import DataCenterAsset
 from ralph.back_office.models import BackOfficeAsset
+from ralph.data_center.models.physical import DataCenterAsset
 from ralph.data_importer.models import ImportedObjects
-
 
 logger = logging.getLogger(__name__)
 

--- a/src/ralph/dc_view/serializers/models_serializer.py
+++ b/src/ralph/dc_view/serializers/models_serializer.py
@@ -1,15 +1,9 @@
-# -*- coding: utf-8 -*-
-
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
-
 from collections import OrderedDict
 
 from django.core.urlresolvers import reverse
 from rest_framework import serializers
 
+from ralph.data_center.models.choices import RackOrientation
 from ralph.data_center.models.physical import (
     DataCenter,
     DataCenterAsset,
@@ -17,8 +11,6 @@ from ralph.data_center.models.physical import (
     RackAccessory,
     ServerRoom
 )
-from ralph.data_center.models.choices import RackOrientation
-
 
 TYPE_EMPTY = 'empty'
 TYPE_ACCESSORY = 'accessory'

--- a/src/ralph/dc_view/tests.py
+++ b/src/ralph/dc_view/tests.py
@@ -1,37 +1,28 @@
-# -*- coding: utf-8 -*-
-
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
-
 import json
 
 from django.contrib.auth import get_user_model
 from django.test import TestCase
 from rest_framework.test import APIClient
 
-
 from ralph.assets.models.choices import ObjectModelType
 from ralph.assets.tests.factories import (
     DataCenterAssetModelFactory,
     EnvironmentFactory,
-    ServiceFactory,
-    ServiceEnvironment
+    ServiceEnvironment,
+    ServiceFactory
 )
+from ralph.data_center.models.choices import Orientation
 from ralph.data_center.tests.factories import (
     AccessoryFactory,
     DataCenterAssetFactory,
-    RackFactory,
     RackAccessoryFactory,
+    RackFactory,
     ServerRoomFactory
 )
-
 from ralph.dc_view.serializers.models_serializer import (
     TYPE_ACCESSORY,
-    TYPE_ASSET,
+    TYPE_ASSET
 )
-from ralph.data_center.models.choices import Orientation
 
 
 class TestRestAssetInfoPerRack(TestCase):

--- a/src/ralph/dc_view/urls/api.py
+++ b/src/ralph/dc_view/urls/api.py
@@ -1,16 +1,6 @@
-# -*- coding: utf-8 -*-
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
-
 from django.conf.urls import url
 
-from ralph.dc_view.views.api import (
-    DCAssetsView,
-    DCRacksAPIView,
-)
-
+from ralph.dc_view.views.api import DCAssetsView, DCRacksAPIView
 
 urlpatterns = [
     url(

--- a/src/ralph/dc_view/urls/ui.py
+++ b/src/ralph/dc_view/urls/ui.py
@@ -1,13 +1,6 @@
-# -*- coding: utf-8 -*-
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
-
 from django.conf.urls import url
 
 from ralph.dc_view.views.ui import DataCenterView
-
 
 urlpatterns = [
     url(

--- a/src/ralph/dc_view/views/api.py
+++ b/src/ralph/dc_view/views/api.py
@@ -1,27 +1,15 @@
-# -*- coding: utf-8 -*-
-
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
-
 from django.http import Http404
-
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
-from ralph.data_center.models.physical import (
-    DataCenter,
-    Rack,
-    RackAccessory
-)
+from ralph.data_center.models.physical import DataCenter, Rack, RackAccessory
 from ralph.dc_view.serializers.models_serializer import (
     DataCenterAssetSerializer,
     DCSerializer,
+    PDUSerializer,
     RackAccessorySerializer,
     RackBaseSerializer,
-    RackSerializer,
-    PDUSerializer,
+    RackSerializer
 )
 
 

--- a/src/ralph/dc_view/views/ui.py
+++ b/src/ralph/dc_view/views/ui.py
@@ -1,10 +1,3 @@
-# -*- coding: utf-8 -*-
-
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
-
 from ralph.admin.mixins import RalphTemplateView
 from ralph.data_center.models.physical import DataCenter
 

--- a/src/ralph/lib/foundation/templatetags/foundation_alert.py
+++ b/src/ralph/lib/foundation/templatetags/foundation_alert.py
@@ -1,10 +1,3 @@
-# -*- coding: utf-8 -*-
-
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
-
 from django import template
 
 register = template.Library()

--- a/src/ralph/lib/foundation/templatetags/foundation_form.py
+++ b/src/ralph/lib/foundation/templatetags/foundation_form.py
@@ -1,12 +1,4 @@
-# -*- coding: utf-8 -*-
-
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
-
 from django import template
-
 
 register = template.Library()
 

--- a/src/ralph/lib/network/__init__.py
+++ b/src/ralph/lib/network/__init__.py
@@ -1,12 +1,6 @@
-# -*- coding: utf-8 -*-
-
 """Low-level network utilities, silently returning empty answers in place of
 domain-related exceptions."""
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
 
 import socket
 

--- a/src/ralph/lib/permissions/__init__.py
+++ b/src/ralph/lib/permissions/__init__.py
@@ -1,10 +1,3 @@
-# -*- coding: utf-8 -*-
-
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
-
 from ralph.lib.permissions.models import PermByFieldMixin
 
 

--- a/src/ralph/lib/permissions/models.py
+++ b/src/ralph/lib/permissions/models.py
@@ -1,15 +1,7 @@
-# -*- coding: utf-8 -*-
-
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
-
-from six import with_metaclass
-
 from django.db import models
 from django.db.models.base import ModelBase
 from django.utils.translation import ugettext_lazy as _
+from six import with_metaclass
 
 
 def get_perm_key(action, class_name, field_name):

--- a/src/ralph/lib/permissions/tests.py
+++ b/src/ralph/lib/permissions/tests.py
@@ -1,22 +1,12 @@
-# -*- coding: utf-8 -*-
-
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
-
 from django.contrib.auth import get_user_model
 from django.contrib.auth.models import Permission
-from django.test import (
-    TestCase,
-    RequestFactory,
-)
+from django.test import RequestFactory, TestCase
 
-from ralph.assets.models.choices import ObjectModelType
 from ralph.assets.models.assets import AssetModel
+from ralph.assets.models.choices import ObjectModelType
 from ralph.data_center.models.physical import DataCenterAsset
-from ralph.lib.permissions.models import get_perm_key
 from ralph.lib.permissions.admin import PermissionAdminMixin
+from ralph.lib.permissions.models import get_perm_key
 
 
 class PermissionsByFieldTestCase(TestCase):

--- a/src/ralph/licences/admin.py
+++ b/src/ralph/licences/admin.py
@@ -11,7 +11,7 @@ from ralph.licences.models import (
     Licence,
     LicenceType,
     LicenceUser,
-    SoftwareCategory,
+    SoftwareCategory
 )
 
 

--- a/src/ralph/licences/models.py
+++ b/src/ralph/licences/models.py
@@ -5,6 +5,7 @@ from django.db import models
 from django.db.models import Sum
 from django.utils.functional import cached_property
 from django.utils.translation import ugettext_lazy as _
+
 from ralph.assets.models.assets import Manufacturer
 from ralph.assets.models.base import BaseObject
 from ralph.lib.mixins.models import (

--- a/src/ralph/reports/tests.py
+++ b/src/ralph/reports/tests.py
@@ -1,16 +1,13 @@
 # -*- coding: utf-8 -*-
 
+from ralph.assets.models.choices import ObjectModelType
 from ralph.assets.tests.factories import (
     CategoryFactory,
-    DataCenterAssetModelFactory,
+    DataCenterAssetModelFactory
 )
-from ralph.assets.models.choices import ObjectModelType
 from ralph.data_center.models.physical import DataCenterAsset
 from ralph.data_center.tests.factories import DataCenterAssetFactory
-from ralph.reports.views import (
-    CategoryModelReport,
-    CategoryModelStatusReport,
-)
+from ralph.reports.views import CategoryModelReport, CategoryModelStatusReport
 from ralph.tests import RalphTestCase
 from ralph.tests.mixins import ClientMixin
 

--- a/src/ralph/reports/urls.py
+++ b/src/ralph/reports/urls.py
@@ -3,7 +3,6 @@ from django.conf.urls import url
 
 from ralph.reports import views
 
-
 urlpatterns = [
     url(
         r'^category_model_report/?$',

--- a/src/ralph/settings/__init__.py
+++ b/src/ralph/settings/__init__.py
@@ -1,8 +1,1 @@
-# -*- coding: utf-8 -*-
-
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
-
 from ralph.settings.base import *  # noqa

--- a/src/ralph/supports/models.py
+++ b/src/ralph/supports/models.py
@@ -1,11 +1,10 @@
 # -*- coding: utf-8 -*-
 from datetime import datetime
 
+from dj.choices import Choices
 from django.contrib.humanize.templatetags.humanize import naturaltime
 from django.db import models
 from django.utils.translation import ugettext_lazy as _
-
-from dj.choices import Choices
 
 from ralph.assets.models.base import BaseObject
 from ralph.lib.mixins.models import NamedMixin, TimeStampMixin

--- a/src/ralph/tests/__init__.py
+++ b/src/ralph/tests/__init__.py
@@ -1,10 +1,3 @@
-# -*- coding: utf-8 -*-
-
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
-
 from ralph.admin.sites import RalphAdminSite
 from ralph.tests.base import RalphTestCase
 

--- a/src/ralph/tests/admin.py
+++ b/src/ralph/tests/admin.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 from ralph.admin import RalphAdmin, register
-
 from ralph.tests.models import Car, Manufacturer
 
 

--- a/src/ralph/tests/base.py
+++ b/src/ralph/tests/base.py
@@ -1,10 +1,3 @@
-# -*- coding: utf-8 -*-
-
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
-
 from django.test import TestCase
 
 

--- a/src/ralph/tests/factories.py
+++ b/src/ralph/tests/factories.py
@@ -1,12 +1,4 @@
-# -*- coding: utf-8 -*-
-
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
-
 import factory
-
 from django.contrib.auth import get_user_model
 
 

--- a/src/ralph/tests/mixins.py
+++ b/src/ralph/tests/mixins.py
@@ -1,16 +1,9 @@
-# -*- coding: utf-8 -*-
-
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
-
-from six.moves import reload_module
 import sys
 
 from django.conf import settings
 from django.core.urlresolvers import clear_url_caches
 from django.utils.importlib import import_module
+from six.moves import reload_module
 
 from ralph.tests.factories import UserFactory
 

--- a/src/ralph/tests/models.py
+++ b/src/ralph/tests/models.py
@@ -1,10 +1,3 @@
-# -*- coding: utf-8 -*-
-
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
-
 from django.db import models
 
 from ralph.lib.mixins.models import AdminAbsoluteUrlMixin

--- a/src/ralph/urls/__init__.py
+++ b/src/ralph/urls/__init__.py
@@ -1,8 +1,1 @@
-# -*- coding: utf-8 -*-
-
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
-
 from ralph.urls.base import urlpatterns  # noqa

--- a/src/ralph/urls/base.py
+++ b/src/ralph/urls/base.py
@@ -1,10 +1,3 @@
-# -*- coding: utf-8 -*-
-
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
-
 from django.conf.urls import include, url
 
 from ralph.admin import ralph_site as admin

--- a/src/ralph/urls/dev.py
+++ b/src/ralph/urls/dev.py
@@ -1,13 +1,5 @@
-# -*- coding: utf-8 -*-
-
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-from __future__ import unicode_literals
-
-from django.conf.urls import include, url
-
 import debug_toolbar
+from django.conf.urls import include, url
 
 from ralph.urls import urlpatterns as base_urlpatterns
 


### PR DESCRIPTION
- remove source code encodings comment
- remove `__future__` imports
- cleanup imports
- add import sort checker to `.travis.yml`

To automaticly sort imports you can use command:
`isort -rc src/`
