### PR TITLE
Use admin_objects_bo to export all objects to NG (without checking user region)

### DIFF
--- a/src/ralph/export_to_ng/resources.py
+++ b/src/ralph/export_to_ng/resources.py
@@ -84,8 +84,7 @@ class BackOfficeAssetResource(AssetResource):
         model = models_assets.Asset
 
     def get_queryset(self):
-        return self.Meta.model.objects.filter(
-            type=models_assets.AssetType.back_office,
+        return self.Meta.model.admin_objects_bo.filter(
             part_info=None,
         ).select_related('office_info')
 


### PR DESCRIPTION
Regular `objects` manager excluded some of assets during export because there is no user in shell, so default region was assumed for this manager, what causes limiting exported assets only to assets with default region set.
