### PR TITLE
Permissions in API

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -3,7 +3,7 @@ dj.choices==0.10.0
 django-import-export==0.2.7
 django-mptt==0.7.4
 django-reversion==1.8.6
-djangorestframework==3.1.2
+djangorestframework==3.2.2
 mysqlclient==1.3.6
 python-dateutil==2.4.2
 pytz==2015.4

--- a/src/ralph/accounts/models.py
+++ b/src/ralph/accounts/models.py
@@ -114,6 +114,9 @@ class RalphUser(AbstractUser):
             'region_id', flat=True
         )
 
+    def has_any_perms(self, perms, obj=None):
+        return any([self.has_perm(p, obj=obj) for p in perms])
+
     def save(self, *args, **kwargs):
         # set default values if None provided
         for field in ('gender', 'country'):

--- a/src/ralph/api/__init__.py
+++ b/src/ralph/api/__init__.py
@@ -1,0 +1,9 @@
+from ralph.api.serializers import RalphAPISerializer
+from ralph.api.viewsets import RalphAPIViewSet
+from ralph.api.routers import router
+
+__all__ = [
+    'RalphAPISerializer',
+    'RalphAPIViewSet',
+    'router',
+]

--- a/src/ralph/api/permissions.py
+++ b/src/ralph/api/permissions.py
@@ -1,0 +1,85 @@
+# -*- coding: utf-8 -*-
+from rest_framework.compat import get_model_name
+from rest_framework.permissions import IsAuthenticated as DRFIsAuthenticated
+
+from ralph.lib.permissions.api import ObjectPermissionsMixin
+
+ADD_PERM = ['%(app_label)s.add_%(model_name)s']
+CHANGE_PERM = ['%(app_label)s.change_%(model_name)s']
+DELETE_PERM = ['%(app_label)s.delete_%(model_name)s']
+# user could have any of add, change, delete permissions to view model
+VIEW_PERM = ADD_PERM + CHANGE_PERM + DELETE_PERM
+
+
+def is_staff(user):
+    """
+    Check if user is staff (he's staff if he has is_staff OR is_superuser flag)
+    """
+    return user.is_staff or user.is_superuser
+
+
+class IsAuthenticated(DRFIsAuthenticated):
+    """
+    Extends default DRF IsAuthenticated permission and additionally check if
+    user is staff.
+    """
+    def has_permission(self, request, view):
+        return super().has_permission(request, view) and is_staff(request.user)
+
+
+class RalphPermission(ObjectPermissionsMixin, IsAuthenticated):
+    """
+    Ralph API Permissions.
+
+    Performed checks:
+        * user has access to object (through `ObjectPermissionsMixin`)
+        * user is properly authenticated (through `IsAuthenticated`)
+        * user has proper Django admin permissions (add_*, change_*, delete_*)
+          for model he requested
+    """
+
+    perms_map = {
+        'GET': VIEW_PERM,
+        'OPTIONS': VIEW_PERM,
+        'HEAD': VIEW_PERM,
+        'POST': ADD_PERM,
+        'PUT': CHANGE_PERM,
+        'PATCH': CHANGE_PERM,
+        'DELETE': DELETE_PERM,
+    }
+
+    def get_required_permissions(self, method, model_cls):
+        """
+        Given a model and an HTTP method, return the list of permission
+        codes that the user is required to have.
+        """
+        kwargs = {
+            'app_label': model_cls._meta.app_label,
+            'model_name': get_model_name(model_cls)
+        }
+        return [perm % kwargs for perm in self.perms_map[method]]
+
+    def _check_model_permissions(self, request, view):
+        """
+        Check if user has permissions to model assigned to view based on Django
+        admin permissions. If view doesn't have model (queryset) assigned,
+        permission is granted here.
+        """
+        try:
+            queryset = view.get_queryset()
+        except (AttributeError, TypeError):
+            queryset = getattr(view, 'queryset', None)
+
+        model_perms = True
+        if queryset is not None:
+            perms = self.get_required_permissions(
+                request.method, queryset.model
+            )
+            model_perms = request.user.has_any_perms(perms)
+        return model_perms
+
+    def has_permission(self, request, view):
+        return (
+            super().has_permission(request, view) and
+            self._check_model_permissions(request, view)
+        )

--- a/src/ralph/api/routers.py
+++ b/src/ralph/api/routers.py
@@ -1,0 +1,54 @@
+# -*- coding: utf-8 -*-
+from collections import OrderedDict
+
+from django.core.urlresolvers import NoReverseMatch
+from rest_framework import routers, views
+from rest_framework.response import Response
+from rest_framework.reverse import reverse
+
+from ralph.api.permissions import RalphPermission
+
+
+class RalphRouter(routers.DefaultRouter):
+    """
+    Acts like DefaultRouter + checks if user has permissions to see viewset.
+    Viewsets for which user doesn't have permissions are hidden in root view.
+    """
+    def get_api_root_view(self):
+        api_root_dict = OrderedDict()
+        list_name = self.routes[0].name
+        for prefix, viewset, basename in self.registry:
+            api_root_dict[prefix] = (
+                list_name.format(basename=basename), viewset
+            )
+
+        class APIRoot(views.APIView):
+            _ignore_model_permissions = True
+
+            def _check_viewset_permissions(self, request, viewset):
+                return RalphPermission().has_permission(request, viewset)
+
+            def get(self, request, *args, **kwargs):
+                ret = OrderedDict()
+                namespace = request.resolver_match.namespace
+                for key, (url_name, viewset) in api_root_dict.items():
+                    if not self._check_viewset_permissions(request, viewset):
+                        continue
+                    if namespace:
+                        url_name = namespace + ':' + url_name
+                    try:
+                        ret[key] = reverse(
+                            url_name,
+                            args=args,
+                            kwargs=kwargs,
+                            request=request,
+                            format=kwargs.get('format', None)
+                        )
+                    except NoReverseMatch:
+                        continue
+
+                return Response(ret)
+
+        return APIRoot.as_view()
+
+router = RalphRouter()

