### PR TITLE
Fixed 500 errors in transitions

### DIFF
--- a/src/ralph/lib/transitions/models.py
+++ b/src/ralph/lib/transitions/models.py
@@ -314,7 +314,7 @@ def get_available_transitions_for_field(instance, field, user=None):
     Returns list of all available transitions for field.
     """
     if not hasattr(instance, 'transition_models'):
-        return
+        return []
     transitions = Transition.objects.filter(
         model=instance.transition_models[field],
     )

--- a/src/ralph/lib/transitions/templatetags/transitions_tags.py
+++ b/src/ralph/lib/transitions/templatetags/transitions_tags.py
@@ -9,7 +9,7 @@ register = template.Library()
 def available_transitions(context, obj, field):
     """Render available transitions for instance."""
     get_available_transitions = getattr(
-        obj, 'get_available_transitions_for_{}'.format(field), None
+        obj, 'get_available_transitions_for_{}'.format(field), lambda user: []
     )
     if get_available_transitions:
         transitions = []


### PR DESCRIPTION
- When object does not have `get_available_transitions_for_<field>` method, `None` was used before and later called as a function - i've replaced it with lambda
- When model does not have `transition_models`, None was returned which was iterated by later - now empty list is returned

These bugs appears on demo instance during preparation to FOSDEM.
