### PR TITLE
Visualization save rack location bugfix

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -4,3 +4,4 @@ indent='    '
 multi_line_output=3
 skip=migrations
 forced_separate=ralph
+order_by_type=False

--- a/src/ralph/dc_view/views/api.py
+++ b/src/ralph/dc_view/views/api.py
@@ -51,14 +51,14 @@ class DCAssetsView(APIView):
 
     def put(self, request, rack_id, format=None):
         serializer = RackSerializer(
-            self.get_object(rack_id), data=request.DATA)
+            self.get_object(rack_id), data=request.data)
         if serializer.is_valid():
-            rack = serializer.update(data=request.DATA)
+            rack = serializer.update(data=request.data)
             return Response(self._get_rack_data(rack))
         return Response(serializer.errors)
 
     def post(self, request, format=None):
-        serializer = RackBaseSerializer(data=request.DATA)
+        serializer = RackBaseSerializer(data=request.data)
         if serializer.is_valid():
             rack = serializer.create(serializer.data)
             return Response(self._get_rack_data(rack))


### PR DESCRIPTION
Exception from Rest Framework:

```
`request.DATA` has been deprecated in favor of `request.data` since version 3.0, and has been fully removed as of version 3.2.
```