--- a/src/ralph/api/serializers.py
+++ b/src/ralph/api/serializers.py
@@ -1,0 +1,72 @@
+# -*- coding: utf-8 -*-
+import logging
+from collections import OrderedDict
+
+from rest_framework import serializers
+
+from ralph.lib.permissions.api import (
+    PermissionsPerFieldSerializerMixin,
+    RelatedObjectsPermissionsSerializerMixin
+)
+
+logger = logging.getLogger(__name__)
+
+
+class ReversedChoiceField(serializers.ChoiceField):
+    """
+    Choice field serializer which allow to pass value by name instead of key.
+    Additionally it present value in user-friendly format by-name.
+
+    Notice that requirement for this field to work properly is uniqueness of
+    choice values.
+
+    This field works perfectly with `dj.choices.Choices`.
+    """
+    def __init__(self, choices, **kwargs):
+        super(ReversedChoiceField, self).__init__(choices, **kwargs)
+        # mapping by value
+        self.reversed_choices = OrderedDict([(v, k) for (k, v) in choices])
+
+    def to_representation(self, obj):
+        """
+        Return choice name (value) instead of default key.
+        """
+        return self.choices[obj]
+
+    def to_internal_value(self, data):
+        """
+        Try to get choice by value first. If it doesn't succeed fallback to
+        default action (get by key).
+        """
+        try:
+            return self.reversed_choices[data]
+        except KeyError:
+            pass
+        return super(ReversedChoiceField, self).to_internal_value(data)
+
+
+class RalphAPISerializerMixin(
+    RelatedObjectsPermissionsSerializerMixin,
+    PermissionsPerFieldSerializerMixin,
+):
+    """
+    Mix used in Ralph API serializers features:
+        * checking if user has permissions to related objects (through
+          `RelatedObjectsPermissionsSerializerMixin`)
+        * handling field-level permissions (through
+          `PermissionsPerFieldSerializerMixin`)
+        * use `ReversedChoiceField` as default serializer for choice field
+        * request and user object easily accessible in serializer
+    """
+    serializer_choice_field = ReversedChoiceField
+    # turn if on when all models are linked
+    # serializer_related_field = serializers.HyperlinkedRelatedField
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._request = self.context['request']
+        self._user = self._request.user
+
+
+class RalphAPISerializer(RalphAPISerializerMixin, serializers.ModelSerializer):
+    pass

--- a/src/ralph/api/tests/_base.py
+++ b/src/ralph/api/tests/_base.py
@@ -1,0 +1,37 @@
+# -*- coding: utf-8 -*-
+from django.contrib.auth import get_user_model
+from django.contrib.auth.models import Permission
+from django.contrib.contenttypes.models import ContentType
+
+from ralph.tests.models import Foo
+
+
+class APIPermissionsTestMixin(object):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+
+        cls.foo = Foo.objects.create(bar='rab')
+
+        def create_user(name, **kwargs):
+            params = dict(
+                username=name,
+                is_staff=True,
+                is_active=True,
+            )
+            params.update(kwargs)
+            return get_user_model().objects.create(**params)
+        cls.user1 = create_user('user1')
+        cls.user2 = create_user('user2')
+        cls.user3 = create_user('user3')
+        cls.user_not_staff = create_user('user_not_staff', is_staff=False)
+
+        def add_perm(user, perm):
+            user.user_permissions.add(Permission.objects.get(
+                content_type=ContentType.objects.get_for_model(Foo),
+                codename=perm
+            ))
+        add_perm(cls.user1, 'change_foo')
+        add_perm(cls.user1, 'delete_foo')
+        add_perm(cls.user2, 'add_foo')
+        add_perm(cls.user_not_staff, 'change_foo')

--- a/src/ralph/api/tests/api.py
+++ b/src/ralph/api/tests/api.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+from django.conf.urls import include, url
+
+from ralph.api import RalphAPISerializer, RalphAPIViewSet
+from ralph.api.routers import RalphRouter
+from ralph.tests.models import Foo
+
+
+class FooSerializer(RalphAPISerializer):
+    class Meta:
+        model = Foo
+
+
+class FooViewSet(RalphAPIViewSet):
+    queryset = Foo.objects.all()
+    serializer_class = FooSerializer
+
+router = RalphRouter()
+router.register(r'foos', FooViewSet)
+urlpatterns = [
+    url(r'^test-ralph-api/', include(router.urls, namespace='test-ralph-api')),
+]

