### PR TITLE
Added tagging mechanism

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -5,6 +5,8 @@ django-filter==0.11.0
 django-import-export==0.2.7
 django-mptt==0.7.4
 django-reversion==1.8.6
+django-taggit==0.17.1
+django-taggit-serializer==0.1.5
 djangorestframework==3.2.2
 mysqlclient==1.3.6
 python-dateutil==2.4.2

--- a/src/ralph/admin/__init__.py
+++ b/src/ralph/admin/__init__.py
@@ -1,6 +1,7 @@
 from ralph.admin.sites import ralph_site
 from ralph.admin.mixins import (
     RalphAdmin,
+    RalphAdminForm,
     RalphStackedInline,
     RalphTabularInline,
 )
@@ -13,6 +14,7 @@ __all__ = [
     'default_app_config',
     'register',
     'RalphAdmin',
+    'RalphAdminForm',
     'RalphStackedInline',
     'RalphTabularInline',
 ]

--- a/src/ralph/api/utils.py
+++ b/src/ralph/api/utils.py
@@ -22,7 +22,7 @@ class QuerysetRelatedMixin(object):
         ) or []
         self.prefetch_related = kwargs.pop(
             'prefetch_related', self.prefetch_related
-        )
+        ) or []
         if getattr(self, 'queryset', None) is not None:
             admin_site = ralph_site._registry.get(self.queryset.model)
             if (

--- a/src/ralph/assets/models/base.py
+++ b/src/ralph/assets/models/base.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from django.db import models
 
-from ralph.lib.mixins.models import TimeStampMixin
+from ralph.lib.mixins.models import TaggableMixin, TimeStampMixin
 from ralph.lib.permissions import PermByFieldMixin
 from ralph.lib.permissions.models import PermissionsBase
 from ralph.lib.polymorphic.models import Polymorphic, PolymorphicBase
@@ -18,6 +18,7 @@ BaseObjectMeta = type(
 
 class BaseObject(
     Polymorphic,
+    TaggableMixin,
     PermByFieldMixin,
     TimeStampMixin,
     models.Model,

--- a/src/ralph/back_office/admin.py
+++ b/src/ralph/back_office/admin.py
@@ -102,7 +102,7 @@ class BackOfficeAssetAdmin(
             'fields': (
                 'hostname', 'model', 'barcode', 'sn', 'niw', 'status',
                 'warehouse', 'location', 'region', 'loan_end_date',
-                'service_env', 'remarks', 'imei'
+                'service_env', 'remarks', 'imei', 'tags',
             )
         }),
         (_('User Info'), {

--- a/src/ralph/back_office/api.py
+++ b/src/ralph/back_office/api.py
@@ -35,6 +35,7 @@ class BackOfficeAssetViewSet(RalphAPIViewSet):
         'service_env__service__environments',
         'service_env__service__business_owners',
         'service_env__service__technical_owners',
+        'tags',
     ]
     queryset = BackOfficeAsset.objects.all()
     serializer_class = BackOfficeAssetSerializer

--- a/src/ralph/data_center/admin.py
+++ b/src/ralph/data_center/admin.py
@@ -145,7 +145,7 @@ class DataCenterAssetAdmin(
         (_('Basic info'), {
             'fields': (
                 'hostname', 'model', 'status', 'barcode', 'sn', 'niw',
-                'required_support', 'remarks', 'parent',
+                'required_support', 'remarks', 'parent', 'tags',
             )
         }),
         (_('Location Info'), {

--- a/src/ralph/data_center/api/views.py
+++ b/src/ralph/data_center/api/views.py
@@ -32,6 +32,7 @@ class DataCenterAssetViewSet(RalphAPIViewSet):
         'service_env__service__business_owners',
         'service_env__service__technical_owners',
         'connections',
+        'tags',
     ]
 
 

--- a/src/ralph/lib/mixins/models.py
+++ b/src/ralph/lib/mixins/models.py
@@ -3,6 +3,7 @@ from django.core.urlresolvers import reverse
 from django.db import models
 from django.utils import timezone
 from django.utils.translation import ugettext_lazy as _
+from taggit.managers import TaggableManager
 
 
 class NamedMixin(models.Model):
@@ -66,3 +67,10 @@ class AdminAbsoluteUrlMixin(object):
                 self._meta.app_label, self._meta.model_name
             ), args=(self.pk,)
         )
+
+
+class TaggableMixin(models.Model):
+    tags = TaggableManager(blank=True)
+
+    class Meta:
+        abstract = True

--- a/src/ralph/licences/models.py
+++ b/src/ralph/licences/models.py
@@ -12,6 +12,7 @@ from ralph.assets.models.base import BaseObject
 from ralph.lib.mixins.models import (
     AdminAbsoluteUrlMixin,
     NamedMixin,
+    TaggableMixin,
     TimeStampMixin
 )
 from ralph.lib.permissions import PermByFieldMixin
@@ -53,6 +54,7 @@ class Licence(
     AdminAbsoluteUrlMixin,
     PermByFieldMixin,
     TimeStampMixin,
+    TaggableMixin,
     models.Model,
 ):
 

--- a/src/ralph/settings/base.py
+++ b/src/ralph/settings/base.py
@@ -40,6 +40,8 @@ INSTALLED_APPS = (
     'ralph.lib.transitions',
     'rest_framework',
     'rest_framework.authtoken',
+    'taggit',
+    'taggit_serializer',
 )
 
 MIDDLEWARE_CLASSES = (
@@ -168,3 +170,5 @@ REST_FRAMEWORK = {
     'DEFAULT_PAGINATION_CLASS': 'rest_framework.pagination.LimitOffsetPagination',  # noqa
     'PAGE_SIZE': 10,
 }
+
+TAGGIT_CASE_INSENSITIVE = True  # case insensitive tags

--- a/src/ralph/supports/models.py
+++ b/src/ralph/supports/models.py
@@ -8,7 +8,7 @@ from django.utils.translation import ugettext_lazy as _
 
 from ralph.accounts.models import Regionalizable
 from ralph.assets.models.base import BaseObject
-from ralph.lib.mixins.models import NamedMixin, TimeStampMixin
+from ralph.lib.mixins.models import NamedMixin, TaggableMixin, TimeStampMixin
 from ralph.lib.permissions import PermByFieldMixin
 
 
@@ -28,6 +28,7 @@ class Support(
     PermByFieldMixin,
     NamedMixin.NonUnique,
     TimeStampMixin,
+    TaggableMixin,
     models.Model,
 ):
     contract_id = models.CharField(max_length=50, blank=False)


### PR DESCRIPTION
- used django-taggit as tagging mechanism
- used django-taggit-serializer for cooperation with DRF
- tags are automatically shown in django admin and API (if model inherits `ralph.lib.mixins.models.TaggableMixin`).

Connected to #1512 
