### PR TITLE
Remove python-ldap from requirements

### DIFF
--- a/requirements/prod_ldap.txt
+++ b/requirements/prod_ldap.txt
@@ -1,3 +1,2 @@
 -r prod.txt
-django-auth-ldap==1.2.6
-git+https://github.com/rbarrois/python-ldap@py3  # py3 branch, not on pypi
+django-auth-ldap==1.2.7


### PR DESCRIPTION
django-auth-ldap in version 1.2.7 requires pyldap (2.4.20), which is implementation of python-ldap (http://www.python-ldap.org/index.html) in python3. Branch py3 was removed from python-ldap repo. See https://github.com/rbarrois/python-ldap/tree/release for details
