### PR TITLE
Docker image & DEB build in Travis

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -72,3 +72,5 @@ node_modules/
 src/ralph/static/css/
 src/ralph/static/vendor/
 src/ralph/var/
+
+debian/ralph-core*

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
-sudo: false
+sudo: required
 language: python
+
+services:
+    - docker
 
 cache:
   directories:
@@ -13,6 +16,8 @@ python:
 before_install:
     - pip install flake8 isort
     - make flake
+    - export RALPH_VERSION=$(cat VERSION)
+    - export NEW_TAG=$RALPH_VERSION-snapshot-$(date "+%Y%m%d")-$TRAVIS_BUILD_NUMBER
 
 install:
     - npm config set python /usr/bin/python2.7
@@ -28,6 +33,24 @@ script:
 
 after_success:
     - coveralls
+
+before_deploy:
+    - sudo add-apt-repository -y ppa:spotify-jyrki/dh-virtualenv
+    - sudo apt-get update
+    - sudo apt-get install -y devscripts python-virtualenv git equivs dh-virtualenv
+    - make build-package
+
+deploy:
+    -   provider: script
+        script: scripts/travis_deploy_docker.sh
+        on:
+            branch: ng
+            python: 3.4
+    -   provider: script
+        script: scripts/travis_deploy_bintray.sh
+        on:
+            branch: ng
+            python: 3.4
 
 notifications:
   webhooks:

--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ clean:
 	find . -name '*.py[cod]' -exec rm -rf {} \;
 
 coverage: clean
-	coverage run '$(VIRTUAL_ENV)/bin/test_ralph' test ralph --settings="ralph.settings.test"
+	coverage run $(shell which test_ralph) test ralph --settings="ralph.settings.test"
 	coverage report
 
 docs:

--- a/debian/changelog
+++ b/debian/changelog
@@ -183,6 +183,6 @@ ralph (3.0.0-2) UNRELEASED; urgency=medium
 
 ralph (3.0.0-1) UNRELEASED; urgency=medium
 
-  * Initial release. 
+  * Initial release.
 
  -- MAINTAINER <vagrant@ralph-dev>  Mon, 29 Jun 2015 11:39:55 +0000

--- a/debian/source/options
+++ b/debian/source/options
@@ -1,0 +1,1 @@
+tar-ignore = ".git/*"

--- a/packaging/build-package.sh
+++ b/packaging/build-package.sh
@@ -2,12 +2,15 @@
 
 set -e
 DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
