### PR TITLE
ServiceEnvironment inheriting from BaseObject

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,14 +4,13 @@ language: python
 env:
     global:
         - DATABASE_USER=travis
-        - DATABASE_PASSWORD=
+        - DATABASE_PASSWORD=travis
     matrix:
         - TEST_DB_ENGINE=mysql
         - TEST_DB_ENGINE=sqlite
 
 services:
-    - mysql
-    # - docker  # TEMPORARY - docker is not working with mysql
+    - docker
 
 cache:
   directories:
@@ -27,6 +26,7 @@ before_install:
     - make flake
     - export RALPH_VERSION=$(cat VERSION)
     - export NEW_TAG=$RALPH_VERSION-snapshot-$(date "+%Y%m%d")-$TRAVIS_BUILD_NUMBER
+    - if [[ $TEST_DB_ENGINE == mysql ]]; then docker run -d -v $(pwd)/docker/mysql.cnf:/etc/mysql/conf.d/mysql.cnf -p "3306:3306" -e "MYSQL_ALLOW_EMPTY_PASSWORD=yes" -e "MYSQL_DATABASE=ralph_ng" -e "MYSQL_ROOT_PASSWORD=root" -e "MYSQL_USER=travis" -e "MYSQL_PASSWORD=travis" mysql:5.6; fi
 
 install:
     - npm config set python /usr/bin/python2.7
@@ -50,12 +50,12 @@ before_deploy:
     - make build-package
 
 deploy:
-    # -   provider: script
-    #     script: scripts/travis_deploy_docker.sh
-    #     on:
-    #         branch: ng
-    #         python: 3.4
-    #         condition: $TEST_DB_ENGINE = mysql
+    -   provider: script
+        script: scripts/travis_deploy_docker.sh
+        on:
+            branch: ng
+            python: 3.4
+            condition: $TEST_DB_ENGINE = mysql
     -   provider: script
         script: scripts/travis_deploy_bintray.sh
         on:

--- a/docker/mysql.cnf
+++ b/docker/mysql.cnf
@@ -1,0 +1,11 @@
+[client]
+default-character-set=utf8
+
+[mysql]
+default-character-set=utf8
+
+
+[mysqld]
+collation-server = utf8_unicode_ci
+init-connect='SET NAMES utf8'
+character-set-server = utf8

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -15,6 +15,7 @@ pytz==2015.4
 redis==2.10.3
 rq==0.5.6
 six>=1.9.0
+sqlparse==0.1.16
 Unidecode==0.04.18
 git+https://github.com/kennethreitz/tablib.git@develop#egg=tablib
 git+http://github.com/idlesign/django-sitetree.git@a626559c39ff1e865cde3441c44f42864c648dfb

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -5,6 +5,7 @@ coverage
 coveralls
 ddt
 django-plainpasswordhasher
+django_migration_testcase
 factory-boy
 flake8
 sphinx

--- a/src/ralph/assets/admin.py
+++ b/src/ralph/assets/admin.py
@@ -27,7 +27,9 @@ class ServiceEnvironmentAdmin(RalphAdmin):
 
     search_fields = ['service__name', 'environment__name']
     list_select_related = ['service', 'environment']
+    raw_id_fields = ['service', 'environment']
     resource_class = resources.ServiceEnvironmentResource
+    exclude = ('parent', 'service_env')
 
 
 class ServiceEnvironmentInline(RalphTabularInline):

--- a/src/ralph/assets/api/serializers.py
+++ b/src/ralph/assets/api/serializers.py
@@ -73,13 +73,11 @@ class SaveServiceSerializer(RalphAPISerializer):
             )
         )
         # create ServiceEnv for new environments
-        service_env_to_create = []
         for environment in environments:
             if environment.id not in current_environments:
-                service_env_to_create.append(ServiceEnvironment(
+                ServiceEnvironment.objects.create(
                     service=instance, environment=environment
-                ))
-        ServiceEnvironment.objects.bulk_create(service_env_to_create)
+                )
 
     def create(self, validated_data):
         environments = validated_data.pop('environments', [])
