### PR TITLE
Change AssetModel required fields

### DIFF
--- a/src/ralph/assets/migrations/0008_auto_20160122_1429.py
+++ b/src/ralph/assets/migrations/0008_auto_20160122_1429.py
@@ -1,0 +1,30 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+import django.core.validators
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('assets', '0007_auto_20160122_1022'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='assetmodel',
+            name='cores_count',
+            field=models.PositiveIntegerField(verbose_name='Cores count', default=0),
+        ),
+        migrations.AlterField(
+            model_name='assetmodel',
+            name='height_of_device',
+            field=models.FloatField(verbose_name='Height of device', validators=[django.core.validators.MinValueValidator(0)], default=0),
+        ),
+        migrations.AlterField(
+            model_name='assetmodel',
+            name='power_consumption',
+            field=models.PositiveIntegerField(verbose_name='Power consumption', default=0),
+        ),
+    ]

--- a/src/ralph/assets/models/assets.py
+++ b/src/ralph/assets/models/assets.py
@@ -122,18 +122,15 @@ class AssetModel(
     )
     power_consumption = models.PositiveIntegerField(
         verbose_name=_("Power consumption"),
-        blank=True,
         default=0,
     )
     height_of_device = models.FloatField(
         verbose_name=_("Height of device"),
-        blank=True,
         default=0,
         validators=[MinValueValidator(0)],
     )
     cores_count = models.PositiveIntegerField(
         verbose_name=_("Cores count"),
-        blank=True,
         default=0,
     )
     visualization_layout_front = models.PositiveIntegerField(


### PR DESCRIPTION
power_consumption, cores_count and height_of_device cannot be blank anymore (raised IntegrityError, since they cannot be null).
