### PR TITLE
Operations fixes

### DIFF
--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1,5 +1,5 @@
 -r test.txt
-django-debug-toolbar
+git+http://github.com/django-debug-toolbar/django-debug-toolbar.git@0ed1538374d3dc41d51fc562b4e8be6ce8208552
 Werkzeug
 pudb
 ipython

--- a/src/ralph/admin/mixins.py
+++ b/src/ralph/admin/mixins.py
@@ -323,7 +323,13 @@ class RalphMPTTAdmin(MPTTModelAdmin, RalphAdmin):
     form = RalphMPTTAdminForm
 
 
+class RalphInlineMixin(object):
+    # display change link for inline row in popup
+    change_link_url_params = '_popup=1'
+
+
 class RalphTabularInline(
+    RalphInlineMixin,
     RalphAutocompleteMixin,
     admin.TabularInline
 ):
@@ -331,6 +337,7 @@ class RalphTabularInline(
 
 
 class RalphStackedInline(
+    RalphInlineMixin,
     RalphAutocompleteMixin,
     admin.StackedInline
 ):

--- a/src/ralph/admin/templates/admin/base.html
+++ b/src/ralph/admin/templates/admin/base.html
@@ -77,26 +77,7 @@
       {{ media.js }}
       <!-- extra media -->
       {% block extra_scripts %}{% endblock %}
-      {% block admin_change_form_document_ready %}
-        <script type="text/javascript">
-          (function($) {
-            $(document).ready(function() {
-              $('.add-related').click(function(e) {
-                e.preventDefault();
-                showAddAnotherPopup(this);
-              });
-              $('.related-lookup').click(function(e) {
-                e.preventDefault();
-                showRelatedObjectLookupPopup(this);
-              });
-              $('.change-related').click(function(e) {
-                e.preventDefault();
-                showRelatedObjectPopup(this);
-              });
-            });
-          })(django.jQuery);
-        </script>
-      {% endblock %}
+      {% block admin_change_form_document_ready %}{% endblock %}
     {% endblock %}
     {% download_attachment %}
   </body>

--- a/src/ralph/admin/templates/admin/edit_inline/tabular.html
+++ b/src/ralph/admin/templates/admin/edit_inline/tabular.html
@@ -38,7 +38,7 @@
             <tr class="form-row {% cycle "row1" "row2" %} {% if inline_admin_form.original or inline_admin_form.show_url %}has_original{% endif %}{% if forloop.last %} empty-form{% endif %}" id="{{ inline_admin_formset.formset.prefix }}-{% if not forloop.last %}{{ forloop.counter0 }}{% else %}empty{% endif %}">
               <td class="original">
                 {% if inline_admin_form.original and inline_admin_form.model_admin.show_change_link and inline_admin_form.model_admin.has_registered_model %}
-                  <a href="{% url inline_admin_form.model_admin.opts|admin_urlname:'change' inline_admin_form.original.pk|admin_urlquote %}" class="inlinechangelink change-related" title="{% trans 'Change' %}">
+                  <a href="{% url inline_admin_form.model_admin.opts|admin_urlname:'change' inline_admin_form.original.pk|admin_urlquote %}?{{ inline_admin_form.model_admin.change_link_url_params }}" class="inlinechangelink change-related" title="{% trans 'Change' %}">
                     <i class="fa fa-pencil fa-lg"></i>
                   </a>
                 {% endif %}

--- a/src/ralph/operations/tests/factories.py
+++ b/src/ralph/operations/tests/factories.py
@@ -1,0 +1,53 @@
+# -*- coding: utf-8 -*-
+import factory
+from factory.django import DjangoModelFactory
+
+from ralph.operations.models import (
+    Change,
+    Failure,
+    Incident,
+    Operation,
+    OperationStatus,
+    OperationType,
+    Problem
+)
+
+
+def get_operation_type(name):
+    return OperationType.objects.get(name=name)
+
+
+class OperationFactory(DjangoModelFactory):
+
+    title = factory.Sequence(lambda n: 'Operation #%d' % n)
+    status = OperationStatus.opened
+    type = factory.LazyAttribute(lambda obj: get_operation_type('Change'))
+
+    class Meta:
+        model = Operation
+
+
+class ChangeFactory(OperationFactory):
+    class Meta:
+        model = Change
+
+
+class FailureFactory(OperationFactory):
+    type = factory.LazyAttribute(lambda obj: get_operation_type('Failure'))
+
+    class Meta:
+        model = Failure
+
+
+class ProblemFactory(OperationFactory):
+    type = factory.LazyAttribute(lambda obj: get_operation_type('Problem'))
+
+    class Meta:
+        model = Problem
+
+
+class IncidentFactory(OperationFactory):
+    type = factory.LazyAttribute(lambda obj: get_operation_type('Incident'))
+
+    class Meta:
+        model = Incident

--- a/src/ralph/operations/tests/test_models.py
+++ b/src/ralph/operations/tests/test_models.py
@@ -1,0 +1,18 @@
+from django.forms import ValidationError
+
+from ralph.operations.models import OperationType
+from ralph.operations.tests.factories import FailureFactory
+from ralph.tests import RalphTestCase
+
+
+class OperationModelsTestCase(RalphTestCase):
+    def setUp(self):
+        self.failure = FailureFactory()
+
+    def test_wrong_type(self):
+        self.failure.type = OperationType.objects.get(name='Change')
+        with self.assertRaises(
+            ValidationError,
+            msg='Invalid Operation type. Choose descendant of Failure'
+        ):
+            self.failure.clean()


### PR DESCRIPTION
- limit possible type choices by Operation main type (Failure, Change etc)
- fixed doubled popup when changing Operation from DCA view
- changed base objects widget to M2M
- fixed Django Debug Toolbar to work with iron-flex-layout
- add popup to Operation change link in DCA tab
