### PR TITLE
Fix permission check for admin views

### DIFF
--- a/src/ralph/lib/permissions/views.py
+++ b/src/ralph/lib/permissions/views.py
@@ -40,9 +40,11 @@ class PermissionViewMetaClass(type):
         codename = 'can_view_extra_{}'.format(name.lower())
 
         attrs['permision_codename'] = codename
+        if 'dispatch' in attrs:
+            attrs = dict(attrs)
+            print('wrapping', name, attrs['dispatch'])
+            attrs['dispatch'] = view_permission_dispatch(attrs.pop('dispatch'))
         new_class = super().__new__(cls, name, bases, attrs)
-        dispatch = getattr(new_class, 'dispatch', None)
-        setattr(new_class, 'dispatch', view_permission_dispatch(dispatch))
         _permission_views.append((new_class, codename))
         return new_class
 


### PR DESCRIPTION
Admin views returned HTTP 404 for no-adin user with granted permission for
the view.
Metaclass .dispatch wrapper created method for every subclass of View.
Fix it by wrapping only specific classes .dispatch method
