### PR TITLE
Fixed vagrant provisioning - missing python3.4-venv package

### DIFF
--- a/vagrant/provision.sh
+++ b/vagrant/provision.sh
@@ -13,6 +13,7 @@ sudo DEBIAN_FRONTEND=noninteractive apt-get install -y \
     mysql-server-5.6 \
     python3.4 \
     python3.4-dev \
+    python3.4-venv \
     redis-server
 
 # INSTALL Ralph in virtualenv


### PR DESCRIPTION
added missing python3.4-venv packge, dependency broken in python3.4-3.4.1-1
(https://launchpad.net/ubuntu/+source/python3.4/3.4.1-1)