--- a/src/ralph/api/tests/test_permissions.py
+++ b/src/ralph/api/tests/test_permissions.py
@@ -1,0 +1,81 @@
+# -*- coding: utf-8 -*-
+from ddt import data, ddt, unpack
+from django.core.urlresolvers import reverse
+from rest_framework import status
+from rest_framework.test import APITestCase
+
+from ralph.api.tests._base import APIPermissionsTestMixin
+
+
+@ddt
+class RalphPermissionsTests(APIPermissionsTestMixin, APITestCase):
+    @unpack
+    @data(
+        ('user1',),
+        ('user2',),
+    )
+    def test_user_should_get_model_when_he_has_any_permission(self, username):
+        url = reverse('test-ralph-api:foo-list')
+        self.client.force_authenticate(getattr(self, username))
+        response = self.client.get(url, format='json')
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+    def test_user_should_not_get_model_when_he_has_any_access(self):
+        url = reverse('test-ralph-api:foo-list')
+        self.client.force_authenticate(self.user3)
+        response = self.client.get(url, format='json')
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_user_should_not_get_model_when_he_is_not_staff(self):
+        url = reverse('test-ralph-api:foo-list')
+        self.client.force_authenticate(self.user_not_staff)
+        response = self.client.get(url, format='json')
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_user_should_add_model_when_he_has_add_access(self):
+        url = reverse('test-ralph-api:foo-list')
+        self.client.force_authenticate(self.user2)
+        response = self.client.post(url, {'bar': 'test'}, format='json')
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+
+    def test_user_should_not_add_model_when_he_has_not_add_access(self):
+        url = reverse('test-ralph-api:foo-list')
+        self.client.force_authenticate(self.user1)
+        response = self.client.post(url, {'bar': 'test'}, format='json')
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_user_should_patch_model_when_he_has_change_access(self):
+        url = reverse('test-ralph-api:foo-detail', args=(self.foo.id,))
+        self.client.force_authenticate(self.user1)
+        response = self.client.patch(url, {'bar': 'test'}, format='json')
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+    def test_user_should_put_model_when_he_has_change_access(self):
+        url = reverse('test-ralph-api:foo-detail', args=(self.foo.id,))
+        self.client.force_authenticate(self.user1)
+        response = self.client.patch(url, {'bar': 'test'}, format='json')
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+    def test_user_should_not_patch_model_when_he_has_not_change_access(self):
+        url = reverse('test-ralph-api:foo-detail', args=(self.foo.id,))
+        self.client.force_authenticate(self.user2)
+        response = self.client.patch(url, {'bar': 'test'}, format='json')
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_user_should_not_put_model_when_he_has_not_change_access(self):
+        url = reverse('test-ralph-api:foo-detail', args=(self.foo.id,))
+        self.client.force_authenticate(self.user2)
+        response = self.client.patch(url, {'bar': 'test'}, format='json')
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_user_should_delete_model_when_he_has_delete_access(self):
+        url = reverse('test-ralph-api:foo-detail', args=(self.foo.id,))
+        self.client.force_authenticate(self.user1)
+        response = self.client.delete(url, format='json')
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+
+    def test_user_should_not_delete_model_when_he_has_not_delete_access(self):
+        url = reverse('test-ralph-api:foo-detail', args=(self.foo.id,))
+        self.client.force_authenticate(self.user2)
+        response = self.client.delete(url, format='json')
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)

--- a/src/ralph/api/tests/test_routers.py
+++ b/src/ralph/api/tests/test_routers.py
@@ -1,0 +1,29 @@
+# -*- coding: utf-8 -*-
+from django.core.urlresolvers import reverse
+from rest_framework import status
+from rest_framework.test import APITestCase
+
+from ralph.api.tests._base import APIPermissionsTestMixin
+
+
+class RalphRouterTests(APIPermissionsTestMixin, APITestCase):
+    def test_router_user_has_access_to_foo(self):
+        url = reverse('test-ralph-api:api-root')
+        self.client.force_authenticate(self.user1)
+        response = self.client.get(url, format='json')
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertIn('foos', response.data)
+
+    def test_router_user_has_not_access_to_foo(self):
+        url = reverse('test-ralph-api:api-root')
+        self.client.force_authenticate(self.user3)
+        response = self.client.get(url, format='json')
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertNotIn('foos', response.data)
+
+    def test_router_user_not_staff_has_not_access_to_foo(self):
+        url = reverse('test-ralph-api:api-root')
+        self.client.force_authenticate(self.user_not_staff)
+        response = self.client.get(url, format='json')
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+        self.assertNotIn('foos', response.data)

--- a/src/ralph/api/tests/test_serializers.py
+++ b/src/ralph/api/tests/test_serializers.py
@@ -1,0 +1,45 @@
+# -*- coding: utf-8 -*-
+from collections import OrderedDict
+
+from dj.choices import Choices
+from rest_framework.exceptions import ValidationError
+
+from ralph.api.serializers import ReversedChoiceField
+from ralph.tests import RalphTestCase
+
+
+class TestChoices(Choices):
+    _ = Choices.Choice
+
+    foo = _('foo11')
+    bar = _('bar22')
+
+
+class TestReversedChoiceField(RalphTestCase):
+    def setUp(self):
+        self.reversed_choice_field = ReversedChoiceField(TestChoices())
+
+    def test_reversed_choices(self):
+        self.assertEqual(
+            self.reversed_choice_field.reversed_choices,
+            OrderedDict([
+                ('foo11', TestChoices.foo.id),
+                ('bar22', TestChoices.bar.id)
+            ])
+        )
+
+    def test_to_representation_should_return_choice_text(self):
+        self.assertEqual(
+            self.reversed_choice_field.to_representation(TestChoices.foo.id),
+            'foo11'
+        )
+
+    def test_to_internal_value_should_map_choice_text_to_id(self):
+        self.assertEqual(
+            self.reversed_choice_field.to_internal_value('foo11'),
+            TestChoices.foo.id,
+        )
+
+    def test_to_internal_value_with_choice_not_found_should_raise_validation_error(self):  # noqa
+        with self.assertRaises(ValidationError):
+            self.reversed_choice_field.to_internal_value('foo33')