+# ignore warnings about python librariers deps
+export DEB_DH_SHLIBDEPS_ARGS_ALL="--dpkg-shlibdeps-params=--ignore-missing-info"
+SRC_DIR="$DIR/.."
 
 function install_dh_virtualenv {
 	# in ubuntu 14.04 provided by system - just for another systems
 	# compile and install dh_virtualenv in travis sandbox - we need sudo here
 	sudo apt-get update
-	sudo apt-get install devscripts python-virtualenv git equivs
+	sudo apt-get install -y devscripts python-virtualenv git equivs
 	git clone https://github.com/spotify/dh-virtualenv.git
 	cd dh-virtualenv
 	sudo mk-build-deps -ri
@@ -16,18 +19,20 @@ function install_dh_virtualenv {
 }
 
 function build_package {
-	RALPH_VERSION=`cat ${SRC_DIR}/VERSION`
-	VERSION="${RALPH_VERSION}-${TRAVIS_BUILD_NUMBER}"
 	cd $SRC_DIR
-	dch --team "ralph pre-release test build"
+	if [ ! -z "$TRAVIS" ]; then
+		if [ -z "$NEW_TAG" ]; then
+			RALPH_VERSION=`cat ${SRC_DIR}/VERSION`
+			VERSION=snapshot-$RALPH_VERSION-$(date "+%Y%m%d")
+		else
+			VERSION=${NEW_TAG}
+		fi
+		dch --newversion="$VERSION" -- 'travis'
+	else
+		dch --team "ralph pre-release test build"
+	fi
 	dpkg-buildpackage -us -uc
 }
 
 
-# ignore warnings about python librariers deps
-export DEB_DH_SHLIBDEPS_ARGS_ALL="--dpkg-shlibdeps-params=--ignore-missing-info"
-
-SRC_DIR="$DIR/.."
-
 build_package
-

--- a/packaging/upload-package.sh
+++ b/packaging/upload-package.sh
@@ -7,7 +7,7 @@ SRC_DIR="$DIR/.."
 
 cd $SRC_DIR
 
-if [ ! -z "$BINTRAY_APIKEY" ]; then 
+if [ ! -z "$BINTRAY_APIKEY" ]; then
 	DEB_NAME=$(ls $SRC_DIR/../*.deb | sort -Vr  | head -1)
 	echo "Uploading $DEB_NAME"
 	GENERIC_DEB_NAME=`basename $DEB_NAME`

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -1,9 +1,10 @@
 -e .
 -r prod_ldap.txt
 -r docs.txt
-factory-boy
 coverage
-sphinx
-flake8
-django-plainpasswordhasher
+coveralls
 ddt
+django-plainpasswordhasher
+factory-boy
+flake8
+sphinx

--- a/scripts/travis_deploy_bintray.sh
+++ b/scripts/travis_deploy_bintray.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+# designed to be run in travis after successfull build of not-PR
+# required env variabled set in travis:
+# BINTRAY_USER
+# BINTRAY_APIKEY
+# BINTRAY_REPO_NAME
+# BINTRAY_PACKAGE_NAME
+
+set -e
+
+DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
+SRC_DIR="$DIR/.."
+
+cd $SRC_DIR
+
+DEB_NAME=$(ls $SRC_DIR/../*.deb | sort -Vr | head -1)
+GENERIC_DEB_NAME=`basename $DEB_NAME`
+echo "Uploading $GENERIC_DEB_NAME"
+curl -T $DEB_NAME -u $BINTRAY_USER:$BINTRAY_APIKEY "https://api.bintray.com/content/$BINTRAY_USER/$BINTRAY_REPO_NAME/$BINTRAY_PACKAGE_NAME/$NEW_TAG/dists/wheezy/main/binary-amd64/$GENERIC_DEB_NAME;deb_distribution=wheezy;deb_component=main;deb_architecture=amd64?publish=1"

--- a/scripts/travis_deploy_docker.sh
+++ b/scripts/travis_deploy_docker.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+# designed to be run in travis after successfull build of not-PR
+# required env variabled set in travis:
+# DOCKER_IMAGE
+# DOCKER_EMAIL
+# DOCKER_USERNAME
+# DOCKER_PASSWORD
+
+set -e
+
+DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
+SRC_DIR="$DIR/.."
+
+# run this only for main build
+if [[ "${TRAVIS_JOB_NUMBER: -1}" == "1" ]]; then
+    echo "deploying docker image"
+    docker login -e="$DOCKER_EMAIL" -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD"
+    docker build -t $DOCKER_IMAGE:$NEW_TAG .
+    docker tag $DOCKER_IMAGE:$NEW_TAG $DOCKER_IMAGE:snapshot_latest
+    echo "pushing docker images: $DOCKER_IMAGE:$NEW_TAG and $DOCKER_IMAGE:snapshot_latest"
+    docker push $DOCKER_IMAGE:$NEW_TAG
+    docker push $DOCKER_IMAGE:snapshot_latest
+fi


### PR DESCRIPTION
There is new phase in Travis - deploy. It's executed only for non-PR builds (and with our conditions only on commit to branch ng and when python 3.4 build is performed).
During deploy, there are two (independent) steps: processing DEB package and Docker image.

Version format for both packages: `<RALPH_VERSION>-snapshot-<DATE %Y%m%d>-<TRAVIS_BUILD_NUMBER>`, ex. `3.0.0-snapshot-20151106-70`

DEB package processing steps:
- installation of dh-virtualenv
- deb package build (using `make build-package`)
- upload of deb package to bintray (using curl)

Docker image processing steps:
- login to Docker Hub
- build of new image
- push image to docker hub (using version number specified above and additional `snapshot_latest` tag)

Environment variables that need to be set in travis:
- `DOCKER_IMAGE`
- `DOCKER_EMAIL`
- `DOCKER_USERNAME`
- `DOCKER_PASSWORD`
- `BINTRAY_USER`
- `BINTRAY_APIKEY`
- `BINTRAY_REPO_NAME`
- `BINTRAY_PACKAGE_NAME`
