### PR TITLE
Timeouts and multiple priv protocol in discovery/snmp.py

### DIFF
--- a/src/ralph/scan/snmp.py
+++ b/src/ralph/scan/snmp.py
@@ -10,7 +10,6 @@ from __future__ import print_function
 from __future__ import unicode_literals
 
 from django.conf import settings
-from pysnmp.entity.rfc3413.oneliner import cmdgen
 
 from ralph.discovery.snmp import snmp_command, check_snmp_port
 
@@ -23,21 +22,14 @@ SNMP_V3_AUTH = (
 )
 if not all(SNMP_V3_AUTH):
     SNMP_V3_AUTH = None
-PRIV_PROTOCOLS = (
-    cmdgen.usmDESPrivProtocol,
-    cmdgen.usmAesCfb128Protocol,
-    cmdgen.usmAesCfb192Protocol,
-    cmdgen.usmAesCfb256Protocol,
-)
 
 
 def _snmp(
-    ip, community, oid, attempts=2, timeout=3, snmp_version='2c',
-    priv_protocol=cmdgen.usmDESPrivProtocol
+    ip, community, oid, attempts=2, timeout=3, snmp_version='2c'
 ):
     result = snmp_command(
         str(ip), community, oid, attempts=attempts, timeout=timeout,
-        snmp_version=snmp_version, priv_protocol=priv_protocol,
+        snmp_version=snmp_version,
     )
     if result is None:
         message = None
@@ -93,18 +85,16 @@ def get_snmp(ipaddress):
                 return message, community, version
     if SNMP_V3_AUTH:
         version = '3'
-        for priv_protocol in PRIV_PROTOCOLS:
-            message = _snmp(
-                ipaddress.address,
-                SNMP_V3_AUTH,
-                oid,
-                attempts=2,
-                timeout=2,  # SNMP v3 usually needs more time
-                snmp_version=version,
-                priv_protocol=priv_protocol,
-            )
-            if message:
-                return message, community, version
+        message = _snmp(
+            ipaddress.address,
+            SNMP_V3_AUTH,
+            oid,
+            attempts=2,
+            timeout=2,  # SNMP v3 usually needs more time
+            snmp_version=version,
+        )
+        if message:
+            return message, community, version
     if not message:
         return None, None, None
     return message, community, version


### PR DESCRIPTION
Adding higher timeout (2 seconds) to every snmp function for properly
work with SNMPv3. Creating loop in snmp_command, snmp_bulk, snmp_walk
to get data from devices with different priv protocol.
