### PR TITLE
Thousands separator missing

### DIFF
--- a/src/ralph/reports/templates/reports/report_tree.html
+++ b/src/ralph/reports/templates/reports/report_tree.html
@@ -1,13 +1,14 @@
+{% load humanize %}
 <li class="accordion-navigation">
   <a href="#{{ node.uid }}">
-    {{ node.name }} <span class="right">{{ node.count }}</span>
+    {{ node.name }} <span class="right">{{ node.count|intcomma }}</span>
   </a>
   <div id="{{ node.uid }}" class="content">
     <div class="row">
       <div class="small-12 columns">
         {{ node.name }}
         <span class="right">
-          {{ node.count }}
+          {{ node.count|intcomma }}
         </span>
         {% if node.children %}
           {% for ch in node.children %}

--- a/src/ralph/settings/base.py
+++ b/src/ralph/settings/base.py
@@ -18,6 +18,7 @@ INSTALLED_APPS = (
     'django.contrib.admin',
     'django.contrib.auth',
     'django.contrib.contenttypes',
+    'django.contrib.humanize',
     'django.contrib.sessions',
     'django.contrib.messages',
     'django.contrib.staticfiles',


### PR DESCRIPTION
Fixed thousand separator in reports view.

Connected to #1685 
