### PR TITLE
Update gitignore.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,7 +56,6 @@ docs/_build/
 src/ralph_assets
 src/ralph/settings/*local.py
 src/ralph/urls/*local.py
-!/src/ralph/lib
 
 # Vagrant
 vagrant/.vagrant
@@ -74,3 +73,5 @@ src/ralph/static/vendor/
 src/ralph/var/
 
 debian/ralph-core*
+
+.idea


### PR DESCRIPTION
1. Add `.idea` for Jetbrain IDE's.
2. Remove exclusion for `src/ralph/lib`. Then `__pycache__` under this can be ignored.