@@ -105,6 +103,7 @@ class ServiceEnvironmentSerializer(RalphAPISerializer):
     class Meta:
         model = ServiceEnvironment
         depth = 1
+        exclude = ('content_type', 'parent', 'service_env')
 
 
 class ManufacturerSerializer(RalphAPISerializer):

--- a/src/ralph/assets/api/views.py
+++ b/src/ralph/assets/api/views.py
@@ -33,6 +33,7 @@ class ServiceViewSet(RalphAPIViewSet):
     queryset = models.Service.objects.all()
     serializer_class = serializers.ServiceSerializer
     save_serializer_class = serializers.SaveServiceSerializer
+    select_related = ['profit_center']
     prefetch_related = ['business_owners', 'technical_owners', 'environments']
 
 

--- a/src/ralph/assets/migrations/0010_service_env_inherits_base_object.py
+++ b/src/ralph/assets/migrations/0010_service_env_inherits_base_object.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+from ralph.assets.migrations._helpers import InheritFromBaseObject
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('assets', '0009_asset_property_of_rename'),
+    ]
+
+    operations = [
+        InheritFromBaseObject('assets', 'ServiceEnvironment'),
+        migrations.AlterField(
+            model_name='baseobject',
+            name='parent',
+            field=models.ForeignKey(to='assets.BaseObject', null=True, blank=True, related_name='children'),
+        ),
+    ]

