### PR TITLE
Polymorphic objects in API

### DIFF
--- a/src/ralph/api/serializers.py
+++ b/src/ralph/api/serializers.py
@@ -143,8 +143,22 @@ class RalphAPISaveSerializer(serializers.ModelSerializer):
         return field_class, field_kwargs
 
 
+serializers_registry = {}
+
+
+class RalphAPISerializerMetaclass(serializers.SerializerMetaclass):
+    def __new__(cls, name, bases, attrs):
+        attrs['_serializers_registry'] = serializers_registry
+        new_cls = super().__new__(cls, name, bases, attrs)
+        meta = getattr(new_cls, 'Meta', None)
+        if getattr(meta, 'model', None):
+            serializers_registry[meta.model] = new_cls
+        return new_cls
+
+
 class RalphAPISerializer(
     RalphAPISerializerMixin,
-    serializers.HyperlinkedModelSerializer
+    serializers.HyperlinkedModelSerializer,
+    metaclass=RalphAPISerializerMetaclass
 ):
     pass

--- a/src/ralph/api/utils.py
+++ b/src/ralph/api/utils.py
@@ -1,3 +1,6 @@
+from django.db import models
+from rest_framework import serializers
+
 from ralph.admin.sites import ralph_site
 
 
@@ -13,24 +16,104 @@ class QuerysetRelatedMixin(object):
     _skip_admin_list_select_related = False
 
     def __init__(self, *args, **kwargs):
-        self.select_related = kwargs.pop('select_related', self.select_related)
+        self.select_related = kwargs.pop(
+            'select_related',
+            self.select_related
+        ) or []
         self.prefetch_related = kwargs.pop(
             'prefetch_related', self.prefetch_related
         )
-        kwargs.setdefault('style', {})['base_template'] = 'input.html'
+        if getattr(self, 'queryset', None) is not None:
+            admin_site = ralph_site._registry.get(self.queryset.model)
+            if (
+                admin_site and
+                not self._skip_admin_list_select_related and
+                admin_site.list_select_related
+            ):
+                self.select_related.extend(admin_site.list_select_related)
         super().__init__(*args, **kwargs)
 
     def get_queryset(self):
         queryset = super().get_queryset()
-        admin_site = ralph_site._registry.get(queryset.model)
         if self.select_related:
             queryset = queryset.select_related(*self.select_related)
         if self.prefetch_related:
             queryset = queryset.prefetch_related(*self.prefetch_related)
-        if (
-            admin_site and
-            not self._skip_admin_list_select_related and
-            admin_site.list_select_related
-        ):
-            queryset = queryset.select_related(*admin_site.list_select_related)
         return queryset
+
+
+class PolymorphicViewSetMixin(QuerysetRelatedMixin):
+    """
+    ViewSet for polymorphic models - for each descendant model, dedicated
+    serializer for this model is used. This ViewSet is working together with
+    `PolymorphicSerializer`.
+    """
+    def get_queryset(self):
+        queryset = super().get_queryset()
+        polymorphic_select_related = {}
+        for model, view in self._viewsets_registry.items():
+            if model in queryset.model._polymorphic_descendants:
+                polymorphic_select_related[model._meta.object_name] = (
+                    view.select_related
+                )
+        return queryset.polymorphic_select_related(**polymorphic_select_related)
+
+    def get_serializer(self, *args, **kwargs):
+        serializer_class = self.get_serializer_class()
+        kwargs['context'] = self.get_serializer_context()
+        # for single object use dedicated serializer directly
+        # for many objects, `PolymorphicListSerializer` is used underneath
+        if not kwargs.get('many'):
+            try:
+                serializer_class = serializer_class._serializers_registry[
+                    args[0].__class__
+                ]
+            except KeyError:
+                pass
+        return serializer_class(*args, **kwargs)
+
+
+class PolymorphicListSerializer(serializers.ListSerializer):
+    """
+    List serializer to use with many `Polymorphic` instances.
+    For each instance (model) dedicated `to_representation` of this model
+    serializer is called.
+    """
+    def __init__(self, *args, **kwargs):
+        self.child_serializers = kwargs.pop('child_serializers')
+        return super().__init__(*args, **kwargs)
+
+    def to_representation(self, data):
+        iterable = data.all() if isinstance(data, models.Manager) else data
+        return [
+            self.child_serializers[item.__class__].to_representation(item)
+            for item in iterable
+        ]
+
+
+class PolymorphicSerializer(serializers.Serializer):
+    """
+    Serializer to user with `Polymorphic` model.
+
+    The only difference comparing to regular serializer is case with many
+    objects - instead of `ListSerializer`, `PolymorphicListSerializer` is used.
+    """
+    @classmethod
+    def many_init(cls, *args, **kwargs):
+        child_serializer = cls(*args, **kwargs)
+        # use dedicated model serializer for each possible descendant class
+        # and pass it to list serializer
+        child_serializers = {}
+        for descendant_model in cls.Meta.model._polymorphic_descendants:
+            child_serializers[descendant_model] = cls._serializers_registry.get(
+                descendant_model, cls
+            )(*args, **kwargs)
+        list_kwargs = {
+            'child': child_serializer,
+            'child_serializers': child_serializers,
+        }
+        list_kwargs.update(dict([
+            (key, value) for key, value in kwargs.items()
+            if key in serializers.LIST_SERIALIZER_KWARGS
+        ]))
+        return PolymorphicListSerializer(*args, **list_kwargs)

