### PR TITLE
Added attachments to BackOfficeAsset, Licence and Support

### DIFF
--- a/src/ralph/admin/mixins.py
+++ b/src/ralph/admin/mixins.py
@@ -130,6 +130,14 @@ class RalphAdminMixin(RalphAutocompleteMixin):
         else:
             self.change_views = copy(self.change_views) or []
         super().__init__(*args, **kwargs)
+        # create copy (subclass) of view class to assign unique
+        # class to each admin when it's used (prevents conflicts between urls
+        # etc). See ralph.admin.extra.RalphExtraViewMixin.post_register for
+        # details
+        self.list_views = [type(c.__name__, (c,), {}) for c in self.list_views]
+        self.change_views = [
+            type(c.__name__, (c,), {}) for c in self.change_views
+        ]
 
     def get_form(self, request, obj=None, **kwargs):
         """

--- a/src/ralph/admin/sites.py
+++ b/src/ralph/admin/sites.py
@@ -19,11 +19,12 @@ class RalphAdminSiteMixin(object):
 
     def register(self, model_or_iterable, *args, **kwargs):
         super().register(model_or_iterable, *args, **kwargs)
-        admin_class = kwargs.get('admin_class', None)
-        if not admin_class:
-            return
-        for view in self._get_views(admin_class):
-            for model in model_or_iterable:
+        # operate on admin class instance to get processed extra views
+        for model in model_or_iterable:
+            if model._meta.swapped:
+                continue
+            admin_instance = self._registry[model]
+            for view in self._get_views(admin_instance):
                 view.post_register(self.name, model)
 
     def get_urls(self, *args, **kwargs):

--- a/src/ralph/admin/views/extra.py
+++ b/src/ralph/admin/views/extra.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 from copy import copy
 
+from django.core.exceptions import ImproperlyConfigured
 from django.shortcuts import get_object_or_404
 
 from ralph.admin.mixins import (
@@ -31,6 +32,12 @@ class RalphExtraViewMixin(object):
 
     @classmethod
     def post_register(cls, namespace, model):
+        # make sure that single view is not processed more than once
+        if getattr(cls, 'namespace', None):
+            raise ImproperlyConfigured((
+                'Single view class ({}) cannot be attached to more than one '
+                'admin site'
+            ).format(cls.__name__))
         cls.namespace = namespace
         cls.url_to_reverse = '{}_{}_{}'.format(
             model._meta.app_label, model._meta.model_name, cls.url_name

--- a/src/ralph/admin/views/multiadd.py
+++ b/src/ralph/admin/views/multiadd.py
@@ -17,6 +17,7 @@ from ralph.admin.fields import (
 )
 from ralph.admin.mixins import RalphTemplateView
 from ralph.admin.sites import ralph_site
+from ralph.helpers import get_model_view_url_name
 
 
 class MultiAddView(RalphTemplateView):
@@ -166,11 +167,7 @@ class MulitiAddAdminMixin(object):
         raise NotImplementedError()
 
     def get_url_name(self, with_namespace=True):
-        params = self.model._meta.app_label, self.model._meta.model_name
-        url = '{}_{}_multiadd'.format(*params)
-        if with_namespace:
-            url = 'admin:' + url
-        return url
+        return get_model_view_url_name(self.model, 'multiadd', with_namespace)
 
     def add_view(self, request, form_url='', extra_context=None):
         if not extra_context:

--- a/src/ralph/attachments/admin.py
+++ b/src/ralph/attachments/admin.py
@@ -7,6 +7,7 @@ from django.utils.http import http_date
 
 from ralph.attachments.models import Attachment
 from ralph.attachments.views import AttachmentsView
+from ralph.helpers import get_model_view_url_name
 
 
 class AttachmentsMixin(object):
@@ -21,9 +22,11 @@ class AttachmentsMixin(object):
         urlpatterns = super().get_urls()
         urlpatterns += [
             url(
-                r'^attachment/(?P<id>\d+)-(?P<filename>\S+)',
+                r'^attachment/(?P<id>\d+)-(?P<filename>.+)',
                 self.serve_attachment,
-                name='get_attachment'
+                name=get_model_view_url_name(
+                    self.model, 'attachment', with_admin_namespace=False
+                )
             ),
         ]
         return urlpatterns

--- a/src/ralph/attachments/templates/attachments/attachments.html
+++ b/src/ralph/attachments/templates/attachments/attachments.html
@@ -21,7 +21,7 @@
                 <td>
                   {{ form.id }}
                   {% if obj.pk %}
-                    <a href="{% url 'admin:get_attachment' obj.id obj.original_filename %}">
+                    <a href="{% url attachment_url_name obj.id obj.original_filename %}">
                       {{ obj.original_filename }}
                     </a>
                   {% else %}

--- a/src/ralph/attachments/views.py
+++ b/src/ralph/attachments/views.py
@@ -4,7 +4,7 @@ from django.http import HttpResponseRedirect
 from ralph.admin.views.extra import RalphDetailView
 from ralph.attachments.forms import AttachmentForm
 from ralph.attachments.models import Attachment, AttachmentItem
-from ralph.helpers import add_request_to_form
+from ralph.helpers import add_request_to_form, get_model_view_url_name
 
 
 class AttachmentsView(RalphDetailView):
@@ -35,6 +35,20 @@ class AttachmentsView(RalphDetailView):
         """
         formset = self.get_formset(request)
         return self.render_to_response(self.get_context_data(formset=formset))
