### PR TITLE
Base object licence clean metgod bugfix

### DIFF
--- a/src/ralph/licences/models.py
+++ b/src/ralph/licences/models.py
@@ -262,7 +262,10 @@ class BaseObjectLicence(models.Model):
         bo_asset = getattr_dunder(
             self.base_object, 'asset__backofficeasset'
         )
-        if bo_asset and self.licence.region_id != bo_asset.region_id:
+        if (
+            bo_asset and self.licence and
+            self.licence.region_id != bo_asset.region_id
+        ):
             raise ValidationError(
                 _('Asset region is in a different region than licence.')
             )


### PR DESCRIPTION
Bugfix in BaseObjectLicence clean method.
If there was no license raised an exception.