--- a/src/ralph/api/viewsets.py
+++ b/src/ralph/api/viewsets.py
@@ -94,5 +94,22 @@ class RalphAPIViewSetMixin(QuerysetRelatedMixin, AdminSearchFieldsMixin):
         return base_serializer
 
 
-class RalphAPIViewSet(RalphAPIViewSetMixin, viewsets.ModelViewSet):
+_viewsets_registry = {}
+
+
+class RalphAPIViewSetMetaclass(type):
+    def __new__(cls, name, bases, attrs):
+        attrs['_viewsets_registry'] = _viewsets_registry
+        new_cls = super().__new__(cls, name, bases, attrs)
+        queryset = getattr(new_cls, 'queryset', None)
+        if queryset is not None:  # don't evaluate queryset
+            _viewsets_registry[queryset.model] = new_cls
+        return new_cls
+
+
+class RalphAPIViewSet(
+    RalphAPIViewSetMixin,
+    viewsets.ModelViewSet,
+    metaclass=RalphAPIViewSetMetaclass
+):
     pass

--- a/src/ralph/assets/api/routers.py
+++ b/src/ralph/assets/api/routers.py
@@ -1,6 +1,7 @@
 from ralph.api import router
 from ralph.assets.api.views import (
     AssetModelViewSet,
+    BaseObjectViewSet,
     BusinessSegmentViewSet,
     CategoryViewSet,
     EnvironmentViewSet,
@@ -11,6 +12,7 @@ from ralph.assets.api.views import (
 )
 
 router.register(r'assetmodels', AssetModelViewSet)
+router.register(r'base-objects', BaseObjectViewSet)
 router.register(r'business-segments', BusinessSegmentViewSet)
 router.register(r'categories', CategoryViewSet)
 router.register(r'environments', EnvironmentViewSet)

--- a/src/ralph/assets/api/serializers.py
+++ b/src/ralph/assets/api/serializers.py
@@ -2,6 +2,7 @@ from django.db import transaction
 from rest_framework import serializers
 
 from ralph.api import RalphAPISerializer
+from ralph.api.utils import PolymorphicSerializer
 from ralph.assets.models import (
     Asset,
     AssetModel,
@@ -98,14 +99,29 @@ class AssetModelSerializer(RalphAPISerializer):
         model = AssetModel
 
 
-class BaseObjectSerializer(RalphAPISerializer):
+class BaseObjectPolymorphicSerializer(
+    PolymorphicSerializer,
+    RalphAPISerializer
+):
+    """
+    Serializer for BaseObjects viewset (serialize each model using dedicated
+    serializer).
+    """
     service_env = ServiceEnvironmentSerializer()
-
-    # TODO: proper parent handling (depending on type - similar to #1725)
 
     class Meta:
         model = BaseObject
-        exclude = ('content_type',)
+
+
+class BaseObjectSerializer(RalphAPISerializer):
+    """
+    Base class for other serializers inheriting from `BaseObject`.
+    """
+    service_env = ServiceEnvironmentSerializer()
+
+    class Meta:
+        model = BaseObject
+        exclude = ('content_type', )
 
 
 class AssetSerializer(BaseObjectSerializer):

--- a/src/ralph/assets/api/views.py
+++ b/src/ralph/assets/api/views.py
@@ -1,4 +1,5 @@
 from ralph.api import RalphAPIViewSet
+from ralph.api.utils import PolymorphicViewSetMixin
 from ralph.assets import models
 from ralph.assets.api import serializers
 
@@ -48,3 +49,9 @@ class CategoryViewSet(RalphAPIViewSet):
 class AssetModelViewSet(RalphAPIViewSet):
     queryset = models.AssetModel.objects.all()
     serializer_class = serializers.AssetModelSerializer
+
+
+class BaseObjectViewSet(PolymorphicViewSetMixin, RalphAPIViewSet):
+    queryset = models.BaseObject.polymorphic_objects.all()
+    serializer_class = serializers.BaseObjectPolymorphicSerializer
+    http_method_names = ['get', 'options', 'head']

--- a/src/ralph/assets/tests/test_api.py
+++ b/src/ralph/assets/tests/test_api.py
@@ -19,6 +19,8 @@ from ralph.assets.tests.factories import (
     ManufacturerFactory,
     ServiceFactory
 )
+from ralph.back_office.tests.factories import BackOfficeAssetFactory
+from ralph.data_center.tests.factories import DataCenterAssetFactory
 
 
 class ServicesEnvironmentsAPITests(RalphAPITestCase):
@@ -286,3 +288,24 @@ class AssetModelAPITests(RalphAPITestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.asset_model.refresh_from_db()
         self.assertEqual(self.asset_model.name, 'Iphone 6')
+
+
+class BaseObjectAPITests(RalphAPITestCase):
+    def setUp(self):
+        super().setUp()
+        self.bo_asset = BackOfficeAssetFactory(barcode='12345')
+        self.dc_asset = DataCenterAssetFactory(barcode='54321')
+
+    def test_get_base_objects_list(self):
+        url = reverse('baseobject-list')
+        response = self.client.get(url, format='json')
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data['count'], 2)
+        barcodes = [item['barcode'] for item in response.data['results']]
+        self.assertCountEqual(barcodes, set(['12345', '54321']))
+
+    def test_get_asset_model_details(self):
+        url = reverse('baseobject-detail', args=(self.bo_asset.id,))
+        response = self.client.get(url, format='json')
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data['barcode'], '12345')

--- a/src/ralph/lib/polymorphic/models.py
+++ b/src/ralph/lib/polymorphic/models.py
@@ -19,6 +19,8 @@ from django.db import models
 
 
 class PolymorphicQuerySet(models.QuerySet):
+    _polymorphic_select_related = {}
+    _polymorphic_prefetch_related = {}
 
     def iterator(self):
         """
@@ -28,27 +30,79 @@ class PolymorphicQuerySet(models.QuerySet):
             - Returns iterator with different models
         """
         result = []
-        content_type_model_map = {}
+        content_types_ids = set()
         for obj in super().iterator():
-            content_type_model_map[
-                obj.content_type_id
-            ] = obj.content_type.model_class()
+            content_types_ids.add(obj.content_type_id)
             result.append((
                 obj.content_type_id, obj.pk)
             )
         result = groupby(result, lambda x: x[0])
 
-        result_query = []
+        content_type_model_map = {
+            ct.id: ct.model_class() for ct in ContentType.objects.filter(
+                pk__in=list(content_types_ids)
+            )
+        }
+
+        # result_query = []
         for k, v in result:
             model = content_type_model_map[k]
             polymorphic_models = getattr(model, '_polymorphic_models', [])
             if polymorphic_models and model not in polymorphic_models:
-                result_query.extend(
-                    model.objects.filter(pk__in=[i[1] for i in v])
-                )
+                model_query = model.objects.filter(pk__in=[i[1] for i in v])
+                model_name = model._meta.object_name
+                # first check if select_related/prefetch_related is present for
+                # this model to not trigger selecting/prefetching all related
+                # or reset select_related accidentally
+                # see https://docs.djangoproject.com/en/1.8/ref/models/querysets/#select-related  # noqa
+                # for details
+                if model_name in self._polymorphic_select_related:
+                    model_query = model_query.select_related(
+                        *self._polymorphic_select_related[model_name]
+                    )
+                if model_name in self._polymorphic_prefetch_related:
+                    model_query = model_query.prefetch_related(
+                        *self._polymorphic_prefetch_related[model_name]
+                    )
+                for obj in model_query:
+                    yield obj
 
-        for obj in result_query:
-            yield obj
+    def _clone(self, *args, **kwargs):
+        clone = super()._clone(*args, **kwargs)
+        clone._polymorphic_select_related = (
+            self._polymorphic_select_related.copy()
+        )
+        clone._polymorphic_prefetch_related = (
+            self._polymorphic_prefetch_related.copy()
+        )
+        return clone
+
+    def polymorphic_select_related(self, **kwargs):
+        """
+        Apply select related on descendant model (passed as model name). Usage:
+
+        >>> MyBaseModel.objects.polymorphic_select_related(
+            MyDescendantModel=['related_field1', 'related_field2'],
+            MyDescendantModel2=['related_field3'],
+        )
+        """
+        obj = self._clone()
+        obj._polymorphic_select_related = kwargs
+        return obj
+
+    def polymorphic_prefetch_related(self, **kwargs):
+        """
+        Apply prefetch related on descendant model (passed as model name).
+        Usage:
+
+        >>> MyBaseModel.objects.polymorphic_prefetch_related(
+            MyDescendantModel=['related_field1', 'related_field2'],
+            MyDescendantModel2=['related_field3'],
+        )
+        """
+        obj = self._clone()
+        obj._polymorphic_prefetch_related = kwargs
+        return obj
 
 
 class PolymorphicBase(models.base.ModelBase):

--- a/src/ralph/lib/polymorphic/tests/models.py
+++ b/src/ralph/lib/polymorphic/tests/models.py
@@ -8,12 +8,17 @@ from ralph.lib.polymorphic.models import (
 )
 
 
+class SomethingRelated(models.Model):
+    name = models.CharField(max_length=50, blank=True, null=True)
+
+
 class PolymorphicModelBaseTest(
     Polymorphic,
     models.Model,
     metaclass=PolymorphicBase
 ):
     name = models.CharField(max_length=50, blank=True, null=True)
+    sth_related = models.ForeignKey(SomethingRelated, null=True, blank=True)
 
     polymorphic_objects = PolymorphicQuerySet.as_manager()
     objects = models.Manager()
@@ -25,3 +30,12 @@ class PolymorphicModelTest(
 ):
     def __str__(self):
         return 'PolymorphicModelTest: {}'.format(self.pk)
+
+
+class PolymorphicModelTest2(PolymorphicModelBaseTest, models.Model):
+    another_related = models.ForeignKey(
+        SomethingRelated, null=True, blank=True, related_name='+'
+    )
+
+    def __str__(self):
+        return 'PolymorphicModelTest2: {}'.format(self.pk)

--- a/src/ralph/lib/polymorphic/tests/tests_models.py
+++ b/src/ralph/lib/polymorphic/tests/tests_models.py
@@ -5,7 +5,9 @@ from django.test import TestCase
 from ralph.lib.polymorphic.models import Polymorphic
 from ralph.lib.polymorphic.tests.models import (
     PolymorphicModelBaseTest,
-    PolymorphicModelTest
+    PolymorphicModelTest,
+    PolymorphicModelTest2,
+    SomethingRelated
 )
 
 
@@ -14,9 +16,19 @@ class PolymorphicTestCase(TestCase):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
-        cls.pol_1 = PolymorphicModelTest()
-        cls.pol_1.name = 'Pol1'
-        cls.pol_1.save()
+        cls.sth_related = SomethingRelated.objects.create(name='Rel1')
+        cls.pol_1 = PolymorphicModelTest.objects.create(
+            name='Pol1',
+            sth_related=cls.sth_related
+        )
+        cls.pol_2 = PolymorphicModelTest.objects.create(
+            name='Pol2',
+            sth_related=cls.sth_related
+        )
+        cls.pol_3 = PolymorphicModelTest2.objects.create(
+            name='Pol3',
+            another_related=cls.sth_related,
+        )
 
     def test_polymorphic_metaclass(self):
         self.assertIn(
@@ -30,12 +42,42 @@ class PolymorphicTestCase(TestCase):
         )
 
     def test_get_descendants_models(self):
-        base = PolymorphicModelBaseTest()
+        base = PolymorphicModelBaseTest
         self.assertIn(PolymorphicModelTest, base._polymorphic_descendants)
+        self.assertIn(PolymorphicModelTest2, base._polymorphic_descendants)
 
     def test_polymorphic_queryset(self):
-        result = [
-            str(obj)
-            for obj in PolymorphicModelBaseTest.polymorphic_objects.all()
-        ]
+        result = []
+        with self.assertNumQueries(7):
+            # queries:
+            # select PolymorphicModelBaseTest
+            # select content types
+            # select PolymorphicModelTest
+            # select SomethingRelated (from sth_related) x2
+            # select PolymorphicModelTest2
+            # select SomethingRelated (from another_related)
+            for item in PolymorphicModelBaseTest.polymorphic_objects.all():
+                result.append(str(item))
+                # just get related attribute to force fetching it from DB
+                item.sth_related
+                if isinstance(item, PolymorphicModelTest2):
+                    item.another_related
+
         self.assertIn('PolymorphicModelTest: {}'.format(self.pol_1.pk), result)
+        self.assertIn('PolymorphicModelTest2: {}'.format(self.pol_3.pk), result)
+
+    def test_polymorphic_queryset_with_select_related(self):
+        with self.assertNumQueries(4):
+            # queries:
+            # select PolymorphicModelBaseTest
+            # select content types
+            # select PolymorphicModelTest
+            # select PolymorphicModelTest2
+            for item in PolymorphicModelBaseTest.polymorphic_objects.polymorphic_select_related(  # noqa
+                PolymorphicModelTest=['sth_related'],
+                PolymorphicModelTest2=['sth_related', 'another_related'],
+            ):
+                # just get related attribute to force fetching it from DB
+                item.sth_related
+                if isinstance(item, PolymorphicModelTest2):
+                    item.another_related


### PR DESCRIPTION
Return polymorphic objects to API using dedicated serializers for each inheriting model.
Use this polymorphic logic to BaseObject in API.
Added `polymorphic_select_related` and `polymorphic_prefetch_related` to Polymorphic queryset.
Minor performance improvements in polymorphic logic.

Connected to #1789 
