### PR TITLE
Added profit center and business segment exporter resources

### DIFF
--- a/src/ralph/export_to_ng/management/commands/export_model.py
+++ b/src/ralph/export_to_ng/management/commands/export_model.py
@@ -24,6 +24,8 @@ NAMESPACE_SIZE = 10
 SIMPLE_MODELS = [
     'AssetLastHostname',
     'Environment',
+    'BusinessSegment',
+    'ProfitCenter',
     'Service',
     'Manufacturer',
     'Category',
@@ -54,8 +56,8 @@ DEPENDENT_MODELS = [
     # new scan handles that: 'DiskShareMount',
     'Licence',
     'Support',
-    'Network',
-    'IPAddress',
+    # to export with core models: 'Network',
+    # to export with core models: 'IPAddress',
 ]
 MANY_TO_MANY = [
     'BaseObjectLicence',


### PR DESCRIPTION
- Added ProfitCenter and BusinessSegment (BusinessLine) exporter resources
- minor fixes in DataCenterAsset resource (not every asset was included, ex. ones with null model category is_blade)
- turned off IPAddress and Network exported - they will be relevant when scan/core functionality are moved to NG 
