### PR TITLE
Exposed licences in baseobject API

### DIFF
--- a/src/ralph/accounts/api.py
+++ b/src/ralph/accounts/api.py
@@ -11,7 +11,8 @@ from ralph.back_office.api import (
     BackOfficeAssetViewSet
 )
 from ralph.back_office.models import BackOfficeAsset
-from ralph.licences.api import LicenceUserViewSet, SimpleLicenceUserSerializer
+from ralph.licences.api import LicenceUserViewSet
+from ralph.licences.api_simple import SimpleLicenceUserSerializer
 from ralph.licences.models import LicenceUser
 
 

--- a/src/ralph/accounts/api_simple.py
+++ b/src/ralph/accounts/api_simple.py
@@ -1,0 +1,12 @@
+# -*- coding: utf-8 -*-
+from django.contrib.auth import get_user_model
+
+from ralph.api import RalphAPISerializer
+
+
+class SimpleRalphUserSerializer(RalphAPISerializer):
+    class Meta:
+        model = get_user_model()
+        fields = ('id', 'url', 'username', 'first_name', 'last_name')
+        read_only_fields = fields
+        depth = 1

--- a/src/ralph/assets/api/serializers.py
+++ b/src/ralph/assets/api/serializers.py
@@ -16,6 +16,7 @@ from ralph.assets.models import (
     Service,
     ServiceEnvironment
 )
+from ralph.licences.api_simple import SimpleBaseObjectLicenceSerializer
 
 
 class BusinessSegmentSerializer(RalphAPISerializer):