--- a/src/ralph/api/tests/test_viewsets.py
+++ b/src/ralph/api/tests/test_viewsets.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+from ralph.api.viewsets import RalphAPIViewSet
+from ralph.tests import RalphTestCase
+
+
+class ViewsetWithoutRalphPermission(RalphAPIViewSet):
+    permission_classes = []
+
+
+class ViewsetWithoutPermissionsForObjectFilter(RalphAPIViewSet):
+    filter_backends = []
+
+
+class TestRalphViewset(RalphTestCase):
+    def test_should_raise_attributeerror_when_ralph_permission_missing(self):
+        with self.assertRaises(AttributeError):
+            ViewsetWithoutRalphPermission()
+
+    def test_should_raise_attributeerror_when_permission_for_object_filter_missing(self):  # noqa
+        with self.assertRaises(AttributeError):
+            ViewsetWithoutPermissionsForObjectFilter()

--- a/src/ralph/api/viewsets.py
+++ b/src/ralph/api/viewsets.py
@@ -1,0 +1,30 @@
+# -*- coding: utf-8 -*-
+from rest_framework import viewsets
+
+from ralph.api.permissions import RalphPermission
+from ralph.lib.permissions.api import PermissionsForObjectFilter
+
+
+class RalphAPIViewSetMixin(object):
+    """
+    Ralph API default viewset. Provides object-level permissions checking and
+    model permissions checking (using Django-admin permissions).
+    """
+    filter_backends = [PermissionsForObjectFilter]
+    permission_classes = [RalphPermission]
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        # check if required permissions and filters classes are present
+        if RalphPermission not in self.permission_classes:
+            raise AttributeError(
+                'RalphPermission missing in permission_classes'
+            )
+        if PermissionsForObjectFilter not in self.filter_backends:
+            raise AttributeError(
+                'PermissionsForObjectFilter missing in filter_backends'
+            )
+
+
+class RalphAPIViewSet(RalphAPIViewSetMixin, viewsets.ModelViewSet):
+    pass

--- a/src/ralph/data_center/urls/api.py
+++ b/src/ralph/data_center/urls/api.py
@@ -1,12 +1,6 @@
 # -*- coding: utf-8 -*-
-from django.conf.urls import include, url
-from rest_framework import routers
-
+from ralph.api import router
 from ralph.data_center.views.api import DataCenterAssetViewSet
 
-router = routers.DefaultRouter()
 router.register(r'data-center-assets', DataCenterAssetViewSet)
-
-urlpatterns = [
-    url(r'^', include(router.urls)),
-]
+urlpatterns = []

--- a/src/ralph/lib/permissions/api.py
+++ b/src/ralph/lib/permissions/api.py
@@ -1,0 +1,134 @@
+# -*- coding: utf-8 -*-
+"""
+Django Rest Framework Mixins to use with permissions per field and per object.
+"""
+from collections import OrderedDict
+
+from django.utils.translation import ugettext_lazy as _
+from rest_framework.exceptions import ValidationError
+from rest_framework.fields import empty
+from rest_framework.filters import BaseFilterBackend
+
+from ralph.lib.permissions import PermByFieldMixin, PermissionsForObjectMixin
+
+
+class PermissionsForObjectFilter(BaseFilterBackend):
+    """
+    Filter queryset for objects for which user has permissions (only if
+    model subclasses `PermissionsForObjectMixin`).
+    """
+    def filter_queryset(self, request, queryset, view):
+        model_cls = queryset.model
+        if issubclass(model_cls, PermissionsForObjectMixin):
+            queryset = model_cls._get_objects_for_user(request.user, queryset)
+        return queryset
+
+
+class ObjectPermissionsMixin(object):
+    """
+    Validate user permissions to single object if it is instance of
+    `PermissionsForObjectMixin`.
+
+    This class should be use as a mixin to
+    `rest_framework.permissions.BasePermission` subclasses.
+    """
+    def has_object_permission(self, request, view, obj):
+        result = super().has_object_permission(request, view, obj)
+        if isinstance(obj, PermissionsForObjectMixin):
+            result &= obj.has_permission_to_object(request.user)
+        return result
+
+
+class PermissionsPerFieldSerializerMixin(object):
+    """
+    Apply permission validation on field level.
+
+    This class should be used as a mixin to
+    `rest_framework.serializers.BaseSerializer` subclasses.
+    """
+    def get_field_names(self, declared_fields, model_info):
+        """
+        Remove fields for which user doesn't have access.
+
+        Fields declared in serializer which aren't related from model are
+        always passed here (for any user) - it's `declared_fields` in
+        DRF nomenclature.
+        """
+        result = super().get_field_names(declared_fields, model_info)
+        model = model_info.pk.model
+        permissioned_fields = set(
+            list(model_info.fields.keys()) +
+            list(model_info.forward_relations.keys())
+        )
+        if issubclass(model, PermByFieldMixin):
+            user = self.context['request'].user
+            view_fields = model.allowed_fields(user, action='view')
+            for field_name in permissioned_fields - view_fields:
+                result.remove(field_name)
+        return result
+
+    def _get_read_only_fields(self):
+        """
+        Return model read only fields for current user.
+        """
+        read_only_fields = set()
+        model = getattr(self.Meta, 'model')
+        if issubclass(model, PermByFieldMixin):
+            user = self.context['request'].user
+            change_fields = model.allowed_fields(user, action='change')
+            view_fields = model.allowed_fields(user, action='view')
+            read_only_fields = view_fields - change_fields
+        return read_only_fields
+
+    def get_extra_kwargs(self):
+        """
+        Apply read_only=True on (model) fields which should be read only for
+        current user.
+
+        It's applied in extra_kwargs for each field to not touch other DRF
+        mechanisms.
+        """
+        extra_kwargs = super().get_extra_kwargs()
+        for field_name in self._get_read_only_fields():
+            extra_kwargs.setdefault(field_name, {})['read_only'] = True
+        return extra_kwargs
+
+    def run_validation(self, data=empty):
+        """
+        Perform additional check to see if readonly data is not being updated.
+        Raise `rest_framework.exceptions.ValidationError` if true.
+        """
+        result = super().run_validation(data)
+        readonly_fields = self._get_read_only_fields()
+        errors = OrderedDict()
+        for field in readonly_fields:
+            if field in data:
+                errors[field] = _('You cannot update readonly field.')
+        if errors:
+            raise ValidationError(errors)
+        return result
+
+
+class RelatedObjectsPermissionsSerializerMixin(object):
+    """
+    Apply permission validation on object level for related fields
+    (ex. foreign keys or many to many fields).
+
+    This class should be used as a mixin to
+    `rest_framework.serializers.BaseSerializer` subclasses.
+    """
+    def build_relational_field(self, field_name, relation_info):
+        """
+        Overwrite related field queryset to objects for which current user has
+        permissions.
+        """
+        field_class, field_kwargs = super().build_relational_field(
+            field_name, relation_info
+        )
+        queryset = field_kwargs.get('queryset')
+        if queryset and issubclass(queryset.model, PermissionsForObjectMixin):
+            queryset = queryset.model._get_objects_for_user(
+                self.context['request'].user, queryset
+            )
+            field_kwargs['queryset'] = queryset
+        return field_class, field_kwargs

