### PR TITLE
Fixed nested group syncing when logging in

### DIFF
--- a/docs/installation/configuration.md
+++ b/docs/installation/configuration.md
@@ -89,6 +89,15 @@ AUTH_LDAP_GROUP_SEARCH = LDAPSearch("DC=organization,DC=internal",
     ldap.SCOPE_SUBTREE, '(objectClass=group)')
 ```
 
+If you nest one LDAP group in another and want to use such (parent) group
+in Ralph, you have to define this mapping in ``AUTH_LDAP_NESTED_GROUPS``:
+
+```python3
+AUTH_LDAP_NESTED_GROUPS = {
+  'CN=_gr_ralph_users,OU=Other,DC=mygroups,DC=domain': "staff",  # _gr_ralph_users contains other LDAP groups inside
+}
+```
+
 Note: For OpenDJ implementation ``AUTH_LDAP_GROUP_MAPPING`` is not obligatory. ``AUTH_LDAP_GROUP_TYPE`` and ``AUTH_LDAP_GROUP_SEARCH`` should be set as follows:
 
 ```python3
@@ -101,7 +110,7 @@ AUTH_LDAP_GROUP_SEARCH = LDAPSearch("DC=organization,DC=internal",
 If you want to define ldap groups with names identical to ralph roles, you
 shouldn't declare mapping ``AUTH_LDAP_GROUP_MAPPING``. If there are any one
 mapping defined another groups will be filtered. Some groups have
-special meanings. For example users need to be in ``staff`` to log in,
+special meanings. For example users need to be in ``active`` to log in,
 ``superuser`` gives superuser privileges. You can read more info
 in :ref:`groups`.
 

--- a/src/ralph/helpers.py
+++ b/src/ralph/helpers.py
@@ -1,4 +1,12 @@
+import logging
+import pickle
+from functools import wraps
+
+from django.conf import settings
+from django.core.cache import caches, DEFAULT_CACHE_ALIAS
 from django.http import HttpResponse
+
+logger = logging.getLogger(__name__)
 
 
 def add_request_to_form(form_class, request):
@@ -32,3 +40,36 @@ def generate_pdf_response(pdf_data, file_name):
         file_name,
     )
     return response
+
+CACHE_DEFAULT = object()
+
+
+def _cache_key_hash(func, *args, **kwargs):
+    return pickle.dumps((func.__module__, func.__name__, args, kwargs))
+
+
+def cache(seconds=300, cache_name=DEFAULT_CACHE_ALIAS):
+    """
+    Cache the result of a function call with particular parameters for specified
+    number of seconds.
+    """
+    def _cache(func):
+        @wraps(func)
+        def wrapper(*args, **kwargs):
+            cache_proxy = caches[cache_name]
+            key = _cache_key_hash(func, *args, **kwargs)
+            result = cache_proxy.get(key, default=CACHE_DEFAULT)
+            if result is CACHE_DEFAULT:
+                logger.debug('Recalculating result of {}'.format(func.__name__))
+                result = func(*args, **kwargs)
+                cache_proxy.set(key, result, seconds)
+            else:
+                logger.debug(
+                    'Taking result of {} from cache'.format(func.__name__)
+                )
+            return result
+        if settings.USE_CACHE:
+            return wrapper
+        else:
+            return func
+    return _cache

--- a/src/ralph/settings/base.py
+++ b/src/ralph/settings/base.py
@@ -249,6 +249,8 @@ REDIS_CONNECTION = {
     'PASSWORD': os.environ.get('REDIS_PASSWORD', ''),
 }
 
+# set to False to turn off cache decorator
+USE_CACHE = os_env_true('USE_CACHE', 'True')
 
 SENTRY_ENABLED = os_env_true('SENTRY_ENABLED')
 SENTRY_JS_DSN = os.environ.get('SENTRY_JS_DSN', None)

--- a/src/ralph/settings/test.py
+++ b/src/ralph/settings/test.py
@@ -30,8 +30,8 @@ INSTALLED_APPS += (
     'ralph.lib.polymorphic.tests',
 )
 
+USE_CACHE = False
 PASSWORD_HASHERS = ('django_plainpasswordhasher.PlainPasswordHasher',)
-
 STATICFILES_STORAGE = 'django.contrib.staticfiles.storage.StaticFilesStorage'
 
 ROOT_URLCONF = 'ralph.urls.test'


### PR DESCRIPTION
- nested groups are now not detached from user after logging in
- WARNING! This commit changes the way nested groups should be configured. Previously keys of `AUTH_LDAP_NESTED_GROUPS` were Ralph groups names and values were LDAP groups DNs - now it's the other way - keys are LDAP groups DNs, values are Ralph groups names (this was done to keep compatibility and consistency with django-auth-ldap)

TODO:
- [x] caching for fetching nested groups
- [x] documentation of nested groups
- [x] additional logging
