### PR TITLE
Fixed autocomplete unique queryset bug

### DIFF
--- a/src/ralph/admin/views/main.py
+++ b/src/ralph/admin/views/main.py
@@ -63,5 +63,18 @@ class RalphChangeList(ChangeList):
                 self.model, 'get_autocomplete_queryset', None
             )
             if autocomplete_queryset:
-                queryset = queryset & autocomplete_queryset()
+                autocomplete_queryset = autocomplete_queryset()
+                # #2248 - cannot combine unique (distinct) and non-unique query
+                # if one of the queries is distinct, make sure all are distinct
+                if (
+                    queryset.query.distinct and
+                    not autocomplete_queryset.query.distinct
+                ):
+                    autocomplete_queryset = autocomplete_queryset.distinct()
+                if (
+                    not queryset.query.distinct and
+                    autocomplete_queryset.query.distinct
+                ):
+                    queryset = queryset.distinct()
+                queryset = queryset & autocomplete_queryset
         return queryset

--- a/src/ralph/api/tests/test_viewsets.py
+++ b/src/ralph/api/tests/test_viewsets.py
@@ -191,5 +191,6 @@ class TestAdminSearchFieldsMixin(RalphTestCase):
     def test_get_filter_fields_from_admin(self):
         cvs = CarViewSet()
         self.assertEqual(
-            cvs.filter_fields, ['manufacturer__name', 'name', 'year']
+            cvs.filter_fields,
+            ['manufacturer__name', 'name', 'foos__bar', 'year']
         )

--- a/src/ralph/tests/admin.py
+++ b/src/ralph/tests/admin.py
@@ -9,7 +9,7 @@ from ralph.tests.models import Bar, Car, Car2, Manufacturer, Order
 class CarAdmin(RalphAdmin):
     ordering = ['name']
     list_filter = ['year']
-    search_fields = ['name']
+    search_fields = ['name', 'foos__bar']
 
 
 @register(Bar)

--- a/src/ralph/tests/migrations/0004_car_foos.py
+++ b/src/ralph/tests/migrations/0004_car_foos.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('tests', '0003_bar'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='car',
+            name='foos',
+            field=models.ManyToManyField(to='tests.Foo'),
+        ),
+    ]

--- a/src/ralph/tests/models.py
+++ b/src/ralph/tests/models.py
@@ -38,6 +38,7 @@ class Car(models.Model):
     manufacturer = models.ForeignKey(Manufacturer)
     manufacturer._autocomplete = False
     manufacturer._filter_title = 'test'
+    foos = models.ManyToManyField(Foo)
 
     @classmethod
     def get_autocomplete_queryset(cls):


### PR DESCRIPTION
Fixed #2248 bug introduced in 53c8dd3 - distinct (unique) queryset cannot be combined with non-distinct (non-unique) queryset.
Solution: if one of the querysets is disctinct, make all of them distinct.
