### PR TITLE
Use HTTPS for GitHub.

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -19,4 +19,4 @@ six>=1.9.0
 sqlparse==0.1.16
 Unidecode==0.04.18
 tablib==0.11.2
-git+http://github.com/idlesign/django-sitetree.git@a626559c39ff1e865cde3441c44f42864c648dfb
+git+https://github.com/idlesign/django-sitetree.git@a626559c39ff1e865cde3441c44f42864c648dfb

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1,5 +1,5 @@
 -r test.txt
-git+http://github.com/django-debug-toolbar/django-debug-toolbar.git@0ed1538374d3dc41d51fc562b4e8be6ce8208552
+git+https://github.com/django-debug-toolbar/django-debug-toolbar.git@0ed1538374d3dc41d51fc562b4e8be6ce8208552
 Werkzeug
 pudb
 ipython


### PR DESCRIPTION
I see the following error when provisioning:

```
==> default: Obtaining file:///home/vagrant/src/ralph (from -r requirements/test.txt (line 1))
==> default: Collecting git+http://github.com/idlesign/django-sitetree.git@a626559c39ff1e865cde3441c44f42864c648dfb (from -r requirements/base.txt (line 22))
==> default:   Cloning http://github.com/idlesign/django-sitetree.git (to a626559c39ff1e865cde3441c44f42864c648dfb) to /tmp/pip-tccbye8u-build
==> default: fatal: unable to access 'http://github.com/idlesign/django-sitetree.git/': Empty reply from server
==> default:   Complete output from command git clone -q http://github.com/idlesign/django-sitetree.git /tmp/pip-tccbye8u-build:
==> default: Exception:
==> default: Traceback (most recent call last):
==> default:   File "/home/vagrant/lib/python3.4/site-packages/pip/basecommand.py", line 209, in main
==> default:     status = self.run(options, args)
==> default:   File "/home/vagrant/lib/python3.4/site-packages/pip/commands/install.py", line 310, in run
==> default:     wb.build(autobuilding=True)
==> default:   File "/home/vagrant/lib/python3.4/site-packages/pip/wheel.py", line 747, in build
==> default:     self.requirement_set.prepare_files(self.finder)
==> default:   File "/home/vagrant/lib/python3.4/site-packages/pip/req/req_set.py", line 359, in prepare_files
==> default:     ignore_dependencies=self.ignore_dependencies))
==> default:   File "/home/vagrant/lib/python3.4/site-packages/pip/req/req_set.py", line 576, in _prepare_file
==> default:     session=self.session, hashes=hashes)
==> default:   File "/home/vagrant/lib/python3.4/site-packages/pip/download.py", line 793, in unpack_url
==> default:     unpack_vcs_link(link, location)
==> default:   File "/home/vagrant/lib/python3.4/site-packages/pip/download.py", line 474, in unpack_vcs_link
==> default:     vcs_backend.unpack(location)
==> default:   File "/home/vagrant/lib/python3.4/site-packages/pip/vcs/__init__.py", line 283, in unpack
==> default:     self.obtain(location)
==> default:   File "/home/vagrant/lib/python3.4/site-packages/pip/vcs/git.py", line 124, in obtain
==> default:     self.run_command(['clone', '-q', url, dest])
==> default:   File "/home/vagrant/lib/python3.4/site-packages/pip/vcs/__init__.py", line 322, in run_command
==> default:     spinner)
==> default:   File "/home/vagrant/lib/python3.4/site-packages/pip/utils/__init__.py", line 711, in call_subprocess
==> default:     ''.join(all_output) +
==> default: UnboundLocalError: local variable 'all_output' referenced before assignment
==> default: make: 
==> default: *** [install-dev] Error 2
```

I find GitHub does not accept HTTP clone address:

```
$ git clone http://github.com/idlesign/django-sitetree.git
Cloning into 'django-sitetree'...
fatal: unable to access 'http://github.com/idlesign/django-sitetree.git/': Recv failure: Connection reset by peer
```

The installation proceeds after this change.