--- a/src/ralph/lib/permissions/tests/_base.py
+++ b/src/ralph/lib/permissions/tests/_base.py
@@ -1,0 +1,79 @@
+# -*- coding: utf-8 -*-
+from django.contrib.auth import get_user_model
+from django.contrib.auth.models import Permission
+from django.contrib.contenttypes.models import ContentType
+
+from ralph.lib.permissions.tests.models import Article, Library, LongArticle
+
+
+class PermissionsTestMixin(object):
+    def _create_users_and_articles(self):
+        self.user1 = get_user_model().objects.create(username='user1')
+        self.user2 = get_user_model().objects.create(username='user2')
+        self.user3 = get_user_model().objects.create(username='user3')
+        self.superuser = get_user_model().objects.create(
+            username='superuser', is_superuser=True
+        )
+
+        content_types = [ContentType.objects.get_for_model(m) for m in (
+            Article,
+            LongArticle,
+            Library,
+        )]
+        base_permissions = Permission.objects.filter(
+            content_type__in=content_types
+        )
+        for user in (self.user1, self.user2, self.user3):
+            user.user_permissions.add(*base_permissions)
+
+        # remove some permissions:
+        # user1 doesn't have access to custome_field_1 at all
+        self.user1.user_permissions.remove(Permission.objects.get(
+            content_type=ContentType.objects.get_for_model(Article),
+            codename='change_article_custom_field_1_field'
+        ))
+        self.user1.user_permissions.remove(Permission.objects.get(
+            content_type=ContentType.objects.get_for_model(Article),
+            codename='view_article_custom_field_1_field'
+        ))
+        # user3 doesn't have change permissions on custom_field_1
+        self.user3.user_permissions.remove(Permission.objects.get(
+            content_type=ContentType.objects.get_for_model(Article),
+            codename='change_article_custom_field_1_field'
+        ))
+
+        # create two articles for each user
+        self.article_1 = Article.objects.create(
+            author=self.user1,
+            title='1',
+            content='1'*10,
+            custom_field_1='test value',
+        )
+        self.article_2 = Article.objects.create(
+            author=self.user2,
+            title='2',
+            content='2'*10,
+        )
+        self.article_3 = Article.objects.create(
+            author=self.user3,
+            title='3',
+            content='3'*10,
+            custom_field_1='test value 2',
+        )
+
+        # create group article
+        self.article_1.collaborators.add(self.user2)
+
+        # create article with long title
+        self.long_article = LongArticle.objects.create(
+            author=self.user1,
+            title='####### long article ########',
+            content='lorem ipsum',
+            custom_field_1='ipsum lorem',
+        )
+        self.long_article_2 = LongArticle.objects.create(
+            author=self.user1,
+            title='short',
+            content='lorem ipsum',
+            custom_field_2=self.article_1,
+        )

