### PR TITLE
Modify catalyst and ssg plugins to prevent hang when scanning host

### DIFF
--- a/src/ralph/scan/plugins/ssh_cisco_catalyst.py
+++ b/src/ralph/scan/plugins/ssh_cisco_catalyst.py
@@ -103,6 +103,9 @@ def scan_address(ip_address, **kwargs):
         raise NoMatchError('Incompatible Juniper found.')
     if 'nx-os' in (kwargs.get('snmp_name', '') or '').lower():
         raise NoMatchError('Incompatible Nexus found.')
+    if 'cisco' not in (kwargs.get('snmp_name', '')
+                       or kwargs.get('http_family', '')).lower():
+        raise NoMatchError('Not a Cisco device')
     if kwargs.get('http_family') not in ('Unspecified', 'Cisco'):
         raise NoMatchError('It is not Cisco.')
     if not SSH_USER or not SSH_PASSWORD:

--- a/src/ralph/scan/plugins/ssh_ssg.py
+++ b/src/ralph/scan/plugins/ssh_ssg.py
@@ -100,8 +100,8 @@ def _ssh_ssg(ip_address, user, password):
 
 
 def scan_address(ip_address, **kwargs):
-    if kwargs.get('http_family') not in ('SSG', 'Unspecified'):
-        raise NoMatchError("It's not a Juniper SSG.")
+    if 'ssg' not in kwargs.get('http_family', '').lower():
+        raise NoMatchError("Incompatible device found.")
     if 'nx-os' in (kwargs.get('snmp_name', '') or '').lower():
         raise NoMatchError("Incompatible Nexus found.")
     user = SETTINGS.get('user')


### PR DESCRIPTION
ssh_ssg and ssh_cisco_catalyst hangs when scanned IP is not assigned to Cisco
device. This fix prevent running plugin when IP belongs to other device then
Cisco.
