### PR TITLE
Fixed status field in reports

### DIFF
--- a/src/ralph/reports/urls.py
+++ b/src/ralph/reports/urls.py
@@ -11,7 +11,7 @@ urlpatterns = [
     ),
     url(
         r'^category_model__status_report/?$',
-        views.ReportDetail.as_view(),
+        views.ReportWithoutAllModeDetail.as_view(),
         name='category_model__status_report'
     ),
     url(
@@ -21,7 +21,7 @@ urlpatterns = [
     ),
     url(
         r'^status_model_report/?$',
-        views.ReportDetail.as_view(),
+        views.ReportWithoutAllModeDetail.as_view(),
         name='status_model_report'
     ),
 ]


### PR DESCRIPTION
In one of transitions commits, status field was moved from `Asset` separately to `DataCenterAsset` and `BackOfficeAsset`. This causes some of reports with status field (for Asset model) to crash. In this commit I turned off 'all' option in 'Category - model - status' and 'Status - model' reports - these reports are now explicit, either in DC mode or BO mode. Default mode is DC.

Conntected to #1745 
