### PR TITLE
changed SaveSecurityScanSerializer inheritance to RalphAPISaveSerializer

### DIFF
--- a/src/ralph/security/api.py
+++ b/src/ralph/security/api.py
@@ -4,6 +4,7 @@ from collections import OrderedDict
 from rest_framework import serializers
 
 from ralph.api import RalphAPISerializer, RalphAPIViewSet, router
+from ralph.api.serializers import RalphAPISaveSerializer
 from ralph.data_center.models.networks import IPAddress
 from ralph.security.models import SecurityScan, Vulnerability
 
@@ -27,7 +28,7 @@ class SecurityScanSerializer(RalphAPISerializer):
         model = SecurityScan
 
 
-class SaveSecurityScanSerializer(RalphAPISerializer):
+class SaveSecurityScanSerializer(RalphAPISaveSerializer):
 
     class Meta:
         model = SecurityScan

--- a/src/ralph/security/migrations/0002_auto_20151223_1000.py
+++ b/src/ralph/security/migrations/0002_auto_20151223_1000.py
@@ -1,0 +1,34 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('security', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='securityscan',
+            name='created',
+            field=models.DateTimeField(verbose_name='date created', auto_now_add=True),
+        ),
+        migrations.AlterField(
+            model_name='securityscan',
+            name='modified',
+            field=models.DateTimeField(auto_now=True, verbose_name='last modified'),
+        ),
+        migrations.AlterField(
+            model_name='vulnerability',
+            name='created',
+            field=models.DateTimeField(verbose_name='date created', auto_now_add=True),
+        ),
+        migrations.AlterField(
+            model_name='vulnerability',
+            name='modified',
+            field=models.DateTimeField(auto_now=True, verbose_name='last modified'),
+        ),
+    ]


### PR DESCRIPTION
change inherited serializer to SaveSecurityScanSerializer to properly handle related field in DRF default form (raw input instead of list of choices)
