### PR TITLE
Fixed taggit in reversion history

### DIFF
--- a/src/ralph/lib/mixins/tests/test_fields.py
+++ b/src/ralph/lib/mixins/tests/test_fields.py
@@ -5,6 +5,7 @@ from django.test import TestCase
 from ralph.assets.models.base import BaseObject
 from ralph.back_office.models import BackOfficeAsset
 from ralph.data_center.models import DataCenterAsset
+from ralph.lib.mixins.fields import TaggitTagField
 from ralph.tests.models import BaseObjectForeignKeyModel
 
 
@@ -22,3 +23,32 @@ class BaseObjectForeignKeyTestCase(TestCase):
             [i.id for i in content_type_result],
             [i.id for i in content_types.values()]
         )
+
+
+class TestTaggitTagField(TestCase):
+    def setUp(self):
+        self.field = TaggitTagField()
+
+    def test_field_hasnt_changed(self):
+        self.assertFalse(self.field.has_changed(['a', 'b'], 'a,b'))
+
+    def test_field_hasnt_changed_with_space(self):
+        self.assertFalse(self.field.has_changed(['a', 'b'], 'a, b'))
+
+    def test_field_hasnt_changed_with_trailing_comma(self):
+        self.assertFalse(self.field.has_changed(['a', 'b'], 'a, b, '))
+
+    def test_field_hasnt_changed_different_order(self):
+        self.assertFalse(self.field.has_changed(['a', 'b'], 'b, a'))
+
+    def test_field_has_changed_new_item(self):
+        self.assertTrue(self.field.has_changed(['a', 'b'], 'a, b, c'))
+
+    def test_field_has_changed_new_item_different_order(self):
+        self.assertTrue(self.field.has_changed(['a', 'b'], 'c, b, a'))
+
+    def test_field_has_changed_remove_item(self):
+        self.assertTrue(self.field.has_changed(['a', 'b'], 'a,'))
+
+    def test_field_has_changed_remove_item_different_order(self):
+        self.assertTrue(self.field.has_changed(['a', 'b', 'c'], 'c,a'))


### PR DESCRIPTION
Original taggit returns (not-evaluated) QuerySet from `value_from_object`, which was evaluated in has_changed method (this fetched current data from DB, not initial state before). After changes, Ralph's `value_from_object` returns list of tags, which could be easily compared with current data from form.
