### PR TITLE
Models cleanup

### DIFF
--- a/src/ralph/__main__.py
+++ b/src/ralph/__main__.py
@@ -3,8 +3,11 @@ import os
 import sys
 
 
-def main(settings_module='ralph.settings'):
-    os.environ.setdefault('DJANGO_SETTINGS_MODULE', settings_module)
+def main(settings_module='ralph.settings', force=False):
+    if force:
+        os.environ['DJANGO_SETTINGS_MODULE'] = settings_module
+    else:
+        os.environ.setdefault('DJANGO_SETTINGS_MODULE', settings_module)
 
     from django.core.management import execute_from_command_line
 
@@ -16,7 +19,10 @@ def dev():
 
 
 def test():
-    main('ralph.settings.test')
+    # test only with test settings, not local (or any set by environment
+    # variable DJANGO_SETTINGS_MODULE) - especially usefull in vagrant, when
+    # default DJANGO_SETTINGS_MODULE is overwrited in .profile
+    main('ralph.settings.test', force=True)
 
 
 def prod():

--- a/src/ralph/admin/mixins.py
+++ b/src/ralph/admin/mixins.py
@@ -49,6 +49,7 @@ class RalphAdminMixin(object):
     change_views = None
     change_list_template = 'admin/change_list.html'
     change_form_template = 'admin/change_form.html'
+    raw_id_override_parent = {}
 
     def __init__(self, *args, **kwargs):
         self.list_views = copy(self.list_views) or []
@@ -121,9 +122,12 @@ class RalphAdminMixin(object):
 
     def formfield_for_foreignkey(self, db_field, request=None, **kwargs):
         if db_field.name in self.raw_id_fields:
+            kw = {}
+            if db_field.name in self.raw_id_override_parent:
+                kw['rel_to'] = self.raw_id_override_parent[db_field.name]
             kwargs['widget'] = widgets.AutocompleteWidget(
                 db_field.rel, self.admin_site, using=kwargs.get('using'),
-                request=request,
+                request=request, **kw
             )
             return db_field.formfield(**kwargs)
         else:

