### PR TITLE
Tabs improvements

### DIFF
--- a/src/ralph/admin/templates/admin/change_form.html
+++ b/src/ralph/admin/templates/admin/change_form.html
@@ -15,15 +15,15 @@
 {% block content %}
   <div id="content-main">
     <div class="row header">
-      <div class="large-4 columns">
-        <h1>{% block title_head %}Edit {{ header_obj_name }}{% endblock %}</h1>
+      <div class="large-3 medium-2 small-3 columns">
+        <h1 class="ellipsis-hidden">{% block title_head %}Edit {{ header_obj_name }}{% endblock %}</h1>
       </div>
-      <div class="large-6 columns">
+      <div class="large-7 medium-8 small-7 columns">
         {% block tabs %}
           {% views_tabs change_views '' original %}
         {% endblock %}
       </div>
-      <div class="large-2 columns">
+      <div class="large-2 medium-2 small-2 columns">
         <div class="header-toolbar">
           {% block object-tools %}
             {% if change %}

--- a/src/ralph/admin/templates/admin/templatetags/tabs.html
+++ b/src/ralph/admin/templates/admin/templatetags/tabs.html
@@ -3,22 +3,37 @@
 {% if views %}
   <div class="tabs">
     <ul>
-      <li{% if name == '' %} class="active"{% endif %}>
-        <a href="{{ object.get_absolute_url }}">
-          <i class="fa fa-info"></i> {% trans "Basic info" %}
+      <li
+        class="has-tip tip-bottom {% if name == '' %} active {% endif %}"
+        title="{{ view.label }}"
+        data-tooltip
+        aria-haspopup="true"
+        data-options="show_on:small"
+      >
+        <a href="{{ object.get_absolute_url }}" title="{% trans "Basic info" %}">
+          <i class="fa fa-info"></i> <span class="tab-label">{% trans "Basic info" %}</span>
         </a>
       </li>
       {% for view in views %}
-        <li{% if name == view.name %} class="active"{% endif %}>
-          {% if object.id %}
-            <a href="{% url view.url_with_namespace object.id %}">
-          {% else %}
-            <a href="{% url view.url_with_namespace %}">
-          {% endif %}
+        <li
+          class="has-tip tip-bottom {% if name == view.name %} active {% endif %}"
+          title="{{ view.label }}"
+          data-tooltip
+          aria-haspopup="true"
+          data-options="show_on:small"
+        >
+          <a href="
+            {% if object.id %}
+              {% url view.url_with_namespace object.id %}
+            {% else %}
+              {% url view.url_with_namespace %}
+            {% endif %}
+            " title="{{ view.label }}"
+          />
             {% if view.icon %}
               <i class="fa fa-{{ view.icon }}"></i>
             {% endif %}
-            {{ view.label }}
+            <span class="tab-label">{{ view.label }}</span>
           </a>
         </li>
       {% endfor %}

--- a/src/ralph/admin/widgets.py
+++ b/src/ralph/admin/widgets.py
@@ -192,7 +192,11 @@ class AutocompleteWidget(forms.TextInput):
         current_object = None
         if value:
             current_object = self.rel_to.objects.select_related(
-                *(admin_model.list_select_related or [])
+                # https://docs.djangoproject.com/en/1.8/ref/models/querysets/#select-related
+                # we cannot pass empty list - this would select all related
+                # model - instead we pass None, which means that none of
+                # related models will be selected
+                *(admin_model.list_select_related or [None])
             ).filter(
                 pk=value
             ).first()

--- a/src/ralph/static/src/scss/_settings.scss
+++ b/src/ralph/static/src/scss/_settings.scss
@@ -79,3 +79,7 @@ $input-box-shadow: none;
 $input-padding: 0.4rem;
 
 $tooltip-font-size: rem-calc(12);
+
+$has-tip-border-bottom: none;
+$has-tip-font-weight: normal;
+$has-tip-border-bottom-hover: none;

--- a/src/ralph/static/src/scss/_styles.scss
+++ b/src/ralph/static/src/scss/_styles.scss
@@ -120,3 +120,10 @@ input.datepicker {
 .with-icons {
     line-height: 3rem;
 }
+
+.ellipsis-hidden {
+    display: block;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    overflow: hidden;
+}

--- a/src/ralph/static/src/scss/components/autocomplete_field.scss
+++ b/src/ralph/static/src/scss/components/autocomplete_field.scss
@@ -1,4 +1,4 @@
-$item-padding: 0.2rem;
+$item-padding: 0.1rem;
 $widget-padding: $input-padding - $item-padding;
 $lookup-icon-width: 20px;
 
@@ -37,7 +37,7 @@ $lookup-icon-width: 20px;
                 }
             }
             .change-related .fa-pencil {
-                padding: 0 10px;
+                padding: 0 4px;
             }
         }
         .widget-icons .fa {

--- a/src/ralph/static/src/scss/components/tabs.scss
+++ b/src/ralph/static/src/scss/components/tabs.scss
@@ -1,6 +1,7 @@
 .tabs {
     display: inline-block;
     vertical-align: middle;
+    margin-bottom: rem-calc(-25);
     ul, li {
         padding: 0;
         margin: 0;
@@ -10,15 +11,18 @@
         li {
             list-style-type: none;
             float: left;
-            margin-right: 5px;
+            margin-right: 3px;
             a {
                 background-color: $tabs-content-bg-color;
                 border: 1px solid $tabs-border-color;
                 border-bottom: 0;
                 font-size: $button-font-med;
-                padding: rem-calc(10 20);
-                padding-bottom: rem-calc(11);
+                padding: rem-calc(8 16);
+                padding-bottom: rem-calc(8);
                 transition: all .1s ease-in-out;
+                .tab-label {
+                    display: none;
+                }
             }
             &:last-child a {
             }
@@ -30,5 +34,11 @@
                 border-bottom: 1px solid $tabs-content-bg-color;
             }
         }
+    }
+}
+
+@media #{$medium-up} {
+    .tabs ul li a .tab-label {
+        display: inline;
     }
 }


### PR DESCRIPTION
- added new `ellipsis-hidden` class, that should hide overflowing text (and replace it with `...`)
- used `ellipsis-hidden` class on change form header
- adjusted change form top bar (header, tabs, buttons) to smaller screens - tabs text is hidden when resolution is small (tooltip is displayed instead)
- changed tab size

![screen shot 2015-08-11 at 08 57 38](https://cloud.githubusercontent.com/assets/107437/9191983/4c220e00-4007-11e5-81d2-7daa21c70b16.png)
![screen shot 2015-08-11 at 08 56 54](https://cloud.githubusercontent.com/assets/107437/9191984/4c2411a0-4007-11e5-9709-fb3449e1106f.png)
![screen shot 2015-08-11 at 08 56 37](https://cloud.githubusercontent.com/assets/107437/9191985/4c3beef6-4007-11e5-8638-4eb3f04472d6.png)
