### PR TITLE
Turn on/off position requirement for rack

### DIFF
--- a/src/ralph/data_center/migrations/0005_rack_require_position.py
+++ b/src/ralph/data_center/migrations/0005_rack_require_position.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('data_center', '0004_auto_20151204_0758'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='rack',
+            name='require_position',
+            field=models.BooleanField(help_text='Uncheck if position is optional for this rack (ex. when rack has warehouse-kind role', default=True),
+        ),
+    ]


### PR DESCRIPTION
- added additional param to rack: require position
- when rack requires position, each asset belonging to this rack has to have non-empty position
- when rack does not require position (ex. warehouse-like rack), position could be empty (it's different than Ralph 2.0 behaviour, which required position for every asset)
