### PR TITLE
Change get_queryset in django popup view.

### DIFF
--- a/src/ralph/admin/views/main.py
+++ b/src/ralph/admin/views/main.py
@@ -55,7 +55,13 @@ class RalphChangeList(ChangeList):
         return ordering
 
     def get_queryset(self, request):
-        queryset = None
+        queryset = super().get_queryset(request)
         if self.is_popup:
-            queryset = getattr(self.model, 'get_autocomplete_queryset', None)
-        return queryset() if queryset else super().get_queryset(request)
+            # For popup window we limit display of records to the same as
+            # we have in the autocomplete widget.
+            autocomplete_queryset = getattr(
+                self.model, 'get_autocomplete_queryset', None
+            )
+            if autocomplete_queryset:
+                queryset = queryset & autocomplete_queryset()
+        return queryset

--- a/src/ralph/api/tests/test_viewsets.py
+++ b/src/ralph/api/tests/test_viewsets.py
@@ -191,5 +191,5 @@ class TestAdminSearchFieldsMixin(RalphTestCase):
     def test_get_filter_fields_from_admin(self):
         cvs = CarViewSet()
         self.assertEqual(
-            cvs.filter_fields, ['manufacturer__name', 'year']
+            cvs.filter_fields, ['manufacturer__name', 'name', 'year']
         )

--- a/src/ralph/tests/admin.py
+++ b/src/ralph/tests/admin.py
@@ -9,6 +9,7 @@ from ralph.tests.models import Bar, Car, Car2, Manufacturer, Order
 class CarAdmin(RalphAdmin):
     ordering = ['name']
     list_filter = ['year']
+    search_fields = ['name']
 
 
 @register(Bar)

--- a/src/ralph/tests/models.py
+++ b/src/ralph/tests/models.py
@@ -39,6 +39,10 @@ class Car(models.Model):
     manufacturer._autocomplete = False
     manufacturer._filter_title = 'test'
 
+    @classmethod
+    def get_autocomplete_queryset(cls):
+        return cls.objects.filter(year=2015)
+
 
 class Car2(models.Model):
     manufacturer = models.ForeignKey(Manufacturer)


### PR DESCRIPTION
In method get_queryset in RalphChangeList checked whether the request is a django POPUP, then checked whether the model has a method get_queryset_autocomplete and we turned back.
Then we overwrite queryset in POPUP and we return queryset from autocomplete and not from Django ChangeList.