--- a/src/ralph/admin/templates/admin/change_form.html
+++ b/src/ralph/admin/templates/admin/change_form.html
@@ -87,13 +87,17 @@
   <script type="text/javascript">
     (function($) {
       $(document).ready(function() {
-        $('.add-another').click(function(e) {
+        $('.add-related').click(function(e) {
           e.preventDefault();
           showAddAnotherPopup(this);
         });
         $('.related-lookup').click(function(e) {
           e.preventDefault();
           showRelatedObjectLookupPopup(this);
+        });
+        $('.change-related').click(function(e) {
+          e.preventDefault();
+          showRelatedObjectPopup(this);
         });
       {% if adminform and add %}
         $('form#{{ opts.model_name }}_form :input:visible:enabled:first').focus()

--- a/src/ralph/admin/templates/admin/widgets/autocomplete.html
+++ b/src/ralph/admin/templates/admin/widgets/autocomplete.html
@@ -32,7 +32,7 @@
             <i data-tooltip class="has-tip fail fa fa-exclamation" title="{% trans 'Something goes wrong...' %}"></i>
         </div>
     </div>
-    <ul class="suggest-list">
+    <ul class="suggest-list" style="display: none;">
         <li class="template item" data-edit-url=""><a class="link" href="#"></a></li>
         <li class="template no-results">{% trans 'No results' %}</li>
     </ul>

--- a/src/ralph/assets/admin.py
+++ b/src/ralph/assets/admin.py
@@ -5,6 +5,7 @@ from ralph.admin import RalphAdmin, register
 from ralph.assets.models.assets import (
     Asset,
     AssetModel,
+    BaseObject,
     Category,
     Environment,
     Manufacturer,
@@ -55,6 +56,11 @@ class AssetModelAdmin(PermissionAdminMixin, RalphAdmin):
     raw_id_fields = ['manufacturer']
     search_fields = ['name', 'manufacturer__name']
     ordering = ['name']
+    fields = (
+        'name', 'manufacturer', 'category', 'type', 'has_parent',
+        'cores_count', 'height_of_device', 'power_consumption',
+        'visualization_layout_front', 'visualization_layout_back'
+    )
 
 
 @register(Category)
@@ -76,4 +82,9 @@ class GenericComponentAdmin(RalphAdmin):
 
 @register(Asset)
 class AssetAdmin(RalphAdmin):
-    pass
+    raw_id_fields = ['parent', 'service_env', 'model']
+
+
+@register(BaseObject)
+class BaseObjectAdmin(RalphAdmin):
+    raw_id_fields = ['parent', 'service_env']

--- a/src/ralph/assets/migrations/0004_auto_20150805_1419.py
+++ b/src/ralph/assets/migrations/0004_auto_20150805_1419.py
@@ -1,0 +1,77 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+import ralph.lib.mixins.fields
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('assets', '0003_auto_20150721_1402'),
+    ]
+
+    operations = [
+        migrations.RemoveField(
+            model_name='asset',
+            name='delivery_date',
+        ),
+        migrations.RemoveField(
+            model_name='asset',
+            name='loan_end_date',
+        ),
+        migrations.RemoveField(
+            model_name='asset',
+            name='production_use_date',
+        ),
+        migrations.RemoveField(
+            model_name='asset',
+            name='production_year',
+        ),
+        migrations.RemoveField(
+            model_name='asset',
+            name='provider_order_date',
+        ),
+        migrations.RemoveField(
+            model_name='asset',
+            name='purchase_order',
+        ),
+        migrations.RemoveField(
+            model_name='asset',
+            name='request_date',
+        ),
+        migrations.RemoveField(
+            model_name='asset',
+            name='source',
+        ),
+        migrations.AddField(
+            model_name='service',
+            name='uid',
+            field=ralph.lib.mixins.fields.NullableCharField(max_length=40, null=True, unique=True, blank=True),
+        ),
+        migrations.AlterField(
+            model_name='asset',
+            name='barcode',
+            field=ralph.lib.mixins.fields.NullableCharField(default=None, unique=True, verbose_name='barcode', max_length=200, null=True, blank=True),
+        ),
+        migrations.AlterField(
+            model_name='asset',
+            name='hostname',
+            field=models.CharField(default=None, verbose_name='hostname', max_length=255, null=True, blank=True),
+        ),
+        migrations.AlterField(
+            model_name='asset',
+            name='niw',
+            field=ralph.lib.mixins.fields.NullableCharField(default=None, verbose_name='Inventory number', max_length=200, null=True, blank=True),
+        ),
+        migrations.AlterField(
+            model_name='asset',
+            name='sn',
+            field=ralph.lib.mixins.fields.NullableCharField(verbose_name='SN', max_length=200, null=True, unique=True, blank=True),
+        ),
+        migrations.AlterField(
+            model_name='genericcomponent',
+            name='sn',
+            field=ralph.lib.mixins.fields.NullableCharField(default=None, unique=True, verbose_name='vendor SN', max_length=255, null=True, blank=True),
+        ),
+    ]

--- a/src/ralph/assets/models/components.py
+++ b/src/ralph/assets/models/components.py
@@ -4,6 +4,7 @@ from django.utils.translation import ugettext_lazy as _
 
 from ralph.assets.models.base import BaseObject
 from ralph.assets.models.choices import ComponentType
+from ralph.lib.mixins.fields import NullableCharField
 from ralph.lib.mixins.models import NamedMixin
 
 
@@ -59,7 +60,7 @@ class GenericComponent(Component):
         verbose_name=_('label'), max_length=255, blank=True,
         null=True, default=None,
     )
-    sn = models.CharField(
+    sn = NullableCharField(
         verbose_name=_('vendor SN'), max_length=255, unique=True, null=True,
         blank=True, default=None,
     )

--- a/src/ralph/assets/tests/factories.py
+++ b/src/ralph/assets/tests/factories.py
@@ -9,6 +9,7 @@ from ralph.assets.models.assets import (
     Service,
     ServiceEnvironment
 )
+from ralph.assets.models.choices import ObjectModelType
 
 
 class CategoryFactory(DjangoModelFactory):
@@ -29,6 +30,7 @@ class BackOfficeAssetModelFactory(DjangoModelFactory):
 class DataCenterAssetModelFactory(DjangoModelFactory):
 
     name = factory.Iterator(['DL360', 'DL380p', 'DL380', 'ML10', 'ML10 v21'])
+    type = ObjectModelType.data_center
 
     class Meta:
         model = AssetModel

--- a/src/ralph/back_office/admin.py
+++ b/src/ralph/back_office/admin.py
@@ -39,24 +39,22 @@ class BackOfficeAssetAdmin(
     fieldsets = (
         (_('Basic info'), {
             'fields': (
-                'model', 'purchase_order', 'niw', 'barcode', 'sn',
-                'warehouse', 'location', 'status', 'task_url',
-                'loan_end_date', 'hostname', 'service_env',
-                'production_year', 'production_use_date',
-                'required_support', 'remarks'
-            )
-        }),
-        (_('Financial Info'), {
-            'fields': (
-                'order_no', 'invoice_date', 'invoice_no', 'price',
-                'depreciation_rate', 'source', 'request_date', 'provider',
-                'provider_order_date', 'delivery_date', 'depreciation_end_date',
-                'force_depreciation'
+                'hostname', 'model', 'barcode', 'sn', 'niw', 'status',
+                'warehouse', 'location', 'loan_end_date', 'service_env',
+                'remarks'
             )
         }),
         (_('User Info'), {
             'fields': (
                 'user', 'owner'
+            )
+        }),
+        (_('Financial Info'), {
+            'fields': (
+                'order_no', 'purchase_order', 'invoice_date', 'invoice_no',
+                'task_url', 'price', 'depreciation_rate',
+                'depreciation_end_date', 'force_depreciation', 'provider',
+
             )
         }),
     )

--- a/src/ralph/back_office/migrations/0002_auto_20150805_1419.py
+++ b/src/ralph/back_office/migrations/0002_auto_20150805_1419.py
@@ -1,0 +1,28 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('back_office', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.AlterModelOptions(
+            name='backofficeasset',
+            options={'verbose_name': 'Back Office Asset', 'verbose_name_plural': 'Back Office Assets'},
+        ),
+        migrations.AddField(
+            model_name='backofficeasset',
+            name='loan_end_date',
+            field=models.DateField(default=None, verbose_name='Loan end date', blank=True, null=True),
+        ),
+        migrations.AddField(
+            model_name='backofficeasset',
+            name='purchase_order',
+            field=models.CharField(max_length=50, null=True, blank=True),
+        ),
+    ]

--- a/src/ralph/back_office/models.py
+++ b/src/ralph/back_office/models.py
@@ -23,6 +23,10 @@ class BackOfficeAsset(Asset):
         related_name='assets_as_user',
     )
     location = models.CharField(max_length=128, null=True, blank=True)
+    purchase_order = models.CharField(max_length=50, null=True, blank=True)
+    loan_end_date = models.DateField(
+        null=True, blank=True, default=None, verbose_name=_('Loan end date'),
+    )
 
     class Meta:
         verbose_name = _('Back Office Asset')

--- a/src/ralph/data_center/admin.py
+++ b/src/ralph/data_center/admin.py
@@ -76,7 +76,7 @@ class DataCenterAssetAdmin(
     ]
     resource_class = resources.DataCenterAssetResource
     list_display = [
-        'status', 'barcode', 'purchase_order', 'model',
+        'status', 'barcode', 'model',
         'sn', 'hostname', 'invoice_date', 'invoice_no',
     ]
     bulk_edit_list = list_display
@@ -84,30 +84,33 @@ class DataCenterAssetAdmin(
     list_filter = ['status']
     date_hierarchy = 'created'
     list_select_related = ['model', 'model__manufacturer']
-    raw_id_fields = ['model', 'rack', 'service_env']
+    raw_id_fields = ['model', 'rack', 'service_env', 'parent']
+    raw_id_override_parent = {'parent': DataCenterAsset}
 
     fieldsets = (
         (_('Basic info'), {
             'fields': (
-                'model', 'purchase_order', 'niw', 'barcode', 'sn',
-                'status', 'task_url',
-                'loan_end_date', 'hostname', 'service_env',
-                'production_year', 'production_use_date',
-                'required_support', 'remarks'
+                'hostname', 'model', 'status', 'barcode', 'sn', 'niw',
+                'required_support', 'remarks', 'parent',
             )
         }),
-        (_('Financial Info'), {
+        (_('Location Info'), {
             'fields': (
-                'order_no', 'invoice_date', 'invoice_no', 'price',
-                'depreciation_rate', 'source', 'request_date', 'provider',
-                'provider_order_date', 'delivery_date', 'depreciation_end_date',
-                'force_depreciation'
+                'rack', 'position', 'orientation', 'slot_no',
             )
         }),
-        (_('Additional Info'), {
+        (_('Usage info'), {
             'fields': (
-                'rack', 'slots', 'slot_no', 'configuration_path',
-                'position', 'orientation'
+                'service_env', 'configuration_path', 'production_year',
+                'production_use_date',
+            )
+        }),
+        (_('Financial & Order Info'), {
+            'fields': (
+                'order_no', 'invoice_date', 'invoice_no', 'task_url', 'price',
+                'depreciation_rate', 'depreciation_end_date',
+                'force_depreciation', 'source', 'provider', 'delivery_date',
+
             )
         }),
     )

--- a/src/ralph/data_center/migrations/0003_auto_20150807_1513.py
+++ b/src/ralph/data_center/migrations/0003_auto_20150807_1513.py
@@ -1,0 +1,55 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+import ralph.lib.mixins.fields
+import django.core.validators
+import re
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('data_center', '0002_auto_20150715_0752'),
+    ]
+
+    operations = [
+        migrations.AlterModelOptions(
+            name='rackaccessory',
+            options={'verbose_name_plural': 'rack accessories'},
+        ),
+        migrations.RemoveField(
+            model_name='datacenterasset',
+            name='slots',
+        ),
+        migrations.AddField(
+            model_name='datacenterasset',
+            name='delivery_date',
+            field=models.DateField(null=True, blank=True),
+        ),
+        migrations.AddField(
+            model_name='datacenterasset',
+            name='production_use_date',
+            field=models.DateField(null=True, blank=True),
+        ),
+        migrations.AddField(
+            model_name='datacenterasset',
+            name='production_year',
+            field=models.PositiveSmallIntegerField(null=True, blank=True),
+        ),
+        migrations.AddField(
+            model_name='datacenterasset',
+            name='source',
+            field=models.PositiveIntegerField(null=True, db_index=True, blank=True, verbose_name='source', choices=[(1, 'shipment'), (2, 'salvaged')]),
+        ),
+        migrations.AlterField(
+            model_name='datacenterasset',
+            name='slot_no',
+            field=models.CharField(validators=[django.core.validators.RegexValidator(code='invalid_slot_no', message="Slot number should be a number from range 1-16 with an optional postfix 'A' or 'B' (e.g. '16A')", regex=re.compile('^([1-9][A,B]?|1[0-6][A,B]?)$', 32))], max_length=3, blank=True, verbose_name='slot number', null=True, help_text='Fill it if asset is blade server'),
+        ),
+        migrations.AlterField(
+            model_name='diskshare',
+            name='wwn',
+            field=ralph.lib.mixins.fields.NullableCharField(unique=True, max_length=33, verbose_name='Volume serial'),
+        ),
+    ]

--- a/src/ralph/data_center/models/__init__.py
+++ b/src/ralph/data_center/models/__init__.py
@@ -1,0 +1,59 @@
+from ralph.data_center.models.choices import (
+    ConnectionType,
+    Orientation,
+    RackOrientation,
+)
+from ralph.data_center.models.components import (
+    DiskShare,
+    DiskShareMount,
+)
+from ralph.data_center.models.networks import (
+    DiscoveryQueue,
+    IPAddress,
+    Network,
+    NetworkEnvironment,
+    NetworkKind,
+    NetworkTerminator,
+)
+from ralph.data_center.models.physical import (
+    Accessory,
+    Connection,
+    DataCenter,
+    DataCenterAsset,
+    Gap,
+    Rack,
+    RackAccessory,
+    ServerRoom,
+)
+from ralph.data_center.models.virtual import (
+    CloudProject,
+    Database,
+    VIP,
+    VirtualServer,
+)
+
+__all__ = [
+    'Accessory',
+    'CloudProject',
+    'Connection',
+    'ConnectionType',
+    'Database',
+    'DataCenter',
+    'DataCenterAsset',
+    'DiscoveryQueue',
+    'DiskShare',
+    'DiskShareMount',
+    'Gap',
+    'IPAddress',
+    'Network',
+    'NetworkEnvironment',
+    'NetworkKind',
+    'NetworkTerminator',
+    'Orientation',
+    'Rack',
+    'RackAccessory',
+    'RackOrientation',
+    'ServerRoom',
+    'VIP',
+    'VirtualServer',
+]

--- a/src/ralph/data_center/models/components.py
+++ b/src/ralph/data_center/models/components.py
@@ -5,6 +5,7 @@ from django.utils.translation import ugettext_lazy as _
 
 from ralph.assets.models.assets import Asset
 from ralph.assets.models.components import Component
+from ralph.lib.mixins.fields import NullableCharField
 
 
 @python_2_unicode_compatible
@@ -22,7 +23,7 @@ class DiskShare(Component):
     snapshot_size = models.PositiveIntegerField(
         verbose_name=_('size for snapshots (MiB)'), null=True, blank=True,
     )
-    wwn = models.CharField(
+    wwn = NullableCharField(
         verbose_name=_('Volume serial'), max_length=33, unique=True,
     )
     full = models.BooleanField(default=True)

--- a/src/ralph/data_center/tests/factories.py
+++ b/src/ralph/data_center/tests/factories.py
@@ -1,6 +1,7 @@
 import factory
 from factory.django import DjangoModelFactory
 
+from ralph.assets.tests.factories import DataCenterAssetModelFactory
 from ralph.data_center.models.physical import (
     Accessory,
     DataCenter,
@@ -56,6 +57,8 @@ class RackFactory(DjangoModelFactory):
 
 
 class DataCenterAssetFactory(DjangoModelFactory):
+    force_depreciation = False
+    model = factory.SubFactory(DataCenterAssetModelFactory)
 
     class Meta:
         model = DataCenterAsset

--- a/src/ralph/lib/foundation/templates/foundation_form/form_field.html
+++ b/src/ralph/lib/foundation/templates/foundation_form/form_field.html
@@ -18,6 +18,17 @@
           <small class="error">{{ error }}</small>
         {% endfor %}
       {% endif %}
+      {% if field.field.help_text %}
+        <span class="help-text">
+          <i
+            class="fa fa-lg fa-info-circle has-tip tip-top"
+            data-tooltip
+            aria-haspopup="true"
+            title="{{ field.field.help_text | escape }}"
+          >
+          </i>
+        </span>
+      {% endif %}
     </div>
   </div>
 </div>

--- a/src/ralph/lib/mixins/fields.py
+++ b/src/ralph/lib/mixins/fields.py
@@ -1,0 +1,25 @@
+# -*- coding: utf-8 -*-
+from django.db import models
+
+
+class NullableCharFieldMixin(object):
+    """
+    Mixin for char fields and descendants which will replace empty string value
+    ('') by null when saving to the database.
+
+    It's especially usefull when field is marked as unique and at the same time
+    allows null/blank (`models.CharField(unique=True, null=True, blank=True)`)
+    """
+    def to_python(self, value):
+        return value or ''
+
+    def get_prep_value(self, value):
+        return value or None
+
+
+class NullableCharField(
+    NullableCharFieldMixin,
+    models.CharField,
+    metaclass=models.SubfieldBase
+):
+    pass

--- a/src/ralph/licences/migrations/0002_auto_20150807_1512.py
+++ b/src/ralph/licences/migrations/0002_auto_20150807_1512.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('licences', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.AlterModelOptions(
+            name='softwarecategory',
+            options={'verbose_name_plural': 'software categories'},
+        ),
+    ]

--- a/src/ralph/static/src/js/ralph-autocomplete.js
+++ b/src/ralph/static/src/js/ralph-autocomplete.js
@@ -17,7 +17,7 @@
 
         var that = this;
         this.$deleteButton.on('click', function(e) {that.deleteItem(e);});
-        this.$queryInput.on('keypress', function(e) {that.keyPress(e);});
+        this.$queryInput.on('keydown', function(e) {that.keyDown(e);});
 
         Object.defineProperty(document.querySelector(that.options.targetSelector), 'value', {
             get: function(){
@@ -28,15 +28,20 @@
                 this.setAttribute('value', val);
             }
         });
-
     };
-    AutocompleteWidget.prototype.keyPress = function(event) {
+    AutocompleteWidget.prototype.keyDown = function(event) {
         var that = this;
         var code = event.keyCode || event.which;
         var startChar = 20; // [space] in ASCII
         var endChar = 126; // ~ in ASCII
-        if (code < startChar || code > endChar) {
-           return;
+        var specialCodes = [
+            8, // backspace
+        ];
+        if (
+            (code < startChar || code > endChar) &&
+            $.inArray(code, specialCodes) === -1
+        ) {
+            return;
         }
         if(that.timer) {
             clearTimeout(that.timer);
@@ -106,15 +111,16 @@
     };
     AutocompleteWidget.prototype.clearSuggestList = function() {
         this.$noResults.hide();
+        this.$suggestList.hide();
         $('>:not(.template)', this.$suggestList).remove();
     };
     AutocompleteWidget.prototype.suggest = function() {
         var that = this;
         var query = that.getQuery();
+        that.clearSuggestList();
         if (query.length < that.options.sentenceLength) {
             return false;
         }
-        that.clearSuggestList();
         that.fetchItems(query, function(data) {
             if (data.results.length !== 0) {
                 $.each(data.results, function() {
@@ -124,6 +130,7 @@
             else {
                 that.$noResults.show();
             }
+            that.$suggestList.show();
         });
     };
     AutocompleteWidget.prototype.fetchItems = function(query, callback) {

--- a/src/ralph/static/src/scss/components/autocomplete_field.scss
+++ b/src/ralph/static/src/scss/components/autocomplete_field.scss
@@ -62,8 +62,8 @@ $lookup-icon-width: 20px;
         }
         .status{
             position: absolute;
-            top: 6px;
-            right: 25px;
+            top: 5px;
+            right: 48px;
             .fa {
                 display: none;
                 font-size: 1.25rem;

--- a/src/ralph/static/src/scss/components/fieldsets.scss
+++ b/src/ralph/static/src/scss/components/fieldsets.scss
@@ -10,3 +10,9 @@ fieldset {
     }
 }
 
+
+.help-text {
+    position: absolute;
+    right: -13px;
+    top: 5px;
+}

--- a/src/ralph/tests/mixins.py
+++ b/src/ralph/tests/mixins.py
@@ -1,9 +1,10 @@
+# -*- coding: utf-8 -*-
 import sys
+from imp import reload
 
 from django.conf import settings
 from django.core.urlresolvers import clear_url_caches
 from django.utils.importlib import import_module
-from six.moves import reload_module
 
 from ralph.tests.factories import UserFactory
 
@@ -26,6 +27,6 @@ class ReloadUrlsMixin(object):
     """
     def reload_urls(self):
         if settings.ROOT_URLCONF in sys.modules:
-            reload_module(sys.modules[settings.ROOT_URLCONF])
+            reload(sys.modules[settings.ROOT_URLCONF])
             clear_url_caches()
         return import_module(settings.ROOT_URLCONF)


### PR DESCRIPTION
connected to #1668 

Models & admin cleanup & improvements (performance and visual)
- added ability to override model pointed by raw_id field (usefull when fields are inherited and we want to specify descending class)
- fixed edit related and add related (openinig in popup now)
- auto-complete widget fixes: hide by default, trigger on backspace, hide when characters count < 2
- fetch related objects by default in auto-complete widgets (performance improvement to not call every table in sequence but use join and fetch them at once)
- changed order of AssetModel fields
- introduced `NullableCharField`, which saves null instead of '' to database
- changed some fields from `CharField` to `NullableCharField`: `barcode`, `niw`, `sn`, `wwn`
- new `Service` field - `uid`
- removed some `Asset` fields:  `provider_order_date`, `request_date`
- removed `slots` field from `DataCenterAsset`
- moved `loan_end_date` and `purchase_order` from `Asset` to `BackOfficeAsset`
- moved `delivery_date`, `production_use_date`, `production_year` to `DataCenterAsset`, `source`
- changed fields order (and fieldsets) in `DataCenterAssetAdmin`
- all data center models are now available to import from `ralph.data_center.models`
- help_text is now displayed as tooltip
- added orientation, slot_no and position validation in `DataCenterAsset`

![screencapture-127-0-0-1-8000-data_center-datacenterasset-add-1438949372776](https://cloud.githubusercontent.com/assets/107437/9135476/08a8f72a-3d0e-11e5-8153-30596adc237f.png)
