### PR TITLE
Discover additional IP addresses by ssh_linux plugin

### DIFF
--- a/src/ralph/scan/plugins/ssh_linux.py
+++ b/src/ralph/scan/plugins/ssh_linux.py
@@ -90,6 +90,19 @@ def _parse_dmidecode(data):
     return result
 
 
+def _get_ip_addresses(ssh):
+    """Get the IP addresses"""
+
+    stdin, stdout, stderr = ssh.exec_command(
+        "/sbin/ip addr show | /bin/grep 'scope global'",
+    )
+    ip_addresses = set()
+    for line in stdout:
+        ip_address = line.split()[1].split('/')[0]
+        ip_addresses.add(ip_address)
+    return list(ip_addresses)
+
+
 def _get_mac_addresses(ssh):
     """Get the MAC addresses"""
 
@@ -212,9 +225,11 @@ def _get_lldp_info(ssh, messages=[]):
 def _ssh_linux(ssh, ip_address, messages=[]):
     device_info = _get_base_device_info(ssh)
     mac_addresses = _get_mac_addresses(ssh)
+    ip_addresses = _get_ip_addresses(ssh)
+    if ip_addresses:
+        device_info['system_ip_addresses'] = ip_addresses
     if mac_addresses:
         device_info['mac_addresses'] = mac_addresses
-    device_info['system_ip_addresses'] = [ip_address]
     device_info['hostname'] = _get_hostname(ssh)
     disk_shares = _get_disk_shares(ssh)
     if disk_shares:

--- a/src/ralph/scan/tests/plugins/test_ssh_linux.py
+++ b/src/ralph/scan/tests/plugins/test_ssh_linux.py
@@ -13,6 +13,7 @@ from ralph.scan.plugins.ssh_linux import (
     _get_base_device_info,
     _get_disk_shares,
     _get_hostname,
+    _get_ip_addresses,
     _get_mac_addresses,
     _get_os_info,
     _get_os_visible_cores_count,
@@ -22,6 +23,10 @@ from ralph.scan.plugins.ssh_linux import (
 )
 
 
+GET_IP_ADDRESSES_RESULT = """\
+inet 192.168.1.52/24 brd 192.168.1.255 scope global eth0
+inet 192.168.1.54/24 brd 192.168.1.255 scope global secondary eth0:1
+"""
 GET_MAC_ADDRESSES_RESULT = """\
 link/ether c8:2a:14:05:3d:53 brd ff:ff:ff:ff:ff:ff
 link/ether e0:f8:47:24:c9:e6 brd ff:ff:ff:ff:ff:ff
@@ -70,6 +75,18 @@ LogVol01 VolGroup00 -wi-ao   2080.37M
 
 
 class SshLinuxPluginTest(TestCase):
+
+    def test_get_ip_addresses(self):
+        ssh = MockSSH([
+            (
+                "/sbin/ip addr show | /bin/grep 'scope global'",
+                GET_IP_ADDRESSES_RESULT,
+            )
+        ])
+        self.assertItemsEqual(
+            _get_ip_addresses(ssh),
+            ['192.168.1.52', '192.168.1.54'],
+        )
 
     def test_get_mac_addresses(self):
         ssh = MockSSH([


### PR DESCRIPTION
ssh_linux plugin can now discover additional IP addresses on hosts.
