### PR TITLE
Fixed tablib version

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -17,5 +17,5 @@ rq==0.5.6
 six>=1.9.0
 sqlparse==0.1.16
 Unidecode==0.04.18
-git+https://github.com/kennethreitz/tablib.git@develop#egg=tablib
+tablib==0.11.2
 git+http://github.com/idlesign/django-sitetree.git@a626559c39ff1e865cde3441c44f42864c648dfb


### PR DESCRIPTION
New version of tablib was released (0.11.X) which fixes Python 3.4 installation bugs. Besides that, develop branch was removed from tablib repository.
