### PR TITLE
Enable isort diff parameter for better description errors.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ install-docs:
 	pip3 install -r requirements/docs.txt
 
 isort:
-	isort --recursive --check-only src
+	isort --diff --recursive --check-only src
 
 test: clean
 	test_ralph test $(TEST)


### PR DESCRIPTION
Now isort show diff when file have wrong order in imports
