### PR TITLE
API versioning

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -17,6 +17,17 @@ In each request to API you have to use your API Token Key in request header:
 
     curl -X GET https://<YOUR-RALPH-URL>/api/ -H 'Authorization: Token <YOUR-TOKEN>'
 
+## API Versioning
+
+Api requires the client to specify the version in the Accept header.
+
+```
+Example:
+GET /bookings/ HTTP/1.1
+Host: example.com
+Accept: application/json; version=v1
+```
+
 ## Output format
 
 Ralph API supports JSON output format (by default) and HTML preview in your browser (go to https://<YOUR-RALPH-URL>/api/ to see preview).

--- a/src/ralph/settings/base.py
+++ b/src/ralph/settings/base.py
@@ -171,7 +171,10 @@ REST_FRAMEWORK = {
     ),
     'DEFAULT_PAGINATION_CLASS': 'rest_framework.pagination.LimitOffsetPagination',  # noqa
     'PAGE_SIZE': 10,
-    'DEFAULT_METADATA_CLASS': 'ralph.lib.api.utils.RalphApiMetadata'
+    'DEFAULT_METADATA_CLASS': 'ralph.lib.api.utils.RalphApiMetadata',
+    'DEFAULT_VERSIONING_CLASS': 'rest_framework.versioning.AcceptHeaderVersioning',  # noqa
+    'DEFAULT_VERSION': 'v1',
+    'ALLOWED_VERSIONS': ('v1',)
 }
 
 REDIS_CONNECTION = {


### PR DESCRIPTION
Example: 
GET /bookings/ HTTP/1.1
Host: example.com
Accept: application/json; version=1.0
