### PR TITLE
Transition history import bugfix

### DIFF
--- a/src/ralph/data_importer/management/commands/import_attachments.py
+++ b/src/ralph/data_importer/management/commands/import_attachments.py
@@ -72,9 +72,12 @@ class Command(BaseCommand):
                     username=line.get('logged_user')
                 )
                 new_history = False
+                old_history_id = '{}|{}'.format(
+                    line.get('id'), line.get('asset')
+                )
                 try:
                     history = ImportedObjects.get_object_from_old_pk(
-                        TransitionsHistory, line.get('id')
+                        TransitionsHistory, old_history_id
                     )
                 except ImportedObjectDoesNotExist:
                     history = TransitionsHistory()
@@ -117,7 +120,7 @@ class Command(BaseCommand):
 
                 history.save()
                 if new_history:
-                    ImportedObjects.create(history, line.get('id'))
+                    ImportedObjects.create(history, old_history_id)
 
     def save_attachments(self, directory):
         with open(os.path.join(directory, 'attachments.csv')) as f:


### PR DESCRIPTION
Before starting to re-import code to be run:

```
for i in ImportedObjects.objects.filter(content_type=ContentType.objects.get_for_model(TransitionsHistory)).exclude(old_object_pk__icontains='|'):
    history = TransitionsHistory.objects.get(pk=i.object_pk)
    print(history.object_id, history.content_type)
    asset = history.content_type.model_class().objects.get(pk=history.object_id)
    old_asset_id = ImportedObjects.get_imported_id(asset)
    i.old_object_pk = '{}|{}'.format(i.old_object_pk, old_asset_id)
    i.save()
```
