### PR TITLE
Fixed ServiceEnvironment API

### DIFF
--- a/src/ralph/assets/tests/test_api.py
+++ b/src/ralph/assets/tests/test_api.py
@@ -109,6 +109,56 @@ class ServicesEnvironmentsAPITests(RalphAPITestCase):
         )
         self.assertIn(self.user2, service.technical_owners.all())
 
+    def test_patch_service_keep_environments_when_not_in_request(self):
+        """
+        Check if ServiceEnvironment for service are not cleaned after PATCH
+        without environments fields.
+        """
+        service = self.services[0]
+        environments_ids = [env.id for env in service.environments.all()]
+        service_env_ids = [
+            se.id for se in service.serviceenvironment_set.all()
+        ]
+        url = reverse('service-detail', args=(service.id,))
+        data = {
+            'name': 'test-service-2',
+        }
+        response = self.client.patch(url, data, format='json')
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        service.refresh_from_db()
+        self.assertEqual(service.name, 'test-service-2')
+        new_environments_ids = [env.id for env in service.environments.all()]
+        new_service_env_ids = [
+            se.id for se in service.serviceenvironment_set.all()
+        ]
+        self.assertCountEqual(environments_ids, new_environments_ids)
+        self.assertCountEqual(service_env_ids, new_service_env_ids)
+
+    def test_patch_service_keep_environments_ids(self):
+        """
+        Check if ServiceEnvironment ids are kept after PATCH.
+        """
+        service = self.services[0]
+        environments_ids = [env.id for env in service.environments.all()]
+        service_env_ids = [
+            se.id for se in service.serviceenvironment_set.all()
+        ]
+        url = reverse('service-detail', args=(service.id,))
+        data = {
+            'name': 'test-service-2',
+            'environments': environments_ids,
+        }
+        response = self.client.patch(url, data, format='json')
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        service.refresh_from_db()
+        self.assertEqual(service.name, 'test-service-2')
+        new_environments_ids = [env.id for env in service.environments.all()]
+        new_service_env_ids = [
+            se.id for se in service.serviceenvironment_set.all()
+        ]
+        self.assertCountEqual(environments_ids, new_environments_ids)
+        self.assertCountEqual(service_env_ids, new_service_env_ids)
+
     def test_get_service_environment(self):
         service_env = ServiceEnvironment.objects.all()[0]
         url = reverse('serviceenvironment-detail', args=(service_env.id,))

--- a/src/ralph/settings/base.py
+++ b/src/ralph/settings/base.py
@@ -124,7 +124,7 @@ MEDIA_ROOT = os.path.join(BASE_DIR, 'var', 'media')
 # adapt message's tags to bootstrap
 MESSAGE_TAGS = {
     messages.DEBUG: 'info',
-    messages.ERROR: 'danger',
+    messages.ERROR: 'alert',
 }
 
 DEFAULT_DEPRECIATION_RATE = 25


### PR DESCRIPTION
- environments are not longer removed when `environments` is missing in update request
- ServiceEnvironment ids are kept after update request
- small fix for error message color (working with foundation now)
