### PR TITLE
Limit scan ganeti plugin calls

### DIFF
--- a/src/ralph/scan/plugins/ssh_ganeti.py
+++ b/src/ralph/scan/plugins/ssh_ganeti.py
@@ -95,6 +95,10 @@ def scan_address(ip_address, **kwargs):
     snmp_name = kwargs.get('snmp_name', '') or ''
     if 'nx-os' in snmp_name.lower():
         raise NoMatchError("Incompatible nexus found")
+    http_family = kwargs.get('http_family')
+    # for ganeti servers, we don't know http_family
+    if http_family != 'Unspecified':
+        raise NoMatchError('It is not Ganeti.')
     device = run_ssh_ganeti(ip_address)
     ret = {
         'status': 'success',


### PR DESCRIPTION
For ganeti system http_family is Unspecified, so there is no need to try call ip's which http family is different.
