### PR TITLE
Enable to clear some fields during multiadd

### DIFF
--- a/src/ralph/admin/tests/tests_multiadd.py
+++ b/src/ralph/admin/tests/tests_multiadd.py
@@ -210,3 +210,85 @@ class MultiAddTest(ClientMixin, TestCase):
             'position',
             'Enter a valid number.'
         )
+
+    def test_multi_add_dc_with_clearing_mgmt(self):
+        dca = DataCenterAssetFactory(
+            management_ip='10.20.30.40',
+            management_hostname='abc.def'
+        )
+        dca_count = DataCenterAsset.objects.count()
+        dca_count_empty_mgmt = DataCenterAsset.objects.filter(
+            management_ip__isnull=True,
+            management_hostname__isnull=True,
+        ).count()
+        post_data = {
+            'sn': 'dc_sn,dc_sn2',
+            'barcode': 'dc_barcode,dc_barcode2'
+        }
+        response = self.client.post(
+            reverse(
+                self.dc_admin.get_url_name(),
+                args=[dca.pk]
+            ),
+            post_data,
+            follow=True
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(DataCenterAsset.objects.count(), dca_count + 2)
+
+        result = DataCenterAsset.objects.filter(
+            management_ip='10.20.30.40',
+            management_hostname='abc.def',
+        ).count()
+        self.assertEqual(result, 1)
+
+        result = DataCenterAsset.objects.filter(
+            management_ip__isnull=True,
+            management_hostname__isnull=True,
+        ).count()
+        self.assertEqual(result, dca_count_empty_mgmt + 2)
+
+    @override_settings(MULTIADD_DATA_CENTER_ASSET_FIELDS=[
+        {'field': 'sn', 'allow_duplicates': False},
+        {'field': 'barcode', 'allow_duplicates': False},
+        {'field': 'management_ip', 'allow_duplicates': False},
+        {'field': 'management_hostname', 'allow_duplicates': False},
+    ])
+    def test_multi_add_dc_with_clearing_mgmt_and_mgmt_fields(self):
+        dca = DataCenterAssetFactory(
+            management_ip='10.20.30.40',
+            management_hostname='abc.def'
+        )
+        dca_count = DataCenterAsset.objects.count()
+        post_data = {
+            'sn': 'dc_sn,dc_sn2',
+            'barcode': 'dc_barcode,dc_barcode2',
+            'management_ip': '10.20.30.41,10.20.30.42',
+            'management_hostname': 'abc.def2,abc.def3',
+        }
+        response = self.client.post(
+            reverse(
+                self.dc_admin.get_url_name(),
+                args=[dca.pk]
+            ),
+            post_data,
+            follow=True
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(DataCenterAsset.objects.count(), dca_count + 2)
+
+        result = DataCenterAsset.objects.filter(
+            management_ip='10.20.30.41',
+            management_hostname='abc.def2',
+            sn='dc_sn',
+            barcode='dc_barcode',
+        ).count()
+        self.assertEqual(result, 1)
+
+        result = DataCenterAsset.objects.filter(
+            management_ip='10.20.30.42',
+            management_hostname='abc.def3',
+            sn='dc_sn2',
+            barcode='dc_barcode2',
+        ).count()
+        self.assertEqual(result, 1)

--- a/src/ralph/admin/views/multiadd.py
+++ b/src/ralph/admin/views/multiadd.py
@@ -36,6 +36,7 @@ class MultiAddView(RalphTemplateView):
         self.info_fields = admin_model.multiadd_info_fields
         self.obj = get_object_or_404(model, pk=object_pk)
         self.fields = admin_model.get_multiadd_fields(obj=self.obj)
+        self.clear_fields = admin_model.get_multiadd_clear_fields(obj=self.obj)
         self.one_of_mulitval_required = admin_model.one_of_mulitvalue_required
         return super().dispatch(request, *args, **kwargs)
 
@@ -116,6 +117,9 @@ class MultiAddView(RalphTemplateView):
                 setattr(self.obj, field, None)
             self.obj.id = self.obj.pk = None
 
+            for field in self.clear_fields:
+                setattr(self.obj, field['field'], field['value'])
+
             for i, field in enumerate(self.fields):
                 setattr(self.obj, field['field'], data[i])
 
@@ -162,6 +166,7 @@ class MulitiAddAdminMixin(object):
 
     view = MultiAddView
     one_of_mulitvalue_required = []
+    multiadd_clear_fields = []
 
     @property
     def multiadd_info_fields(self):
@@ -169,6 +174,9 @@ class MulitiAddAdminMixin(object):
 
     def get_multiadd_fields(self, obj=None):
         raise NotImplementedError()
+
+    def get_multiadd_clear_fields(self, obj=None):
+        return self.multiadd_clear_fields
 
     def get_url_name(self, with_namespace=True):
         return get_model_view_url_name(self.model, 'multiadd', with_namespace)

--- a/src/ralph/data_center/admin.py
+++ b/src/ralph/data_center/admin.py
@@ -140,6 +140,10 @@ class DataCenterAssetAdmin(
     raw_id_fields = ['model', 'rack', 'service_env', 'parent', 'budget_info']
     raw_id_override_parent = {'parent': DataCenterAsset}
     _invoice_report_name = 'invoice-data-center-asset'
+    multiadd_clear_fields = [
+        {'field': 'management_ip', 'value': None},
+        {'field': 'management_hostname', 'value': None},
+    ]
 
     fieldsets = (
         (_('Basic info'), {

--- a/src/ralph/lib/mixins/fields.py
+++ b/src/ralph/lib/mixins/fields.py
@@ -17,7 +17,7 @@ class NullableCharFormField(NullableFormFieldMixin, forms.CharField):
     pass
 
 
-class NullableGenericIPAddressField(
+class NullableGenericIPAddressFormField(
     NullableFormFieldMixin, forms.GenericIPAddressField
 ):
     pass
@@ -34,10 +34,10 @@ class NullableCharFieldMixin(object):
     _formfield_class = NullableCharFormField
 
     def to_python(self, value):
-        return value or ''
+        return super().to_python(value) or ''
 
     def get_prep_value(self, value):
-        return value or None
+        return super().get_prep_value(value) or None
 
     def formfield(self, **kwargs):
         defaults = {}
@@ -56,10 +56,10 @@ class NullableCharField(
 
 
 class NullableGenericIPAddressField(
-    NullableCharField,
+    NullableCharFieldMixin,
     models.GenericIPAddressField
 ):
-    _formfield_class = NullableGenericIPAddressField
+    _formfield_class = NullableGenericIPAddressFormField
 
 
 class BaseObjectForeignKey(models.ForeignKey):


### PR DESCRIPTION
Some (unique) fields should be cleared for duplicated objects, ex. management ip and hostname for DataCenterAsset. This PR adds the ability to specify what fields should be cleared (and using what value) during duplication.