--- a/src/ralph/lib/permissions/tests/api.py
+++ b/src/ralph/lib/permissions/tests/api.py
@@ -1,0 +1,70 @@
+# -*- coding: utf-8 -*-
+from django.conf.urls import include, url
+from rest_framework import permissions, routers, serializers, viewsets
+
+from ralph.lib.permissions.api import (
+    ObjectPermissionsMixin,
+    PermissionsForObjectFilter,
+    PermissionsPerFieldSerializerMixin,
+    RelatedObjectsPermissionsSerializerMixin
+)
+from ralph.lib.permissions.tests.models import Article, Library, LongArticle
+
+
+class Permission(ObjectPermissionsMixin, permissions.IsAuthenticated):
+    pass
+
+
+class ArticleSerializer(
+    PermissionsPerFieldSerializerMixin,
+    RelatedObjectsPermissionsSerializerMixin,
+    serializers.ModelSerializer
+):
+    class Meta:
+        model = Article
+
+
+class ArticleViewSet(viewsets.ModelViewSet):
+    queryset = Article.objects.all()
+    serializer_class = ArticleSerializer
+    filter_backends = [PermissionsForObjectFilter]
+    permission_classes = [Permission]
+
+
+class LongArticleSerializer(
+    PermissionsPerFieldSerializerMixin,
+    RelatedObjectsPermissionsSerializerMixin,
+    serializers.ModelSerializer
+):
+    class Meta:
+        model = LongArticle
+
+
+class LongArticleViewSet(viewsets.ModelViewSet):
+    queryset = LongArticle.objects.all()
+    serializer_class = LongArticleSerializer
+    filter_backends = [PermissionsForObjectFilter]
+    permission_classes = [Permission]
+
+
+class LibrarySerializer(
+    PermissionsPerFieldSerializerMixin,
+    RelatedObjectsPermissionsSerializerMixin,
+    serializers.ModelSerializer
+):
+    class Meta:
+        model = Library
+
+
+class LibraryViewSet(viewsets.ModelViewSet):
+    queryset = Library.objects.all()
+    serializer_class = LibrarySerializer
+
+
+router = routers.DefaultRouter()
+router.register(r'articles', ArticleViewSet)
+router.register(r'long-articles', LongArticleViewSet)
+router.register(r'library', LibraryViewSet)
+urlpatterns = [
+    url(r'^test-api/', include(router.urls, namespace='test-api')),
+]

--- a/src/ralph/lib/permissions/tests/models.py
+++ b/src/ralph/lib/permissions/tests/models.py
@@ -1,7 +1,9 @@
+# -*- coding: utf-8 -*-
 from django.conf import settings
 from django.db import models
 
 from ralph.lib.permissions.models import (
+    PermByFieldMixin,
     PermissionsForObjectMixin,
     user_permission
 )
@@ -22,10 +24,11 @@ def has_long_title(user):
     return models.Q(title__regex=r'.{10}.*')
 
 
-class Article(PermissionsForObjectMixin, models.Model):
+class Article(PermByFieldMixin, PermissionsForObjectMixin, models.Model):
     author = models.ForeignKey(settings.AUTH_USER_MODEL)
     title = models.CharField(max_length=100)
     content = models.CharField(max_length=1000)
+    custom_field_1 = models.CharField(max_length=100, null=True, blank=True)
     collaborators = models.ManyToManyField(settings.AUTH_USER_MODEL)
 
     class Permissions:
@@ -37,6 +40,7 @@ class Article(PermissionsForObjectMixin, models.Model):
 
 class LongArticle(Article):
     remarks = models.CharField(max_length=100)
+    custom_field_2 = models.ForeignKey(Article, null=True, blank=True)
 
     class Permissions:
         # notice that this permission is anded (&) with Article permissions

--- a/src/ralph/lib/permissions/tests/test_api.py
+++ b/src/ralph/lib/permissions/tests/test_api.py
@@ -1,0 +1,86 @@
+# -*- coding: utf-8 -*-
+
+from django.core.urlresolvers import reverse
+from rest_framework import status
+from rest_framework.test import APITestCase
+
+from ralph.lib.permissions.tests._base import PermissionsTestMixin
+
+
+class PermissionsForObjectTests(PermissionsTestMixin, APITestCase):
+    def setUp(self):
+        self._create_users_and_articles()
+
+    def test_filter_objects_list_should_return_only_visible_by_user(self):
+        url = reverse('test-api:article-list')
+        self.client.force_authenticate(self.user1)
+        response = self.client.get(url, format='json')
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data['count'], 3)
+
+    def test_get_single_object_should_success_when_user_has_permissions(self):
+        url = reverse('test-api:article-detail', args=(self.article_1.id,))
+        self.client.force_authenticate(self.user1)
+        response = self.client.get(url, format='json')
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+    def test_get_single_object_should_fail_when_user_doesnt_have_permissions(self):  # noqa
+        url = reverse('test-api:article-detail', args=(self.article_2.id,))
+        self.client.force_authenticate(self.user1)
+        response = self.client.get(url, format='json')
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+
+class PermissionsPerFieldTests(PermissionsTestMixin, APITestCase):
+    def setUp(self):
+        self._create_users_and_articles()
+
+    def test_user_should_see_field_when_he_has_change_access_to_it(self):
+        url = reverse('test-api:article-detail', args=(self.article_1.id,))
+        self.client.force_authenticate(self.user2)
+        response = self.client.get(url, format='json')
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data['custom_field_1'], 'test value')
+
+    def test_user_should_not_see_field_when_he_has_readonly_access_to_it(self):
+        url = reverse('test-api:article-detail', args=(self.article_3.id,))
+        self.client.force_authenticate(self.user3)
+        response = self.client.get(url, format='json')
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data['custom_field_1'], 'test value 2')
+
+    def test_user_should_not_see_field_when_he_has_no_access_to_it(self):
+        url = reverse('test-api:article-detail', args=(self.article_1.id,))
+        self.client.force_authenticate(self.user1)
+        response = self.client.get(url, format='json')
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertNotIn('custom_field_1', response.data)
+
+    def test_user_should_update_field_when_he_has_change_access_to_it(self):
+        url = reverse('test-api:article-detail', args=(self.article_1.id,))
+        self.client.force_authenticate(self.user2)
+        data = {'custom_field_1': 'value1'}
+        response = self.client.patch(url, data, format='json')
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.article_1.refresh_from_db()
+        self.assertEqual(self.article_1.custom_field_1, 'value1')
+
+    def test_user_should_not_update_field_when_he_has_readonly_access_to_it(self):  # noqa
+        url = reverse('test-api:article-detail', args=(self.article_3.id,))
+        self.client.force_authenticate(self.user3)
+        data = {'custom_field_1': 'value1'}
+        response = self.client.patch(url, data, format='json')
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.article_3.refresh_from_db()
+        self.assertEqual(self.article_3.custom_field_1, 'test value 2')
+
+    def test_user_should_not_update_field_when_he_has_no_access_to_it(self):
+        url = reverse('test-api:article-detail', args=(self.article_1.id,))
+        self.client.force_authenticate(self.user1)
+        data = {'custom_field_1': 'value1'}
+        response = self.client.patch(url, data, format='json')
+        # notice that this field is silently ignored for this user (as any
+        # passed value which is not serializer (model) field)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.article_1.refresh_from_db()
+        self.assertEqual(self.article_1.custom_field_1, 'test value')

