### PR TITLE
Fixed autocomplete widget when admin does not have list_select_related defined

### DIFF
--- a/src/ralph/admin/widgets.py
+++ b/src/ralph/admin/widgets.py
@@ -192,7 +192,7 @@ class AutocompleteWidget(forms.TextInput):
         current_object = None
         if value:
             current_object = self.rel_to.objects.select_related(
-                *admin_model.list_select_related
+                *(admin_model.list_select_related or [])
             ).filter(
                 pk=value
             ).first()


### PR DESCRIPTION
Fixed autocomplete widget when admin does not have list_select_related defined (default value for `list_select_related` is `False` :expressionless:)