--- a/src/ralph/assets/migrations/_helpers.py
+++ b/src/ralph/assets/migrations/_helpers.py
@@ -1,0 +1,152 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from collections import defaultdict
+from functools import partial
+
+from django.db import connection, migrations, models
+
+
+def baseobject_migration(
+    apps, schema_editor, app_name, model_name, rewrite_fields=None
+):
+    """
+    Handle ids (duplication) for new BaseObject inherited model.
+
+    Create new BaseObject instance for each old-type objects, then update
+    baseobject_ptr_id to point to new BaseObject id. At the end, update all
+    related models to new point to new ids.
+    """
+    model_str = '{}.{}'.format(app_name, model_name)
+    print('Inheriting {} from baseobject'.format(model_str))
+    Model = apps.get_model(app_name, model_name)
+    BaseObject = apps.get_model('assets', 'BaseObject')
+    ContentType = apps.get_model('contenttypes', 'ContentType')
+    model_content_type = ContentType.objects.get_for_model(Model)
+
+    id_mapping = {}
+    max_id = 0
+    print('Creating new IDs for {}'.format(model_str))
+    for obj in Model._default_manager.order_by('baseobject_ptr_id'):
+        # first of all, create new BaseObject instance for each object
+        # it's id will be later referenced as baseobject_ptr_id
+        base_object = BaseObject.objects.create(
+            content_type=model_content_type,
+            **{k: getattr(obj, v) for (k, v) in (rewrite_fields or {})}
+        )
+        old_pk = obj.pk
+        id_mapping[old_pk] = base_object.id
+        max_id = max(max_id, base_object.id)
+
+    # increase ID of each object by
+    Model._default_manager.update(
+        baseobject_ptr_id=models.F('baseobject_ptr_id') + max_id
+    )
+
+    for obj in Model._default_manager.order_by('baseobject_ptr_id'):
+        # use update instead of model save to call it directly in SQL without
+        # Django mediation (it will try to create new object instead of updating
+        # the old one)
+        old_pk = obj.pk
+        Model._default_manager.filter(baseobject_ptr_id=old_pk).update(
+            baseobject_ptr_id=id_mapping[old_pk - max_id],
+        )
+        print('Mapping {} to {}'.format(old_pk, id_mapping[old_pk - max_id]))
+    print(id_mapping)
+    print(max_id)
+    # save each obj once again to refresh content type etc
+    for obj in Model._default_manager.all():
+        obj.save()
+
+    # foreign keys
+    for relation in Model._meta.get_all_related_objects(local_only=True):
+        related_model = relation.related_model
+        relation_field = relation.field.attname
+        print('Processing relation {}<->{} using field {}'.format(
+            model_str, related_model, relation_field
+        ))
+        relation_mapping = defaultdict(list)
+        for related_object in related_model._default_manager.values_list(
+            'pk', relation_field
+        ):
+            relation_mapping[related_object[1]].append(related_object[0])
+        for old_id, new_id in id_mapping.items():
+            related_model._default_manager.filter(
+                pk__in=relation_mapping.get(old_id, [])
+            ).update(
+                **{relation_field: new_id}
+            )
+
+    # TODO: m2m?
+
+
+def _foreign_key_check_wrap(operations):
+    db_engine = connection.vendor
+    forward = reverse = None
+    if db_engine == 'mysql':
+        forward = 'SET foreign_key_checks=0;'
+        reverse = 'SET foreign_key_checks=1;'
+    # TODO: more engines
+
+    if forward or reverse:
+        operations = [
+            migrations.RunSQL(forward, reverse)
+        ] + operations + [
+            migrations.RunSQL(reverse, forward)
+        ]
+    return operations
+
+
+class InheritFromBaseObject(migrations.SeparateDatabaseAndState):
+    """
+    Handle migrating model to inherit from BaseObject.
+    """
+    def __init__(self, app_name, model_name, rewrite_fields=None):
+        baseobject_model_migration = partial(
+            baseobject_migration, app_name=app_name, model_name=model_name,
+            rewrite_fields=rewrite_fields,
+        )
+
+        # state operations are separated from database operations to handle this
+        # migration easily
+        # state operations are later used to determine changes for futher
+        # migrations (and are not applied directly on database - only on Django
+        # models)
+        # database operations are applied only on database (and not on Django
+        # models)
+        state_operations = [
+            migrations.RemoveField(
+                model_name=model_name.lower(),
+                name='id',
+            ),
+            migrations.AddField(
+                model_name=model_name.lower(),
+                name='baseobject_ptr',
+                field=models.OneToOneField(
+                    auto_created=True,
+                    to='assets.BaseObject',
+                    serialize=False,
+                    primary_key=True,
+                    parent_link=True
+                ),
+                preserve_default=False,
+            ),
+        ]
+
+        database_operations = [
+            migrations.RenameField(
+                model_name=model_name.lower(),
+                old_name='id',
+                new_name='baseobject_ptr_id'
+            ),
+            migrations.RunPython(
+                baseobject_model_migration,
+                # no need for reversing code - just keep id's as they are
+                reverse_code=migrations.RunPython.noop,
+            ),
+        ]
+
+        super().__init__(
+            database_operations=_foreign_key_check_wrap(database_operations),
+            state_operations=state_operations
+        )

--- a/src/ralph/assets/models/assets.py
+++ b/src/ralph/assets/models/assets.py
@@ -89,7 +89,7 @@ class Service(NamedMixin, TimeStampMixin, models.Model):
         return reverse('assets:service_detail', args=(self.pk,))
 
 
-class ServiceEnvironment(models.Model):
+class ServiceEnvironment(BaseObject):
     service = models.ForeignKey(Service)
     environment = models.ForeignKey(Environment)
 