--- a/src/ralph/lib/permissions/tests/test_permissions_per_object.py
+++ b/src/ralph/lib/permissions/tests/test_permissions_per_object.py
@@ -5,6 +5,7 @@ from django.contrib.auth import get_user_model
 from django.test import TestCase
 
 from ralph.lib.permissions.admin import PermissionsPerObjectFormMixin
+from ralph.lib.permissions.tests._base import PermissionsTestMixin
 from ralph.lib.permissions.tests.models import (
     Article,
     Library,
@@ -73,45 +74,8 @@ class TestUserPermissions(TestCase):
         )
 
 
-class PermissionsPerObjectTestMixin(object):
-    def _create_users_and_articles(self):
-        self.user1 = get_user_model().objects.create(username='user1')
-        self.user2 = get_user_model().objects.create(username='user2')
-        self.user3 = get_user_model().objects.create(username='user3')
-        self.superuser = get_user_model().objects.create(
-            username='superuser', is_superuser=True
-        )
-
-        # create two articles for each user
-        self.article_1 = Article.objects.create(
-            author=self.user1,
-            title='1',
-            content='1'*10,
-        )
-        self.article_2 = Article.objects.create(
-            author=self.user2,
-            title='1',
-            content='1'*10,
-        )
-
-        # create group article
-        self.article_1.collaborators.add(self.user2)
-
-        # create article with long title
-        self.long_article = LongArticle.objects.create(
-            author=self.user1,
-            title='####### long article ########',
-            content='lorem ipsum'
-        )
-        self.long_article_2 = LongArticle.objects.create(
-            author=self.user1,
-            title='short',
-            content='lorem ipsum'
-        )
-
-
 @ddt
-class TestPermissionsPerObject(PermissionsPerObjectTestMixin, TestCase):
+class TestPermissionsPerObject(PermissionsTestMixin, TestCase):
     def setUp(self):
         self._create_users_and_articles()
 
@@ -179,7 +143,7 @@ class TestPermissionsPerObject(PermissionsPerObjectTestMixin, TestCase):
         )
 
 
-class TestPermissionsPerObjectForm(PermissionsPerObjectTestMixin, TestCase):
+class TestPermissionsPerObjectForm(PermissionsTestMixin, TestCase):
     class SampleForm(PermissionsPerObjectFormMixin, forms.ModelForm):
         class Meta:
             model = Library

--- a/src/ralph/settings/base.py
+++ b/src/ralph/settings/base.py
@@ -49,6 +49,7 @@ MIDDLEWARE_CLASSES = (
 )
 
 ROOT_URLCONF = 'ralph.urls'