+
+    def get_context_data(self, *args, **kwargs):
+        """
+        Extends context by:
+        * url name for attachments for current model
+        """
+        context_data = super().get_context_data(*args, **kwargs)
+        context_data.update({
+            'attachment_url_name': get_model_view_url_name(
+                self.object._meta.model,
+                'attachment',
+            ),
+        })
+        return context_data
 
     def post(self, request):
         """

--- a/src/ralph/back_office/admin.py
+++ b/src/ralph/back_office/admin.py
@@ -5,6 +5,7 @@ from ralph.admin import RalphAdmin, RalphTabularInline, register
 from ralph.admin.mixins import BulkEditChangeListMixin
 from ralph.admin.views.extra import RalphDetailViewAdmin
 from ralph.admin.views.multiadd import MulitiAddAdminMixin
+from ralph.attachments.admin import AttachmentsMixin
 from ralph.back_office.models import AssetHolder, BackOfficeAsset, Warehouse
 from ralph.back_office.views import (
     BackOfficeAssetComponents,
@@ -52,6 +53,7 @@ class BackOfficeAssetAdmin(
     MulitiAddAdminMixin,
     BulkEditChangeListMixin,
     PermissionAdminMixin,
+    AttachmentsMixin,
     TransitionAdminMixin,
     RalphAdmin
 ):

--- a/src/ralph/helpers.py
+++ b/src/ralph/helpers.py
@@ -2,3 +2,16 @@
 def add_request_to_form(form_class, request):
     form_class._request = request
     return form_class
+
+
+def get_model_view_url_name(model, view_name, with_admin_namespace=True):
+    """
+    Return url name for model additional view (site). Example:
+    >>> get_model_view_url_name(DataCenterAsset, 'attachment')
+    'admin:data_center_datacenterasset_attachment'
+    """
+    params = model._meta.app_label, model._meta.model_name
+    url = '{}_{}_{view_name}'.format(*params, view_name=view_name)
+    if with_admin_namespace:
+        url = 'admin:' + url
+    return url

--- a/src/ralph/licences/admin.py
+++ b/src/ralph/licences/admin.py
@@ -3,6 +3,7 @@ from django.utils.translation import ugettext_lazy as _
 
 from ralph.admin import RalphAdmin, RalphTabularInline, register
 from ralph.admin.views.extra import RalphDetailViewAdmin
+from ralph.attachments.admin import AttachmentsMixin
 from ralph.data_importer import resources
 from ralph.lib.permissions.admin import PermissionAdminMixin
 from ralph.licences.models import (
@@ -43,7 +44,7 @@ class LicenceUserView(RalphDetailViewAdmin):
 
 
 @register(Licence)
-class LicenceAdmin(PermissionAdminMixin, RalphAdmin):
+class LicenceAdmin(PermissionAdminMixin, AttachmentsMixin, RalphAdmin):
 
     """Licence admin class."""
     change_views = [

--- a/src/ralph/supports/admin.py
+++ b/src/ralph/supports/admin.py
@@ -3,6 +3,7 @@ from django.utils.translation import ugettext_lazy as _
 
 from ralph.admin import RalphAdmin, RalphTabularInline, register
 from ralph.admin.views.extra import RalphDetailViewAdmin
+from ralph.attachments.admin import AttachmentsMixin
 from ralph.data_importer import resources
 from ralph.lib.permissions.admin import PermissionAdminMixin
 from ralph.supports.models import Support, SupportType
@@ -24,7 +25,7 @@ class BaseObjectSupportView(RalphDetailViewAdmin):
 
 
 @register(Support)
-class SupportAdmin(PermissionAdminMixin, RalphAdmin):
+class SupportAdmin(PermissionAdminMixin, AttachmentsMixin, RalphAdmin):
 
     """Support model admin class."""
 


### PR DESCRIPTION
- added attachments to BackOfficeAsset, Licence and Support
- fixed attaching the same view to multiple admin sites (ImproperlyConfigured exception will be raised during application start if this happens again in the future)
- fixed serving attachments with space in the name
