### PR TITLE
Fixed transtion assign loan end date field

### DIFF
--- a/src/ralph/back_office/models.py
+++ b/src/ralph/back_office/models.py
@@ -274,7 +274,7 @@ class BackOfficeAsset(Regionalizable, Asset):
     @transition_action(
         form_fields={
             'loan_end_date': {
-                'field': forms.CharField(
+                'field': forms.DateField(
                     label=_('Loan end date'),
                     widget=forms.TextInput(attrs={'class': 'datepicker'})
                 )


### PR DESCRIPTION
Previous field (TextField) assigned date as string to BO Asset object, which causes reversion to crash when serializing object (`datetime.date` was expected to call isoformat on it). Changed field to `DateField`