+URLCONF_MODULES = [ROOT_URLCONF]
 
 TEMPLATES = [
     {
@@ -142,5 +143,16 @@ LOGGING = {
 }
 
 REST_FRAMEWORK = {
-    'PAGE_SIZE': 10
+    'DEFAULT_AUTHENTICATION_CLASSES': (
+        'rest_framework.authentication.BasicAuthentication',
+        'rest_framework.authentication.SessionAuthentication',
+    ),
+    'DEFAULT_PERMISSION_CLASSES': (
+        'ralph.api.permissions.RalphPermission',
+    ),
+    'DEFAULT_FILTER_BACKENDS': (
+        'ralph.lib.permissions.api.PermissionsForObjectFilter',
+    ),
+    'DEFAULT_PAGINATION_CLASS': 'rest_framework.pagination.LimitOffsetPagination',  # noqa
+    'PAGE_SIZE': 10,
 }

--- a/src/ralph/settings/dev.py
+++ b/src/ralph/settings/dev.py
@@ -25,3 +25,10 @@ ROOT_URLCONF = 'ralph.urls.dev'
 # Disable exception for the missing element in SiteTree
 # https://github.com/idlesign/django-sitetree/pull/157/files
 RAISE_ITEMS_ERRORS_ON_DEBUG = False
+
+
+LOGGING['loggers']['ralph'] = {
+    'handlers': ['console'],
+    'level': 'DEBUG',
+    'propagate': True,
+}

--- a/src/ralph/settings/prod.py
+++ b/src/ralph/settings/prod.py
@@ -6,3 +6,6 @@ STATIC_ROOT = os.path.join(BASE_DIR, 'var', 'static')
 # FIXME: when going for full production, change it to False
 
 DEBUG = True
+REST_FRAMEWORK['DEFAULT_AUTHENTICATION_CLASSES'] = (
+    'rest_framework.authentication.TokenAuthentication',
+)

--- a/src/ralph/settings/test.py
+++ b/src/ralph/settings/test.py
@@ -23,4 +23,7 @@ PASSWORD_HASHERS = (
 
 STATICFILES_STORAGE = 'django.contrib.staticfiles.storage.StaticFilesStorage'
 
-ROOT_URLCONF = 'ralph.urls.base'
+ROOT_URLCONF = 'ralph.urls.test'
+# specify all url modules to reload during specific tests
+# see `ralph.tests.mixins.ReloadUrlsMixin` for details
+URLCONF_MODULES = ['ralph.urls.base', ROOT_URLCONF]

--- a/src/ralph/supports/api.py
+++ b/src/ralph/supports/api.py
@@ -1,0 +1,17 @@
+# -*- coding: utf-8 -*-
+from ralph.api import RalphAPISerializer, RalphAPIViewSet, router
+from ralph.supports.models import Support
+
+
+class SupportSerializer(RalphAPISerializer):
+    class Meta:
+        model = Support
+
+
+class SupportViewSet(RalphAPIViewSet):
+    queryset = Support.objects.all()
+    serializer_class = SupportSerializer
+
+
+router.register(r'supports', SupportViewSet)
+urlpatterns = []

--- a/src/ralph/tests/mixins.py
+++ b/src/ralph/tests/mixins.py
@@ -26,7 +26,19 @@ class ReloadUrlsMixin(object):
     Use this mixin if you register dynamically models to admin.
     """
     def reload_urls(self):
-        if settings.ROOT_URLCONF in sys.modules:
-            reload(sys.modules[settings.ROOT_URLCONF])
-            clear_url_caches()
-        return import_module(settings.ROOT_URLCONF)
+        """
+        Reload all url configs specified in `URLCONF_MODULES` list in settings.
+
+        If there are specific urls for testing, then it's not enough to reload
+        only this module, because it's basically (usually) just import main
+        urls (including admin urls), which will not be reloaded in only
+        ROOT_URLCONF module will be reloaded, thus on that list should be every
+        module (spcific, not general module which is proxy to another one, such
+        as __init__) which should be reloaded to get fully functional up-to-date
+        urls.
+        """
+        clear_url_caches()
+        for urlconf in settings.URLCONF_MODULES:
+            if urlconf in sys.modules:
+                reload(sys.modules[urlconf])
+                import_module(urlconf)

--- a/src/ralph/urls/base.py
+++ b/src/ralph/urls/base.py
@@ -1,11 +1,25 @@
 from django.conf.urls import include, url
 
 from ralph.admin import ralph_site as admin
+from ralph.api import router
+
+# import custom urls from each api module
+# notice that each module should have `urlpatters` variable defined
+# (as empty list if there is any custom url)
+api_urls = list(map(lambda u: url(r'^', include(u)), [
+    'ralph.data_center.urls.api',
+    'ralph.dc_view.urls.api',
+    'ralph.supports.api',
+]))
+# include router urls
+# because we're using single router instance and urls are cached inside this
+# object, router.urls may be called after all urls are processed (and all
+# api views are registered in router)
+api_urls += [url(r'^', include(router.urls))]
 
 urlpatterns = [
     url(r'^', include(admin.urls)),
-    url(r'^api/', include('ralph.dc_view.urls.api')),
-    url(r'^api/', include('ralph.data_center.urls.api')),
+    url(r'^api/', include(api_urls)),
     url(r'^', include('ralph.dc_view.urls.ui')),
     url(r'^', include('ralph.reports.urls')),
 ]

--- a/src/ralph/urls/test.py
+++ b/src/ralph/urls/test.py
@@ -1,0 +1,12 @@
+# -*- coding: utf-8 -*-
+from django.conf.urls import include, url
+
+from ralph.api.tests import api as ralph_api
+from ralph.lib.permissions.tests import api as lib_api
+from ralph.urls.base import urlpatterns as base_urlpatterns
+
+urlpatterns = base_urlpatterns
+urlpatterns += [
+    url(r'^', include(lib_api.urlpatterns)),
+    url(r'^', include(ralph_api.urlpatterns)),
+]


### PR DESCRIPTION
Connected to #1452 

API base classes/mixins:
- permissions per object (on list, on single objects, for related objects in object details)
- permissions per field (both readonly and change fields)
- custom router (hide models for which user doesn't have permissions)
- `ReversedChoiceField` - better handling `dj.choices.Choices` fields in API
- improved API urls handling

Permissions mechanism fixes:
- allow to specify permissions for M2M fields too
- fixed permissions per object with inheritance (the same check in Q was repeated multiple times, with many tautologies (empty Q())

TODO: 
- [x] move permissions parts from `ralph.api` to `ralph.permissions.api`
- [x] add unit tests
- [x] add docstrings everywhere