@@ -125,6 +126,7 @@ class BaseObjectSerializer(RalphAPISerializer):
     Base class for other serializers inheriting from `BaseObject`.
     """
     service_env = ServiceEnvironmentSerializer()
+    licences = SimpleBaseObjectLicenceSerializer(read_only=True, many=True)
 
     class Meta:
         model = BaseObject

--- a/src/ralph/assets/api/views.py
+++ b/src/ralph/assets/api/views.py
@@ -1,7 +1,12 @@
+# -*- coding: utf-8 -*-
+from django.db.models import Prefetch
+
 from ralph.api import RalphAPIViewSet
 from ralph.api.utils import PolymorphicViewSetMixin
 from ralph.assets import models
 from ralph.assets.api import serializers
+from ralph.licences.api import BaseObjectLicenceViewSet
+from ralph.licences.models import BaseObjectLicence
 
 
 class BusinessSegmentViewSet(RalphAPIViewSet):
@@ -55,7 +60,11 @@ class BaseObjectViewSet(PolymorphicViewSetMixin, RalphAPIViewSet):
     queryset = models.BaseObject.polymorphic_objects.all()
     serializer_class = serializers.BaseObjectPolymorphicSerializer
     http_method_names = ['get', 'options', 'head']
-
+    prefetch_related = [
+        Prefetch('licences', queryset=BaseObjectLicence.objects.select_related(
+            *BaseObjectLicenceViewSet.select_related
+        )),
+    ]
     filter_fields = ['id']
     extend_filter_fields = {
         'name': ['asset__hostname'],

--- a/src/ralph/back_office/api.py
+++ b/src/ralph/back_office/api.py
@@ -1,22 +1,14 @@
 # -*- coding: utf-8 -*-
-from django.contrib.auth import get_user_model
-
+from ralph.accounts.api_simple import SimpleRalphUserSerializer
 from ralph.api import RalphAPISerializer, RalphAPIViewSet, router
 from ralph.assets.api.serializers import AssetSerializer
+from ralph.assets.api.views import BaseObjectViewSet
 from ralph.back_office.admin import BackOfficeAssetAdmin
 from ralph.back_office.models import (
     BackOfficeAsset,
     OfficeInfrastructure,
     Warehouse
 )
-
-
-class SimpleRalphUserSerializer(RalphAPISerializer):
-    class Meta:
-        model = get_user_model()
-        fields = ('id', 'url', 'username', 'first_name', 'last_name')
-        read_only_fields = fields
-        depth = 1
 
 
 class WarehouseSerializer(RalphAPISerializer):
@@ -51,9 +43,9 @@ class BackOfficeAssetSerializer(AssetSerializer):
 class BackOfficeAssetViewSet(RalphAPIViewSet):
     select_related = BackOfficeAssetAdmin.list_select_related + [
         'service_env', 'service_env__service', 'service_env__environment',
-        'user', 'owner',
+        'user', 'owner', 'property_of', 'office_infrastructure',
     ]
-    prefetch_related = [
+    prefetch_related = BaseObjectViewSet.prefetch_related + [
         'user__groups', 'user__user_permissions',
         'service_env__service__environments',
         'service_env__service__business_owners',

--- a/src/ralph/data_center/api/views.py
+++ b/src/ralph/data_center/api/views.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 from ralph.api import RalphAPIViewSet
+from ralph.assets.api.views import BaseObjectViewSet
 from ralph.data_center.admin import DataCenterAssetAdmin
 from ralph.data_center.api.serializers import (
     AccessorySerializer,
@@ -27,7 +28,7 @@ class DataCenterAssetViewSet(RalphAPIViewSet):
         'service_env', 'service_env__service', 'service_env__environment',
         'rack', 'rack__server_room', 'rack__server_room__data_center',
     ]
-    prefetch_related = [
+    prefetch_related = BaseObjectViewSet.prefetch_related + [
         'service_env__service__environments',
         'service_env__service__business_owners',
         'service_env__service__technical_owners',

--- a/src/ralph/licences/api.py
+++ b/src/ralph/licences/api.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
+from ralph.accounts.api_simple import SimpleRalphUserSerializer
 from ralph.api import RalphAPISerializer, RalphAPIViewSet, router
-from ralph.back_office.api import SimpleRalphUserSerializer
 from ralph.licences.models import (
     BaseObjectLicence,
     Licence,
@@ -8,23 +8,6 @@ from ralph.licences.models import (
     LicenceUser,
     Software
 )
-
-
-# ==================
-# SIMPLE SERIALIZERS
-# ==================
-class SimpleLicenceSerializer(RalphAPISerializer):
-    class Meta:
-        model = Licence
-        depth = 1
-        exclude = ('base_objects', 'users')
-
-
-class SimpleLicenceUserSerializer(RalphAPISerializer):
-    licence = SimpleLicenceSerializer()
-
-    class Meta:
-        model = LicenceUser
 
 
 # ===========
@@ -72,6 +55,10 @@ class SoftwareSerializer(RalphAPISerializer):
 class BaseObjectLicenceViewSet(RalphAPIViewSet):
     queryset = BaseObjectLicence.objects.all()
     serializer_class = BaseObjectLicenceSerializer
+    select_related = [
+        'licence', 'licence__region', 'licence__manufacturer',
+        'licence__licence_type', 'licence__software', 'base_object'
+    ]
 
 
 class LicenceTypeViewSet(RalphAPIViewSet):

--- a/src/ralph/licences/api_simple.py
+++ b/src/ralph/licences/api_simple.py
@@ -1,0 +1,27 @@
+# -*- coding: utf-8 -*-
+from ralph.api import RalphAPISerializer
+from ralph.licences.models import BaseObjectLicence, Licence, LicenceUser
+
+
+# ==================
+# SIMPLE SERIALIZERS
+# ==================
+class SimpleLicenceSerializer(RalphAPISerializer):
+    class Meta:
+        model = Licence
+        depth = 1
+        exclude = ('base_objects', 'users')
+
+
+class SimpleLicenceUserSerializer(RalphAPISerializer):
+    licence = SimpleLicenceSerializer()
+
+    class Meta:
+        model = LicenceUser
+
+
+class SimpleBaseObjectLicenceSerializer(RalphAPISerializer):
+    licence = SimpleLicenceSerializer()
+
+    class Meta:
+        model = BaseObjectLicence


### PR DESCRIPTION
- api imports cleanup (circular imports) - created new module api_simple for simple serializers
- added licences to BaseObject serializer (inherited in BackOfficeAssetSerializer and DataCenterAsset serializer)
