### PR TITLE
Multiadd / duplicate improvements

### DIFF
--- a/src/ralph/admin/templates/admin/multi_add.html
+++ b/src/ralph/admin/templates/admin/multi_add.html
@@ -9,7 +9,7 @@
   </h1>
   <br />
   <div>
-    <h5>{% trans "This object will be copied" %}</h5>
+    <h5>{% trans "This object will be multiplied" %}</h5>
     <table>
       <thead>
         {% for field in info_fields %}

--- a/src/ralph/admin/templatetags/ralph_tags.py
+++ b/src/ralph/admin/templatetags/ralph_tags.py
@@ -3,6 +3,11 @@ from django.contrib.admin.templatetags.admin_modify import submit_row
 from django.contrib.admin.views.main import SEARCH_VAR
 from django.template import Library
 
+from ralph.admin.helpers import (
+    get_field_by_relation_path,
+    get_value_by_relation_path
+)
+
 register = Library()
 
 
@@ -47,7 +52,7 @@ def get_attr(obj, attr):
     {{ obj|get_attr:"my_atribute" }}
 
     """
-    return getattr(obj, attr, None)
+    return get_value_by_relation_path(obj, attr)
 
 
 @register.filter
@@ -59,4 +64,4 @@ def get_verbose_name(obj, name):
     {{ obj|get_verbose_name:"my_field" }}
 
     """
-    return obj._meta.get_field(name).verbose_name
+    return get_field_by_relation_path(obj, name).verbose_name

--- a/src/ralph/back_office/models.py
+++ b/src/ralph/back_office/models.py
@@ -62,7 +62,7 @@ class BackOfficeAsset(Regionalizable, Asset):
         return settings.DEFAULT_COUNTRY_CODE
 
     def __str__(self):
-        return '{}'.format(self.hostname)
+        return '{}'.format(self.hostname or self.barcode or self.sn)
 
     def __repr__(self):
         return '<BackOfficeAsset: {}>'.format(self.id)

--- a/src/ralph/data_center/admin.py
+++ b/src/ralph/data_center/admin.py
@@ -128,7 +128,8 @@ class DataCenterAssetAdmin(
         'status', 'barcode', 'model',
         'sn', 'hostname', 'invoice_date', 'invoice_no',
     ]
-    multiadd_info_fields = list_display
+    multiadd_info_fields = list_display + ['rack']
+    one_of_mulitvalue_required = ['sn', 'barcode']
     bulk_edit_list = list_display
     search_fields = ['barcode', 'sn', 'hostname', 'invoice_no', 'order_no']
     list_filter = [
@@ -173,6 +174,7 @@ class DataCenterAssetAdmin(
         return [
             {'field': 'sn', 'allow_duplicates': False},
             {'field': 'barcode', 'allow_duplicates': False},
+            {'field': 'niw', 'allow_duplicates': False},
             {'field': 'position', 'allow_duplicates': True},
         ]
 

--- a/src/ralph/data_center/models/physical.py
+++ b/src/ralph/data_center/models/physical.py
@@ -272,7 +272,7 @@ class DataCenterAsset(Asset):
         self._rack_id = self.rack_id
 
     def __str__(self):
-        return '{}'.format(self.hostname)
+        return '{}'.format(self.hostname or self.barcode or self.sn)
 
     def __repr__(self):
         return '<DataCenterAsset: {}>'.format(self.id)


### PR DESCRIPTION
- fixed delimiting by pipe (|)
- added rack in dc asset description table
- improved saved message - now shows items count and links to added objects
- added ability to make field non-required
- using 'one_of_mulitvalue_required' in MultiAddView
- added 'niw' field to DC Asset multiadd

Connected to #1809
