### PR TITLE
Fixed help text (tooltip) position

### DIFF
--- a/src/ralph/lib/foundation/templates/foundation_form/form_field.html
+++ b/src/ralph/lib/foundation/templates/foundation_form/form_field.html
@@ -5,17 +5,6 @@
     <div class="small-3 columns">
       {% if show_label %}
         {% label field %}
-        {% if admin_field.help_text %}
-          <span class="help-text">
-            <i
-              class="fa fa-lg fa-info-circle has-tip tip-top"
-              data-tooltip
-              aria-haspopup="true"
-              title="{{ admin_field.help_text | escape }}"
-            >
-            </i>
-          </span>
-        {% endif %}
       {% endif %}
     </div>
     <div class="small-7 end columns {% if field.errors %} error{% endif %}">
@@ -28,6 +17,17 @@
         {% for error in admin_field.errors %}
           <small class="error">{{ error }}</small>
         {% endfor %}
+      {% endif %}
+      {% if admin_field.help_text %}
+        <span class="help-text">
+          <i
+            class="fa fa-lg fa-info-circle has-tip tip-top"
+            data-tooltip
+            aria-haspopup="true"
+            title="{{ admin_field.help_text | escape }}"
+          >
+          </i>
+        </span>
       {% endif %}
     </div>
   </div>


### PR DESCRIPTION
In 4ef3e08 help text was (wrongly) moved after label. This commit moves it back after field.
