### PR TITLE
fixed unique validation for NullableCharField in bulk edit

### DIFF
--- a/src/ralph/back_office/admin.py
+++ b/src/ralph/back_office/admin.py
@@ -118,7 +118,7 @@ class BackOfficeAssetAdmin(
         'invoice_date', 'invoice_no', 'provider', 'task_url',
         'depreciation_rate', 'price', 'order_no', 'depreciation_end_date'
     ]
-    bulk_edit_no_fillable = ['barcode', 'sn', 'hostname']
+    bulk_edit_no_fillable = ['barcode', 'sn', 'imei', 'hostname']
     _invoice_report_name = 'invoice-back-office-asset'
     _invoice_report_item_fields = (
         AssetInvoiceReportMixin._invoice_report_item_fields + ['owner']

--- a/src/ralph/lib/mixins/fields.py
+++ b/src/ralph/lib/mixins/fields.py
@@ -1,7 +1,16 @@
 # -*- coding: utf-8 -*-
+from django import forms
 from django.contrib.contenttypes.models import ContentType
 from django.db import models
 from django.db.models.loading import get_model
+
+
+class NullableCharFormField(forms.CharField):
+    def to_python(self, value):
+        "Returns a Unicode object."
+        if value in self.empty_values:
+            return None
+        return super().to_python(value)
 
 
 class NullableCharFieldMixin(object):
@@ -17,6 +26,11 @@ class NullableCharFieldMixin(object):
 
     def get_prep_value(self, value):
         return value or None
+
+    def formfield(self, **kwargs):
+        defaults = {'form_class': NullableCharFormField}
+        defaults.update(kwargs)
+        return super().formfield(**defaults)
 
 
 class NullableCharField(


### PR DESCRIPTION
refer to https://github.com/django/django/blob/1.8.7/django/forms/models.py#L666

Django doesn't validate uniqueness when there is `None` in field value(s)
