### PR TITLE
Management IP for DataCenterAsset

### DIFF
--- a/src/ralph/attachments/migrations/0002_attachment_md5.py
+++ b/src/ralph/attachments/migrations/0002_attachment_md5.py
@@ -7,7 +7,7 @@ from ralph.attachments.models import Attachment
 
 def update_md5_checksum(apps, schema_editor):
     for item in Attachment.objects.all():
-        item.md5 = item.get_md5_sum()
+        item.md5 = item.get_md5_sum(item.file)
         item.save()
 
 

--- a/src/ralph/data_center/admin.py
+++ b/src/ralph/data_center/admin.py
@@ -142,7 +142,8 @@ class DataCenterAssetAdmin(
         }),
         (_('Location Info'), {
             'fields': (
-                'rack', 'position', 'orientation', 'slot_no', 'budget_info'
+                'rack', 'position', 'orientation', 'slot_no',
+                'management_ip', 'management_hostname',
             )
         }),
         (_('Usage info'), {
@@ -156,7 +157,7 @@ class DataCenterAssetAdmin(
                 'order_no', 'invoice_date', 'invoice_no', 'task_url', 'price',
                 'depreciation_rate', 'depreciation_end_date',
                 'force_depreciation', 'source', 'provider', 'delivery_date',
-
+                'budget_info',
             )
         }),
     )

--- a/src/ralph/data_center/migrations/0007_auto_20151120_1210.py
+++ b/src/ralph/data_center/migrations/0007_auto_20151120_1210.py
@@ -1,0 +1,25 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+import ralph.lib.mixins.fields
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('data_center', '0006_auto_20151120_0829'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='datacenterasset',
+            name='management_hostname',
+            field=ralph.lib.mixins.fields.NullableCharField(unique=True, max_length=100, null=True, blank=True),
+        ),
+        migrations.AddField(
+            model_name='datacenterasset',
+            name='management_ip',
+            field=models.GenericIPAddressField(help_text='Presented as string.', null=True, verbose_name='Management IP address', unique=True, default=None, blank=True),
+        ),
+    ]

--- a/src/ralph/data_center/models/physical.py
+++ b/src/ralph/data_center/models/physical.py
@@ -19,6 +19,7 @@ from ralph.data_center.models.choices import (
     Orientation,
     RackOrientation
 )
+from ralph.lib.mixins.fields import NullableCharField
 from ralph.lib.mixins.models import AdminAbsoluteUrlMixin
 from ralph.lib.transitions.decorators import transition_action
 from ralph.lib.transitions.fields import TransitionField
@@ -256,6 +257,28 @@ class DataCenterAsset(Asset):
     production_year = models.PositiveSmallIntegerField(null=True, blank=True)
     production_use_date = models.DateField(null=True, blank=True)
 
+    # Temporary solution until core functionality will not be fully migrated to
+    # NG
+    management_ip = models.GenericIPAddressField(
+        verbose_name=_('Management IP address'),
+        help_text=_('Presented as string.'),
+        unique=True,
+        blank=True,
+        null=True,
+        default=None,
+    )
+    management_hostname = NullableCharField(
+        max_length=100, unique=True, null=True, blank=True
+    )
+
+    # @property
+    # def management_ip(self):
+    #     """A property that gets management IP of a asset."""
+    #     management_ip = self.ipaddress_set.filter(
+    #         is_management=True
+    #     ).order_by('-address').first()
+    #     return management_ip.address if management_ip else ''
+
     class Meta:
         verbose_name = _('data center asset')
         verbose_name_plural = _('data center assets')
@@ -285,14 +308,6 @@ class DataCenterAsset(Asset):
         """Returns cores count assigned to device in Ralph"""
         asset_cores_count = self.model.cores_count if self.model else 0
         return asset_cores_count
-
-    @property
-    def management_ip(self):
-        """A property that gets management IP of a asset."""
-        management_ip = self.ipaddress_set.filter(is_management=True).order_by(
-            '-address'
-        ).first()
-        return management_ip.address if management_ip else ''
 
     def _validate_orientation(self):
         """

--- a/src/ralph/data_importer/resources.py
+++ b/src/ralph/data_importer/resources.py
@@ -139,19 +139,16 @@ class RackResource(ImportForeignKeyMixin, resources.ModelResource):
 
 
 class NetworkResource(ImportForeignKeyMixin, resources.ModelResource):
-
     data_center = fields.Field(
         column_name='data_center',
         attribute='data_center',
         widget=ImportedForeignKeyWidget(physical.DataCenter),
     )
-
     network_environment = fields.Field(
         column_name='network_environment',
         attribute='network_environment',
         widget=ImportedForeignKeyWidget(networks.NetworkEnvironment),
     )
-
     kind = fields.Field(
         column_name='kind',
         attribute='kind',

--- a/src/ralph/dc_view/serializers/models_serializer.py
+++ b/src/ralph/dc_view/serializers/models_serializer.py
@@ -88,7 +88,7 @@ class DataCenterAssetSerializer(DataCenterAssetSerializerBase):
         return TYPE_ASSET
 
     def get_management(self, obj):
-        return obj.management_ip
+        return obj.management_ip or ''
 
     class Meta:
         model = DataCenterAsset


### PR DESCRIPTION
TEMPORARY SOLUTION! (until core part of Ralph will not be fully migrated to NG)
- added management_ip and management_hostname to DataCenterAsset
- fixed attachment migration