--- a/src/ralph/assets/models/base.py
+++ b/src/ralph/assets/models/base.py
@@ -27,6 +27,8 @@ class BaseObject(
 
     """Base object mixin."""
 
-    parent = models.ForeignKey('self', null=True, blank=True)
+    parent = models.ForeignKey(
+        'self', null=True, blank=True, related_name='children'
+    )
     remarks = models.TextField(blank=True)
     service_env = models.ForeignKey('ServiceEnvironment', null=True)

--- a/src/ralph/assets/tests/test_migrations.py
+++ b/src/ralph/assets/tests/test_migrations.py
@@ -1,0 +1,66 @@
+from django.contrib.contenttypes.models import ContentType
+from django_migration_testcase import MigrationTest
+
+from ralph.assets.models import BaseObject, ObjectModelType, ServiceEnvironment
+
+
+class ServiceEnvironmentInheritingBaseObjectMigrationTest(MigrationTest):
+    app_name = 'assets'
+    before = '0009_asset_property_of_rename'
+    after = '0010_service_env_inherits_base_object'
+
+    def setUp(self):
+        super().setUp()
+
+    def test_migration(self):
+        print('testing service_env migration')
+        # before migration
+        ServiceEnvironmentBefore = self.get_model_before('ServiceEnvironment')
+        self.service = self.get_model_before('Service').objects.create(
+            name='test_service'
+        )
+        self.env = self.get_model_before('Environment').objects.create(
+            name='prod'
+        )
+        self.env2 = self.get_model_before('Environment').objects.create(
+            name='dev'
+        )
+        service_env = ServiceEnvironmentBefore.objects.create(
+            service=self.service, environment=self.env
+        )
+        ServiceEnvironmentBefore.objects.create(
+            service=self.service, environment=self.env2,
+        )
+        AssetBefore = self.get_model_before('Asset')
+        AssetModelBefore = self.get_model_before('AssetModel')
+        asset_model = AssetModelBefore.objects.create(
+            name='XYZ', type=ObjectModelType.data_center
+        )
+        asset = AssetBefore.objects.create(
+            service_env=service_env, force_depreciation=False, model=asset_model
+        )
+
+        self.assertEqual(ServiceEnvironmentBefore.objects.count(), 2)
+        base_objects_count = BaseObject.objects.count()
+
+        # run migration
+        self.run_migration()
+
+        # after migration
+        ServiceEnvironmentAfter = self.get_model_after('ServiceEnvironment')
+
+        self.assertEqual(ServiceEnvironmentAfter.objects.count(), 2)
+        self.assertEqual(BaseObject.objects.count(), base_objects_count + 2)
+
+        new_service_env = ServiceEnvironment.objects.get(
+            service_id=self.service.id, environment_id=self.env.id
+        )
+        self.assertEqual(new_service_env.pk, new_service_env.baseobject_ptr_id)
+        self.assertNotEqual(new_service_env.pk, service_env.id)
+
+        asset_new = self.get_model_after('Asset').objects.get(id=asset.id)
+        self.assertEqual(asset_new.service_env_id, new_service_env.pk)
+        self.assertEqual(
+            new_service_env.content_type,
+            ContentType.objects.get_for_model(ServiceEnvironment)
+        )

--- a/src/ralph/data_center/migrations/0006_auto_20151120_0829.py
+++ b/src/ralph/data_center/migrations/0006_auto_20151120_0829.py
@@ -2,6 +2,7 @@
 from __future__ import unicode_literals
 
 from django.db import migrations, models
+import django.db.models.deletion
 
 
 class Migration(migrations.Migration):
@@ -21,8 +22,8 @@ class Migration(migrations.Migration):
             field=models.ForeignKey(
                 to='assets.BaseObject',
                 default=None,
-                verbose_name='base_object',
-                on_delete=models.deletion.SET_NULL,
+                verbose_name='Base object',
+                on_delete=django.db.models.deletion.SET_NULL,
                 null=True,
                 blank=True
             ),

--- a/src/ralph/data_importer/tests/samples/back_office_assets.csv
+++ b/src/ralph/data_importer/tests/samples/back_office_assets.csv
@@ -1,3 +1,3 @@
 id,sn,model,force_depreciation,warehouse,service_env,region
-1,bo_asset_sn,1,1,1,service_1|environment_1,1
-2,bo_asset_sn2,1,1,1,service_1|environment_1,1
+112122,bo_asset_sn,1,1,1,service_1|environment_1,1
+212312,bo_asset_sn2,1,1,1,service_1|environment_1,1


### PR DESCRIPTION
ServiceEnvironment now inherits from BaseObject!

Added new migration operation which will help to inherit more models from BaseObject in the future. Basic steps:
- rename id to baseobject_ptr_id
- generate new ids for each instance
- fix foreign keys pointing to the old id

I've added new package 'django_migration_testcase' (MIT licence) to better test migrations in the future.
