### PR TITLE
API improvements

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -1,0 +1,124 @@
+# Ralph API consumption
+
+Ralph exposes many resources and operation through REST-ful WEB API that can be used both for querying the database and populating it with data. Ralph API use
+[Django Rest Framework](http://www.django-rest-framework.org/) under the hood, so
+every topic related to it should work in Ralph API as well.
+
+## Authentication
+
+`TODO when token authentication will be included (https://github.com/allegro/ralph/issues/1735).`
+
+## Output format
+
+Ralph API supports JSON output format (by default) and HTML preview in your browser (go to http://<YOUR-RALPH-URL>/api/ to see preview).
+
+## Available resources
+
+`work in progress`
+
+## HTTP methods
+
+The following methods can be used in the API. Consult the API reference of
+specific module for more precise explanation.
+
+| Method | On a collection                  | On a single resource
+|--------|----------------------------------|--------------------------------
+| GET    | Get full list of resources       | Get resource details
+| POST   | Add a new resource               | -
+| PUT    | -                                | Edit the resource (you need to provide all data)
+| PATCH  | -                                | Edit the resource (you only need to provide changed data)
+| DELETE | -                                | Remove the resource
+
+
+## Get sample resource
+
+Use HTTP GET method to get details of the resource. Example:
+
+`curl http://127.0.0.1:8000/api/data-center-assets/1/ | python -m json.tool`
+
+results in:
+
+```JSON
+{
+    "id": 11105,
+    "url": "http://127.0.0.1:8000/api/data-center-assets/1/",
+    "hostname": "aws-proxy-1.my-dc",
+    "status": "used",
+    "sn": "12345",
+    "barcode": "54321",
+    "price": "55500.00",
+    "remarks": "Used as proxy to AWS",
+    "position": 12,
+    "orientation": "front",
+    "configuration_path": "/aws_proxy/prod",
+    "service_env": {
+        "id": 11,
+        "url": "http://127.0.0.1:8000/api/service-environments/11/",
+        "service": {
+            "id": 1,
+            "url": "http://127.0.0.1:8000/api/services/1/",
+            "name": "AWS Proxy",
+            ...
+        },
+        "environment": {
+            "id": 2,
+            "url": "http://127.0.0.1:8000/api/environments/2/",
+            "name": "prod",
+        }
+    }
+    },
+    "model": {
+        "id": 168,
+        "url": "http://127.0.0.1:8000/api/asset-models/168/",
+        "name": "R630",
+        "type": "data_center",
+        "power_consumption": 1234,
+        "height_of_device": 1.0,
+        "cores_count": 8,
+        "has_parent": false,
+        "manufacturer": {
+            "id": 33,
+            "url": "http://127.0.0.1:8000/api/manufacturers/33/",
+            "name": "Dell",
+            ...
+        },
+        ...
+    },
+    "rack": {
+        "id": 15,
+        "url": "http://127.0.0.1:8000/api/racks/15/",
+        "name": "Rack 123",
+        "server_room": {
+            "id": 1,
+            "url": "http://127.0.0.1:8000/api/server-rooms/1/",
+            "name": "Room 1",
+            "data_center": {
+                "id": 99,
+                "url": "http://127.0.0.1:8000/api/data-centers/99/",
+                "name": "New York",
+            }
+        },
+        ...
+    },
+    ...
+}
+```
+
+Part of response was skipped for readability.
+
+## Save sample resource
+
+PATCH data center asset with data:
+```JSON
+{
+    "hostname": "aws-proxy-2.my-dc",
+    "status": "damaged",
+    "service_env": 12,
+    "licences": [1, 2, 3]
+}
+```
+
+Notice in this example that:
+* to set related object (not-simple, like string or number) just pass it's ID (see service_env)
+* to set many of related objects, pass IDs of them in list (see licences)
+* you could pass text value for choice fields (status), even if it's stored as number

--- a/docs/development/api.md
+++ b/docs/development/api.md
@@ -1,0 +1,45 @@
+# Ralph API resources
+
+## How to create new API resource based on Django model
+
+```django
+# model
+from django.db import models
+
+class Foo(model.Model):
+    bar = models.CharField(max_length=10)
+
+
+# API
+from ralph.api import RalphAPISerializer, RalphAPIViewSet, router
+
+
+class FooSerializer(RalphAPISerializer):
+    class Meta:
+        model = Foo
+
+
+class FooViewSet(RalphAPIViewSet):
+    queryset = Foo.objects.all()
+    serializer_class = FooSerializer
+
+
+# use Ralph router instance to register new viewset
+router.register(r'foos', FooViewSet)
+```
+
+## What are built-in features of Ralph API classes?
+
+### `RalphAPISerializer`
+* include both object PK and its url (see `ralph.api.serializers.RalphAPISerializer.get_default_field_names` for details).
+* every sub-serializer (even instantiated directly as a field in other serializer) have current context set.
+* use `ralph.api.serializers.ReversedChoiceField` for all choice fields - this serializer allow to pass value by name instead of key. Additionally it present value in user-friendly format by-name. This field works perfectly with `dj.choices.Choices`.
+* include permissions per field checking using `ralph.lib.permissions.api.PermissionsPerFieldSerializerMixin` - only fields to which user has access will be returned. This field also handle view-only permission as read-only field.
+* include permission validation on object level for related fields - if related field model use permissions for object, then only objects to which user has access could be selected/displayed in related field.
+
+
+### `RalphAPIViewSet`
+* default serializer for save actions (POST, PUT, PATCH) in which every relation will be serialized using `rest_framework.serializers.PrimaryKeyRelatedField` (so user should specify object PK in relation field). This serializer could be overwritten using `save_serializer_class` attribute in `RalphAPIViewSet`.
+* include `ralph.api.utils.QuerysetRelatedMixin` which can easily handle select_related and prefetch_related on queryset. By default select_related is fill with related admin site list_select_related value.
+* include `ralph.api.viewsets.AdminSearchFieldsMixin` thanks to which search fields will be by default taken from related admin site.
+* include `ralph.api.permissions.RalphPermission`, which check if user is properly authenticated (through `IsAuthenticated`), user has access to object (through `ObjectPermissionsMixin`) and user has proper Django admin permissions (`add_*`, `change_*`, `delete_*`) requested model.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -6,6 +6,7 @@ pages:
       - Installation: installation.md
       - Migration from Ralph 2.x: data_migration.md
       - Transitions: transitions.md
+      - API: api.md
   - Developer guide:
       - Before you start: CONTRIBUTING.md
       - Architecture: development/overview.md

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,6 +1,7 @@
 Django==1.8.4
 dj.choices==0.10.0
 django-extensions==1.5.5
+django-filter==0.11.0
 django-import-export==0.2.7
 django-mptt==0.7.4
 django-reversion==1.8.6

--- a/src/ralph/api/relations.py
+++ b/src/ralph/api/relations.py
@@ -1,0 +1,14 @@
+from rest_framework import relations
+
+from ralph.api.utils import QuerysetRelatedMixin
+
+
+class RalphRelatedField(QuerysetRelatedMixin, relations.PrimaryKeyRelatedField):
+    pass
+
+
+class RalphHyperlinkedRelatedField(
+    QuerysetRelatedMixin,
+    relations.HyperlinkedRelatedField
+):
+    pass

--- a/src/ralph/api/serializers.py
+++ b/src/ralph/api/serializers.py
@@ -2,8 +2,9 @@
 import logging
 from collections import OrderedDict
 
-from rest_framework import serializers
+from rest_framework import permissions, serializers
 
+from ralph.api.relations import RalphHyperlinkedRelatedField, RalphRelatedField
 from ralph.lib.permissions.api import (
     PermissionsPerFieldSerializerMixin,
     RelatedObjectsPermissionsSerializerMixin
@@ -31,7 +32,10 @@ class ReversedChoiceField(serializers.ChoiceField):
         """
         Return choice name (value) instead of default key.
         """
-        return self.choices[obj]
+        try:
+            return self.choices[obj]
+        except KeyError:
+            return super().to_representation(obj)
 
     def to_internal_value(self, data):
         """
@@ -56,17 +60,77 @@ class RalphAPISerializerMixin(
         * handling field-level permissions (through
           `PermissionsPerFieldSerializerMixin`)
         * use `ReversedChoiceField` as default serializer for choice field
-        * request and user object easily accessible in serializer
+        * request and user object easily accessible in each related serializer
     """
     serializer_choice_field = ReversedChoiceField
-    # turn if on when all models are linked
-    # serializer_related_field = serializers.HyperlinkedRelatedField
 
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self._request = self.context['request']
-        self._user = self._request.user
+    @property
+    def serializer_related_field(self):
+        """
+        When it's safe request (ex. GET), related serailizer is hyperlinked
+        (contains url to related object). When it's not safe request (ex. POST),
+        serializer expect to pass only PK for related object.
+        """
+        if self.context['request'].method in permissions.SAFE_METHODS:
+            return RalphHyperlinkedRelatedField
+        return RalphRelatedField
+
+    def get_default_field_names(self, declared_fields, model_info):
+        """
+        Return the default list of field names that will be used if the
+        `Meta.fields` option is not specified.
+
+        Add additional pk field at the beginning of fields list (it's not
+        included in `rest_framework.serializers.HyperlinkedModelSerializer`
+        by default).
+        """
+        return (
+            [model_info.pk.name] +
+            super().get_default_field_names(declared_fields, model_info)
+        )
+
+    def get_fields(self, *args, **kwargs):
+        """
+        Bind every returned field to self (as a parent)
+        """
+        fields = super().get_fields(*args, **kwargs)
+        # assign parent to every field as self
+        for field_name, field in fields.items():
+            if not field.parent:
+                field.parent = self
+        return fields
+
+    def build_field(self, field_name, info, model_class, nested_depth):
+        """
+        Attach context with request to every nested field which is another
+        serializer.
+        """
+        field_class, field_kwargs = super().build_field(
+            field_name, info, model_class, nested_depth
+        )
+        if issubclass(field_class, serializers.BaseSerializer):
+            field_kwargs.setdefault('context', {})['request'] = (
+                self.context.get('request')
+            )
+        return field_class, field_kwargs
+
+    def build_nested_field(self, field_name, relation_info, nested_depth):
+        """
+        Nested serializer is inheriting from `RalphAPISerializer`.
+        """
+        class NestedSerializer(RalphAPISerializer):
+            class Meta:
+                model = relation_info.related_model
+                depth = nested_depth - 1
+        field_class, field_kwargs = super().build_nested_field(
+            field_name, relation_info, nested_depth
+        )
+        field_class = NestedSerializer
+        return field_class, field_kwargs
 
 
-class RalphAPISerializer(RalphAPISerializerMixin, serializers.ModelSerializer):
+class RalphAPISerializer(
+    RalphAPISerializerMixin,
+    serializers.HyperlinkedModelSerializer
+):
     pass

--- a/src/ralph/api/tests/_base.py
+++ b/src/ralph/api/tests/_base.py
@@ -2,6 +2,7 @@
 from django.contrib.auth import get_user_model
 from django.contrib.auth.models import Permission
 from django.contrib.contenttypes.models import ContentType
+from rest_framework.test import APITestCase
 
 from ralph.tests.models import Foo
 
@@ -35,3 +36,36 @@ class APIPermissionsTestMixin(object):
         add_perm(cls.user1, 'delete_foo')
         add_perm(cls.user2, 'add_foo')
         add_perm(cls.user_not_staff, 'change_foo')
+
+
+class RalphAPITestCase(APITestCase):
+    """
+    Base test for Ralph API Test Case.
+
+    By default there are some users created.
+    """
+    @classmethod
+    def _create_users(cls):
+        def create_user(name, **kwargs):
+            params = dict(
+                username=name,
+                is_staff=True,
+                is_active=True,
+            )
+            params.update(kwargs)
+            return get_user_model().objects.create(**params)
+
+        cls.user1 = create_user('user1')
+        cls.user2 = create_user('user2')
+        cls.superuser = create_user(
+            'superuser', is_staff=True, is_superuser=True
+        )
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls._create_users()
+
+    def setUp(self):
+        super().setUp()
+        self.client.force_authenticate(self.superuser)

--- a/src/ralph/api/tests/api.py
+++ b/src/ralph/api/tests/api.py
@@ -3,20 +3,73 @@ from django.conf.urls import include, url
 
 from ralph.api import RalphAPISerializer, RalphAPIViewSet
 from ralph.api.routers import RalphRouter
-from ralph.tests.models import Foo
+from ralph.tests.models import Car, Foo, Manufacturer
 
 
 class FooSerializer(RalphAPISerializer):
     class Meta:
         model = Foo
+        # include view namespace for hyperlinked field
+        extra_kwargs = {
+            'url': {
+                'view_name': 'test-ralph-api:foo-detail'
+            }
+        }
+
+
+class ManufacturerSerializer(RalphAPISerializer):
+    class Meta:
+        model = Manufacturer
+        # include view namespace for hyperlinked field
+        extra_kwargs = {
+            'url': {
+                'view_name': 'test-ralph-api:manufacturer-detail'
+            }
+        }
+
+
+class ManufacturerSerializer2(ManufacturerSerializer):
+    def validate_name(self, value):
+        return value
+
+
+class CarSerializer(RalphAPISerializer):
+    class Meta:
+        model = Car
+        # include view namespace for hyperlinked field
+        extra_kwargs = {
+            'url': {
+                'view_name': 'test-ralph-api:car-detail'
+            }
+        }
+        depth = 1
+
+
+class CarSerializer2(CarSerializer):
+    manufacturer = ManufacturerSerializer2()
 
 
 class FooViewSet(RalphAPIViewSet):
     queryset = Foo.objects.all()
     serializer_class = FooSerializer
 
+
+class ManufacturerViewSet(RalphAPIViewSet):
+    queryset = Manufacturer.objects.all()
+    serializer_class = ManufacturerSerializer
+    save_serializer_class = ManufacturerSerializer2
+
+
+class CarViewSet(RalphAPIViewSet):
+    queryset = Car.objects.all()
+    serializer_class = CarSerializer
+    filter_fields = ['manufacturer__name']
+
+
 router = RalphRouter()
 router.register(r'foos', FooViewSet)
+router.register(r'manufacturers', ManufacturerViewSet)
+router.register(r'cars', CarViewSet)
 urlpatterns = [
     url(r'^test-ralph-api/', include(router.urls, namespace='test-ralph-api')),
 ]

--- a/src/ralph/api/tests/test_serializers.py
+++ b/src/ralph/api/tests/test_serializers.py
@@ -3,9 +3,14 @@ from collections import OrderedDict
 
 from dj.choices import Choices
 from rest_framework.exceptions import ValidationError
+from rest_framework.test import APIRequestFactory
 
+from ralph.api.relations import RalphHyperlinkedRelatedField, RalphRelatedField
 from ralph.api.serializers import ReversedChoiceField
+from ralph.api.tests._base import RalphAPITestCase
+from ralph.api.tests.api import CarSerializer, CarSerializer2
 from ralph.tests import RalphTestCase
+from ralph.tests.models import Car, Manufacturer
 
 
 class TestChoices(Choices):
@@ -43,3 +48,50 @@ class TestReversedChoiceField(RalphTestCase):
     def test_to_internal_value_with_choice_not_found_should_raise_validation_error(self):  # noqa
         with self.assertRaises(ValidationError):
             self.reversed_choice_field.to_internal_value('foo33')
+
+
+class TestRalphSerializer(RalphAPITestCase):
+    def setUp(self):
+        self.manufacturer = Manufacturer(name="Tesla", country="USA")
+        self.car = Car(manufacturer=self.manufacturer, name="S", year=2012)
+        self.request_factory = APIRequestFactory()
+
+    def test_get_serializer_related_field_when_safe_request(self):
+        request = self.request_factory.get('/api/cars')
+        car_serializer = CarSerializer(
+            instance=self.car, context={'request': request}
+        )
+        self.assertEqual(
+            car_serializer.serializer_related_field,
+            RalphHyperlinkedRelatedField
+        )
+
+    def test_get_serializer_related_field_when_not_safe_request(self):
+        request = self.request_factory.patch('/api/cars', data={})
+        car_serializer = CarSerializer(
+            instance=self.car, context={'request': request}
+        )
+        self.assertEqual(
+            car_serializer.serializer_related_field,
+            RalphRelatedField
+        )
+
+    def test_serializer_request_assigned_to_related_field(self):
+        request = self.request_factory.patch('/api/cars', data={})
+        request.user = self.user1
+        car_serializer = CarSerializer(
+            instance=self.car, context={'request': request}
+        )
+        fields = car_serializer.get_fields()
+        self.assertIs(fields['year'].context['request'], request)
+        self.assertIs(fields['manufacturer'].context['request'], request)
+
+    def test_serializer_request_assigned_to_related_declared_field(self):
+        request = self.request_factory.patch('/api/cars', data={})
+        request.user = self.user1
+        car_serializer = CarSerializer2(
+            instance=self.car, context={'request': request}
+        )
+        fields = car_serializer.get_fields()
+        self.assertIs(fields['year'].context['request'], request)
+        self.assertIs(fields['manufacturer'].context['request'], request)

--- a/src/ralph/api/tests/test_viewsets.py
+++ b/src/ralph/api/tests/test_viewsets.py
@@ -1,4 +1,15 @@
 # -*- coding: utf-8 -*-
+from rest_framework import relations
+from rest_framework.test import APIRequestFactory
+
+from ralph.api.serializers import ReversedChoiceField
+from ralph.api.tests.api import (
+    Car,
+    CarSerializer,
+    CarViewSet,
+    ManufacturerSerializer2,
+    ManufacturerViewSet
+)
 from ralph.api.viewsets import RalphAPIViewSet
 from ralph.tests import RalphTestCase
 
@@ -12,6 +23,10 @@ class ViewsetWithoutPermissionsForObjectFilter(RalphAPIViewSet):
 
 
 class TestRalphViewset(RalphTestCase):
+    def setUp(self):
+        super().setUp()
+        self.request_factory = APIRequestFactory()
+
     def test_should_raise_attributeerror_when_ralph_permission_missing(self):
         with self.assertRaises(AttributeError):
             ViewsetWithoutRalphPermission()
@@ -19,3 +34,39 @@ class TestRalphViewset(RalphTestCase):
     def test_should_raise_attributeerror_when_permission_for_object_filter_missing(self):  # noqa
         with self.assertRaises(AttributeError):
             ViewsetWithoutPermissionsForObjectFilter()
+
+    def test_get_serializer_class_should_return_base_when_safe_request(self):
+        request = self.request_factory.get('/')
+        cvs = CarViewSet()
+        cvs.request = request
+        self.assertEqual(cvs.get_serializer_class(), CarSerializer)
+
+    def test_get_serializer_class_should_return_dynamic_when_not_safe_request(self):  # noqa
+        request = self.request_factory.post('/')
+        cvs = CarViewSet()
+        cvs.request = request
+        serializer_class = cvs.get_serializer_class()
+        self.assertEqual(serializer_class.__name__, 'CarSaveSerializer')
+        self.assertEqual(serializer_class.Meta.model, Car)
+        self.assertEqual(serializer_class.Meta.depth, 0)
+        self.assertEqual(
+            serializer_class.serializer_choice_field, ReversedChoiceField
+        )
+        self.assertEqual(
+            serializer_class.serializer_related_field,
+            relations.PrimaryKeyRelatedField
+        )
+
+    def test_get_serializer_class_should_return_defined_when_not_safe_request_and_save_serializer_class_defined(self):  # noqa
+        request = self.request_factory.patch('/')
+        mvs = ManufacturerViewSet()
+        mvs.request = request
+        self.assertEqual(mvs.get_serializer_class(), ManufacturerSerializer2)
+
+
+class TestAdminSearchFieldsMixin(RalphTestCase):
+    def test_get_filter_fields_from_admin(self):
+        cvs = CarViewSet()
+        self.assertEqual(
+            cvs.filter_fields, ['manufacturer__name', 'year', 'name']
+        )

--- a/src/ralph/api/utils.py
+++ b/src/ralph/api/utils.py
@@ -1,0 +1,28 @@
+from ralph.admin.sites import ralph_site
+
+
+class QuerysetRelatedMixin(object):
+    """
+    Allow to specify select_related and prefetch_related for queryset.
+
+    Default select_related is taken from related admin site
+    `list_select_related` attribute.
+    """
+    select_related = None
+    prefetch_related = None
+    _skip_admin_list_select_related = False
+
+    def get_queryset(self):
+        queryset = super().get_queryset()
+        admin_site = ralph_site._registry.get(queryset.model)
+        if self.select_related:
+            queryset = queryset.select_related(*self.select_related)
+        if self.prefetch_related:
+            queryset = queryset.prefetch_related(*self.prefetch_related)
+        if (
+            admin_site and
+            not self._skip_admin_list_select_related and
+            admin_site.list_select_related
+        ):
+            queryset = queryset.select_related(*admin_site.list_select_related)
+        return queryset

--- a/src/ralph/api/viewsets.py
+++ b/src/ralph/api/viewsets.py
@@ -1,17 +1,59 @@
 # -*- coding: utf-8 -*-
-from rest_framework import viewsets
+import inspect
 
+from django.contrib.admin import SimpleListFilter
+from rest_framework import (
+    filters,
+    permissions,
+    relations,
+    serializers,
+    viewsets
+)
+
+from ralph.admin.sites import ralph_site
 from ralph.api.permissions import RalphPermission
+from ralph.api.serializers import ReversedChoiceField
+from ralph.api.utils import QuerysetRelatedMixin
 from ralph.lib.permissions.api import PermissionsForObjectFilter
 
 
-class RalphAPIViewSetMixin(object):
+class AdminSearchFieldsMixin(object):
+    """
+    Default `filter_fields` ViewSet are search and filter fields from model's
+    related admin site.
+    """
+    _skip_admin_search_fields = False
+    _skip_admin_list_filter = False
+    filter_backends = [filters.DjangoFilterBackend]
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._set_admin_search_fields()
+
+    def _set_admin_search_fields(self):
+        admin_site = ralph_site._registry.get(self.queryset.model)
+        filter_fields = getattr(self, 'filter_fields', None) or []
+        if admin_site and not self._skip_admin_search_fields:
+            filter_fields.extend(admin_site.search_fields or [])
+        if admin_site and not self._skip_admin_list_filter:
+            for f in admin_site.list_filter or []:
+                f_name = f
+                if inspect.isclass(f) and issubclass(f, SimpleListFilter):
+                    f_name = f.parameter_name
+                filter_fields.append(f_name)
+        setattr(self, 'filter_fields', filter_fields)
+
+
+class RalphAPIViewSetMixin(QuerysetRelatedMixin, AdminSearchFieldsMixin):
     """
     Ralph API default viewset. Provides object-level permissions checking and
     model permissions checking (using Django-admin permissions).
     """
-    filter_backends = [PermissionsForObjectFilter]
+    filter_backends = AdminSearchFieldsMixin.filter_backends + [
+        PermissionsForObjectFilter, filters.OrderingFilter
+    ]
     permission_classes = [RalphPermission]
+    save_serializer_class = None
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -24,6 +66,36 @@ class RalphAPIViewSetMixin(object):
             raise AttributeError(
                 'PermissionsForObjectFilter missing in filter_backends'
             )
+
+    def get_serializer_class(self):
+        """
+        If it's not safe request (ex. POST) and there is `save_serializer_class`
+        specified, return it, otherwise create default serializer with
+        `PrimaryKeyRelatedField` serializer for related fields.
+
+        If it's safe request, just return regular viewset serializer.
+        """
+        base_serializer = super().get_serializer_class()
+        if self.request.method not in permissions.SAFE_METHODS:
+            if self.save_serializer_class:
+                return self.save_serializer_class
+
+            # create default class for save (POST, PUT etc.) serialization
+            # where every related field is serialized by it's primary key
+            class Meta(base_serializer.Meta):
+                model = self.queryset.model
+                depth = 0
+
+            return type(
+                '{}SaveSerializer'.format(Meta.model.__name__),
+                (serializers.ModelSerializer,),
+                {
+                    'Meta': Meta,
+                    'serializer_choice_field': ReversedChoiceField,
+                    'serializer_related_field': relations.PrimaryKeyRelatedField
+                }
+            )
+        return base_serializer
 
 
 class RalphAPIViewSet(RalphAPIViewSetMixin, viewsets.ModelViewSet):

--- a/src/ralph/lib/permissions/api.py
+++ b/src/ralph/lib/permissions/api.py
@@ -55,7 +55,7 @@ class PermissionsPerFieldSerializerMixin(object):
         DRF nomenclature.
         """
         result = super().get_field_names(declared_fields, model_info)
-        model = model_info.pk.model
+        model = self.Meta.model
         permissioned_fields = set(
             list(model_info.fields.keys()) +
             list(model_info.forward_relations.keys())

--- a/src/ralph/settings/base.py
+++ b/src/ralph/settings/base.py
@@ -92,7 +92,8 @@ DATABASES = {
         'USER': os.environ.get('DB_ENV_MYSQL_USER', 'ralph_ng'),
         'PASSWORD': os.environ.get('DB_ENV_MYSQL_PASSWORD', 'ralph_ng'),
         'HOST': os.environ.get('DB_HOST', '127.0.0.1'),
-        'OPTIONS': MYSQL_OPTIONS
+        'OPTIONS': MYSQL_OPTIONS,
+        'ATOMIC_REQUESTS': True,
     }
 }
 

--- a/src/ralph/settings/test.py
+++ b/src/ralph/settings/test.py
@@ -6,6 +6,7 @@ DATABASES = {
     'default': {
         'ENGINE': 'django.db.backends.sqlite3',
         'NAME': ':memory:',
+        'ATOMIC_REQUESTS': True,
     }
 }
 

--- a/src/ralph/tests/admin.py
+++ b/src/ralph/tests/admin.py
@@ -1,12 +1,19 @@
 # -*- coding: utf-8 -*-
 from ralph.admin import RalphAdmin, register
+from ralph.admin.filters import TextFilter
 from ralph.lib.transitions.admin import TransitionAdminMixin
 from ralph.tests.models import Car, Manufacturer, Order
+
+
+class NameFilter(TextFilter):
+    title = 'name'
+    parameter_name = 'name'
 
 
 @register(Car)
 class CarAdmin(RalphAdmin):
     ordering = ['name']
+    list_filter = ['year', NameFilter]
 
 
 @register(Manufacturer)


### PR DESCRIPTION
Various Ralph API improvements:
- improved serialization for save actions (POST, PUT, PATCH) - from now, there will be default serializer created for save actions, in which every relation will be serialized using `PrimaryKeyRelatedField` (so user should specify object PK in relation field). This serializer could be overwritten using `save_serializer_class` attribute in `RalphAPIViewSet`
- serializer now returns both object PK and its url (see `get_default_field_names` for details)
- improved passing context (request and user) to subserializers - from now every serializer (even instantiated directly as a field in other serializer) will have current request and user set (see `assign_request_and_user` and it's usages for details).
- introduced `QuerysetRelatedMixin` which can easily handle `select_related` and `prefetch_related` on queryset. By default `select_related` is fill with related admin site `list_select_related` value
- new `AdminSearchFieldsMixin` thanks to which search fields will be by default taken from related admin site.

TODO:
- [x] Ralph API guideline (both for user and developer)
- [x] unit tests for new features
