### PR TITLE
Fixed permissions to additional list columns (non-models)

### DIFF
--- a/src/ralph/admin/mixins.py
+++ b/src/ralph/admin/mixins.py
@@ -253,20 +253,6 @@ class RalphAdminMixin(RalphAutocompleteMixin):
             request, object_id, version_id, extra_context
         )
 
-    def get_list_display(self, request):
-        """
-        Apply permissions to list columns.
-        """
-        list_display = super().get_list_display(request)
-        if isinstance(self.model, PermByFieldMixin):
-            list_display = [
-                field for field in list_display
-                if self.model.has_access_to_field(
-                    field, request.user, action='view'
-                )
-            ]
-        return list_display
-
     def get_queryset(self, *args, **kwargs):
         if self._queryset_manager:
             return getattr(self.model, self._queryset_manager).all()

--- a/src/ralph/lib/permissions/tests/admin.py
+++ b/src/ralph/lib/permissions/tests/admin.py
@@ -1,0 +1,19 @@
+from django.contrib import admin
+
+from ralph.lib.permissions.admin import PermissionAdminMixin
+from ralph.lib.permissions.tests.models import Article
+
+
+@admin.register(Article)
+class ArticleAdmin(PermissionAdminMixin, admin.ModelAdmin):
+    list_display = [
+        'author', 'title', 'content', 'custom_field_1', 'sample_admin_field',
+        'sample_admin_field_with_permissions', '_sample_property'
+    ]
+
+    def sample_admin_field(self, obj):
+        return 'abc'
+
+    def sample_admin_field_with_permissions(self, obj):
+        return 'def'
+    sample_admin_field_with_permissions._permission_field = 'custom_field_1'

--- a/src/ralph/lib/permissions/tests/models.py
+++ b/src/ralph/lib/permissions/tests/models.py
@@ -37,6 +37,14 @@ class Article(PermByFieldMixin, PermissionsForObjectMixin, models.Model):
     def __str__(self):
         return self.title
 
+    def _sample_property(self):
+        return '123'
+    _sample_property._permission_field = 'content'
+
+    @property
+    def sample_property(self):
+        return self._sample_property
+
 
 class LongArticle(Article):
     remarks = models.CharField(max_length=100)

--- a/src/ralph/lib/permissions/tests/test_admin.py
+++ b/src/ralph/lib/permissions/tests/test_admin.py
@@ -1,0 +1,62 @@
+from django.contrib.admin.sites import site
+from django.contrib.auth.models import Permission
+from django.contrib.contenttypes.models import ContentType
+from django.test import RequestFactory, TestCase
+
+from ralph.lib.permissions.tests._base import PermissionsTestMixin
+from ralph.lib.permissions.tests.models import Article
+
+
+class PermissionPerFieldAdminMixinTestCase(PermissionsTestMixin, TestCase):
+    def setUp(self):
+        self._create_users_and_articles()
+        self.admin = site._registry[Article]
+        self.request_factory = RequestFactory()
+
+    def _get_list_display(self, user):
+        request = self.request_factory.get('/')
+        request.user = user
+        return self.admin.get_list_display(request)
+
+    def test_admin_list_display_for_superuser(self):
+        list_display = self._get_list_display(self.superuser)
+        self.assertEqual(list_display, self.admin.list_display)
+
+    def test_admin_list_display_without_model_field(self):
+        self.user2.user_permissions.remove(Permission.objects.get(
+            content_type=ContentType.objects.get_for_model(Article),
+            codename='view_article_title_field'
+        ))
+        self.user2.user_permissions.remove(Permission.objects.get(
+            content_type=ContentType.objects.get_for_model(Article),
+            codename='change_article_title_field'
+        ))
+        list_display = self._get_list_display(self.user2)
+        user_list_display = self.admin.list_display[:]
+        user_list_display.remove('title')
+        self.assertEqual(list_display, user_list_display)
+
+    def test_admin_list_display_without_model_property(self):
+        self.user2.user_permissions.remove(Permission.objects.get(
+            content_type=ContentType.objects.get_for_model(Article),
+            codename='view_article_content_field'
+        ))
+        self.user2.user_permissions.remove(Permission.objects.get(
+            content_type=ContentType.objects.get_for_model(Article),
+            codename='change_article_content_field'
+        ))
+        list_display = self._get_list_display(self.user2)
+        user_list_display = self.admin.list_display[:]
+        # permission to sample_property is set based on content field
+        user_list_display.remove('content')
+        user_list_display.remove('_sample_property')
+        self.assertEqual(list_display, user_list_display)
+
+    def test_admin_list_display_without_admin_field(self):
+        list_display = self._get_list_display(self.user1)
+        user_list_display = self.admin.list_display[:]
+        # permission to sample_admin_field_with_permissions is set based
+        # on custom_field_1 field
+        user_list_display.remove('custom_field_1')
+        user_list_display.remove('sample_admin_field_with_permissions')
+        self.assertEqual(list_display, user_list_display)

--- a/src/ralph/lib/permissions/tests/test_permissions_by_field.py
+++ b/src/ralph/lib/permissions/tests/test_permissions_by_field.py
@@ -4,8 +4,6 @@ from django.test import RequestFactory, TestCase
 
 from ralph.assets.models.assets import AssetModel
 from ralph.assets.models.choices import ObjectModelType
-from ralph.data_center.models.physical import DataCenterAsset
-from ralph.lib.permissions.admin import PermissionAdminMixin
 from ralph.lib.permissions.models import get_perm_key
 
 
@@ -116,34 +114,4 @@ class PermissionsByFieldTestCase(TestCase):
         self.assertNotIn(
             'manufacturer',
             fields_list
-        )
-
-    def test_get_list_display(self):
-        """Test get list display from PermissionAdminMixin."""
-        request = self.request_factory.get('/')
-        request.user = self.user
-        permission_admin = PermissionAdminMixin()
-        permission_admin.list_display = [
-            'status', 'barcode', 'purchase_order', 'model',
-            'sn', 'hostname', 'invoice_date', 'invoice_no',
-        ]
-        # TODO Change to test models separated from ralph
-        permission_admin.model = DataCenterAsset()
-
-        self.assertListEqual(
-            ['barcode', 'sn'],
-            permission_admin.get_list_display(request),
-        )
-
-    def test_get_empty_list_display(self):
-        request = self.request_factory.get('/')
-        request.user = self.user
-        permission_admin = PermissionAdminMixin()
-
-        # TODO Change to test models separated from ralph
-        permission_admin.model = DataCenterAsset()
-        permission_admin.list_display = []
-        self.assertListEqual(
-            ['__str__'],
-            permission_admin.get_list_display(request),
         )

--- a/src/ralph/licences/models.py
+++ b/src/ralph/licences/models.py
@@ -221,12 +221,14 @@ class Licence(Regionalizable, AdminAbsoluteUrlMixin, BaseObject):
             def get_sum(qs):
                 return qs.aggregate(sum=Sum('quantity'))['sum'] or 0
             return sum(map(get_sum, [base_objects_qs, users_qs]))
+    used._permission_field = 'number_bought'
 
     @cached_property
     def free(self):
         if not self.pk:
             return 0
         return self.number_bought - self.used
+    free._permission_field = 'number_bought'
 
     @classmethod
     def get_autocomplete_queryset(cls):


### PR DESCRIPTION
- before this commit, additional columns (created from property on model or function in admin) were visable only to superuser
- now such columns are by default visible to everyone (who has permission to model)
- there is possibility to specify model-field which will be used as permissions to such additional column
