### PR TITLE
DC assets 'Bulk edit': rack, orientation and position fields added to the form

### DIFF
--- a/src/ralph/data_center/admin.py
+++ b/src/ralph/data_center/admin.py
@@ -116,7 +116,7 @@ class DataCenterAssetAdmin(
     ]
     multiadd_info_fields = list_display + ['rack']
     one_of_mulitvalue_required = ['sn', 'barcode']
-    bulk_edit_list = list_display
+    bulk_edit_list = list_display + ['rack', 'orientation', 'position']
     search_fields = ['barcode', 'sn', 'hostname', 'invoice_no', 'order_no']
     list_filter = [
         'status', 'barcode', 'sn', 'hostname', 'invoice_no', 'invoice_date',


### PR DESCRIPTION
When updating location of multiple items (hardware/assets) in 'Bulk edit' mode it's very convenient (desirable) to be able to do it in one, single step. Otherwise, I have to, one-by-one, edit every single DC asset and change the location respectively. This PR makes the case easy and allows to do it in one step.
