### PR TITLE
fixed upgrading docker containers using init script

### DIFF
--- a/docker/init.sh
+++ b/docker/init.sh
@@ -9,5 +9,7 @@ cd $DIR
 
 ./upgrade.sh
 
-$RALPH_EXEC createsuperuser --noinput --username ralph --email ralph@allegrogroup.com
+# pass the error (ex. when user already exist);
+# by muting the error, this script could be use to upgrade data container too
+$RALPH_EXEC createsuperuser --noinput --username ralph --email ralph@allegrogroup.com || true
 python3 $RALPH_DIR/docker/createsuperuser.py


### PR DESCRIPTION
mute error during creating superuser (for example when user already exists) - if superuser was not created, error will be thrown in createsuperuser.py either way; 
