### PR TITLE
There are fileds without flatchoices property

### DIFF
--- a/src/ralph/admin/filters.py
+++ b/src/ralph/admin/filters.py
@@ -50,8 +50,11 @@ class BaseCustomFilter(FieldListFilter):
     def __init__(self, field, request, params, model, model_admin, field_path):
         self.lookup_kwarg = field_path
         self.model = model
-        if field.flatchoices:
-            self.choices_list = field.flatchoices
+        try:
+            if field.flatchoices:
+                self.choices_list = field.flatchoices
+        except AttributeError:
+            pass
         super().__init__(
             field, request, params, model, model_admin, field_path
         )


### PR DESCRIPTION
.flatchoices is property of `django.db.models.Field`, but
`django.db.models.fields.related.ForeignObjectRel` doesn't have it.
This check breaks filters on ForeignKey fields.
