### PR TITLE
Disable pylint error on landscape.io

### DIFF
--- a/.landscape.yaml
+++ b/.landscape.yaml
@@ -11,3 +11,6 @@ ignore-paths:
     - docs
 ignore-patterns:
     - (^|/)docs(/|$)
+pylint:
+    disable:
+        - E1002


### PR DESCRIPTION
`Missing argument to super()`
