### PR TITLE
Update django-auth-ldap to 1.2.7. This version depends on pyldap to s…

### DIFF
--- a/requirements/prod_ldap.txt
+++ b/requirements/prod_ldap.txt
@@ -1,3 +1,2 @@
 -r prod.txt
-django-auth-ldap==1.2.6
-git+https://github.com/rbarrois/python-ldap@py3  # py3 branch, not on pypi
+django-auth-ldap==1.2.7


### PR DESCRIPTION
…upport

Python 3, so rbarrois/python-ldap fork is no longer needed.
