### PR TITLE
LDAP sync fix & accounts views improvements

### DIFF
--- a/src/ralph/accounts/admin.py
+++ b/src/ralph/accounts/admin.py
@@ -4,6 +4,7 @@ from django.contrib.auth.admin import GroupAdmin, UserAdmin
 from django.contrib.auth.models import Group
 from django.core.urlresolvers import reverse
 from django.db.models import Q
+from django.utils.functional import cached_property
 from django.utils.translation import ugettext_lazy as _
 
 from ralph.accounts.models import RalphUser, Region, Team
@@ -214,6 +215,35 @@ class RalphUserAdmin(UserAdmin, RalphAdmin):
 
 @register(Group)
 class RalphGroupAdmin(EditPermissionsFormMixin, GroupAdmin, RalphAdmin):
+    readonly_fields = ['ldap_mapping', 'users_list']
+    fieldsets = (
+        (None, {'fields': ['name', 'ldap_mapping', 'permissions']}),
+        ('Users', {'fields': ['users_list']}),
+    )
+
+    @cached_property
+    def _ldap_groups(self):
+        groups = {v: k for (k, v) in getattr(
+            settings, 'AUTH_LDAP_GROUP_MAPPING', {}
+        ).items()}
+        groups.update(getattr(settings, 'AUTH_LDAP_NESTED_GROUPS', {}))
+        return groups
+
+    def ldap_mapping(self, obj):
+        return self._ldap_groups.get(obj.name, '-')
+    ldap_mapping.short_description = _('LDAP mapping')
+
+    def users_list(self, obj):
+        users = []
+        for u in obj.user_set.order_by('username'):
+            users.append('<a href="{}">{}</a>'.format(
+                reverse("admin:accounts_ralphuser_change", args=(u.id,)),
+                str(u)
+            ))
+        return '<br>'.join(users)
+    users_list.short_description = _('Users list')
+    users_list.allow_tags = True
+
     def formfield_for_manytomany(self, db_field, request=None, **kwargs):
         if db_field.name == 'permissions':
             qs = kwargs.get('queryset', db_field.rel.to.objects)

--- a/src/ralph/accounts/ldap.py
+++ b/src/ralph/accounts/ldap.py
@@ -11,12 +11,6 @@ from django_auth_ldap.config import ActiveDirectoryGroupType
 # django_auth_ldap with value in settings.py and visible for each
 # ldap_user.
 LDAPSettings.defaults['GROUP_MAPPING'] = {}
-# list of groups names mapped from LDAP
-LDAP_GROUPS_NAMES = list(
-    getattr(settings, 'AUTH_LDAP_GROUP_MAPPING', {}).values()
-) + list(
-    getattr(settings, 'AUTH_LDAP_NESTED_GROUPS', {}).keys()
-)
 
 
 @receiver(populate_user)
@@ -36,6 +30,12 @@ def mirror_groups(self):
     target_group_names = frozenset(self._get_groups().get_group_names())
     # the only difference comparing to original django_auth_ldap:
     if getattr(settings, 'AUTH_LDAP_KEEP_NON_LDAP_GROUPS', False):
+        # list of groups names mapped from LDAP
+        LDAP_GROUPS_NAMES = list(
+            getattr(settings, 'AUTH_LDAP_GROUP_MAPPING', {}).values()
+        ) + list(
+            getattr(settings, 'AUTH_LDAP_NESTED_GROUPS', {}).keys()
+        )
         # include groups not mapped from LDAP into target groups names
         non_ad_groups = list(
             self._user.groups.exclude(name__in=LDAP_GROUPS_NAMES).values_list(

--- a/src/ralph/accounts/views.py
+++ b/src/ralph/accounts/views.py
@@ -3,14 +3,14 @@ from django.conf import settings
 from django.utils.translation import ugettext_lazy as _
 
 from ralph.accounts.admin import AssetList, AssignedLicenceList, UserInfoMixin
-from ralph.admin.mixins import RalphTemplateView
+from ralph.admin.mixins import RalphBaseTemplateView, RalphTemplateView
 
 
 class UserProfileView(RalphTemplateView):
     template_name = 'ralphuser/user_profile.html'
 
 
-class CurrentUserInfoView(UserInfoMixin, RalphTemplateView):
+class CurrentUserInfoView(UserInfoMixin, RalphBaseTemplateView):
     template_name = 'ralphuser/my_equipment.html'
 
     def get_context_data(self, **kwargs):

--- a/src/ralph/admin/mixins.py
+++ b/src/ralph/admin/mixins.py
@@ -286,17 +286,20 @@ class RalphStackedInline(
     pass
 
 
-class RalphTemplateView(TemplateView, metaclass=PermissionViewMetaClass):
-
+class RalphBaseTemplateView(TemplateView):
     def get_context_data(self, **kwargs):
-        context = super(RalphTemplateView, self).get_context_data(
-            **kwargs
-        )
+        context = super().get_context_data(**kwargs)
         context['site_header'] = settings.ADMIN_SITE_HEADER
         context['site_title'] = settings.ADMIN_SITE_TITLE
         # checks if user is allowed to see elements in template
         context['has_permission'] = self.request.user.is_authenticated()
         return context
+
+
+class RalphTemplateView(
+    RalphBaseTemplateView, metaclass=PermissionViewMetaClass
+):
+    pass
 
 
 class RalphMPTTAdmin(MPTTModelAdmin, RalphAdmin):


### PR DESCRIPTION
- parse ldap groups mapping in body of mirror_group function (this module is loaded in settings so settings cannot be readed at module level)
- fix my equipment view permissions
- show ldap group mapping in group view
- show users list in group view
