### PR TITLE
Fixed slot_no validation

### DIFF
--- a/src/ralph/data_center/models/physical.py
+++ b/src/ralph/data_center/models/physical.py
@@ -377,7 +377,7 @@ class DataCenterAsset(Asset):
             raise ValidationError({'position': [msg]})
 
     def _validate_slot_no(self):
-        if self.model and self.model.has_parent and not self.slot_no:
+        if self.model_id and self.model.has_parent and not self.slot_no:
             raise ValidationError({
                 'slot_no': 'Slot number is required when asset is blade'
             })

--- a/src/ralph/data_center/tests/test_models.py
+++ b/src/ralph/data_center/tests/test_models.py
@@ -284,6 +284,11 @@ class DataCenterAssetTest(RalphTestCase):
         dc_asset.slot_no = '1A'
         dc_asset._validate_slot_no()
 
+    def test_should_pass_when_slot_not_filled_without_model(self):
+        dc_asset = DataCenterAsset()
+        dc_asset.slot_no = '1A'
+        dc_asset._validate_slot_no()
+
 
 @ddt
 class RackTest(RalphTestCase):


### PR DESCRIPTION
When model is not assigned, slot_no validation raised `RelatedObjectDoesNotExist`. Now model_id is checked instead of model.
