### PR TITLE
Fix import of fuzzy.

### DIFF
--- a/src/ralph/back_office/tests/factories.py
+++ b/src/ralph/back_office/tests/factories.py
@@ -3,7 +3,7 @@ from datetime import datetime, timedelta
 
 import factory
 from factory.django import DjangoModelFactory
-from factory.fuzzy import FuzzyText
+from factory.fuzzy import FuzzyDecimal
 
 from ralph.accounts.tests.factories import RegionFactory
 from ralph.assets.tests.factories import (
@@ -56,7 +56,7 @@ class BackOfficeAssetFactory(DjangoModelFactory):
     budget_info = factory.SubFactory(BudgetInfoFactory)
     invoice_date = date_now - timedelta(days=15)
     invoice_no = factory.Sequence(lambda n: 'Invoice number ' + str(n))
-    price = factory.fuzzy.FuzzyDecimal(10, 300)
+    price = FuzzyDecimal(10, 300)
 
     class Meta:
         model = BackOfficeAsset

--- a/src/ralph/data_center/tests/factories.py
+++ b/src/ralph/data_center/tests/factories.py
@@ -2,6 +2,7 @@ from datetime import datetime, timedelta
 
 import factory
 from factory.django import DjangoModelFactory
+from factory.fuzzy import FuzzyDecimal, FuzzyText
 
 from ralph.assets.models.choices import AssetSource
 from ralph.assets.tests.factories import (
@@ -86,9 +87,9 @@ class DataCenterAssetFactory(DjangoModelFactory):
     source = factory.Iterator([
         AssetSource.shipment.id, AssetSource.salvaged.id
     ])
-    price = factory.fuzzy.FuzzyDecimal(10, 300)
+    price = FuzzyDecimal(10, 300)
     management_ip = factory.Faker('ipv4')
-    management_hostname = factory.fuzzy.FuzzyText(
+    management_hostname = FuzzyText(
         prefix='ralph.', suffix='.allegro.pl', length=40
     )
 

--- a/src/ralph/supports/tests/factories.py
+++ b/src/ralph/supports/tests/factories.py
@@ -3,6 +3,7 @@ from datetime import date, datetime, timedelta
 
 import factory
 from factory.django import DjangoModelFactory
+from factory.fuzzy import FuzzyText
 
 from ralph.accounts.tests.factories import RegionFactory
 from ralph.assets.tests.factories import AssetHolderFactory, BudgetInfoFactory
@@ -47,7 +48,7 @@ class SupportFactory(DjangoModelFactory):
             '2hp', 'ironport', 'microsoft', 'oracle', '3par', 'tk'
         ]
     )
-    serial_no = factory.fuzzy.FuzzyText()
+    serial_no = FuzzyText()
     invoice_no = factory.Sequence(lambda n: 'Invoice number ' + str(n))
     invoice_date = date_now - timedelta(days=15)
     budget_info = factory.SubFactory(BudgetInfoFactory)


### PR DESCRIPTION
This correctly imports `fuzzy` and fixes the following test error:

```
(vagrant) vagrant@ralph-dev:~/src/ralph$ test_ralph test ralph.security
Creating test database for alias 'default'...
EE
======================================================================
ERROR: ralph.security.tests.test_api (unittest.loader.ModuleImportFailure)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/usr/lib/python3.4/unittest/case.py", line 58, in testPartExecutor
    yield
  File "/usr/lib/python3.4/unittest/case.py", line 577, in run
    testMethod()
  File "/usr/lib/python3.4/unittest/loader.py", line 32, in testFailure
    raise exception
ImportError: Failed to import test module: ralph.security.tests.test_api
Traceback (most recent call last):
  File "/usr/lib/python3.4/unittest/loader.py", line 312, in _find_tests
    module = self._get_module_from_name(name)
  File "/usr/lib/python3.4/unittest/loader.py", line 290, in _get_module_from_name
    __import__(name)
  File "/home/vagrant/src/ralph/src/ralph/security/tests/test_api.py", line 9, in <module>
    from ralph.data_center.tests.factories import IPAddressFactory
  File "/home/vagrant/src/ralph/src/ralph/data_center/tests/factories.py", line 72, in <module>
    class DataCenterAssetFactory(DjangoModelFactory):
  File "/home/vagrant/src/ralph/src/ralph/data_center/tests/factories.py", line 89, in DataCenterAssetFactory
    price = factory.fuzzy.FuzzyDecimal(10, 300)
AttributeError: 'module' object has no attribute 'fuzzy'


======================================================================
ERROR: ralph.security.tests.test_serializers (unittest.loader.ModuleImportFailure)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/usr/lib/python3.4/unittest/case.py", line 58, in testPartExecutor
    yield
  File "/usr/lib/python3.4/unittest/case.py", line 577, in run
    testMethod()
  File "/usr/lib/python3.4/unittest/loader.py", line 32, in testFailure
    raise exception
ImportError: Failed to import test module: ralph.security.tests.test_serializers
Traceback (most recent call last):
  File "/usr/lib/python3.4/unittest/loader.py", line 312, in _find_tests
    module = self._get_module_from_name(name)
  File "/usr/lib/python3.4/unittest/loader.py", line 290, in _get_module_from_name
    __import__(name)
  File "/home/vagrant/src/ralph/src/ralph/security/tests/test_serializers.py", line 6, in <module>
    from ralph.data_center.tests.factories import IPAddressFactory
  File "/home/vagrant/src/ralph/src/ralph/data_center/tests/factories.py", line 72, in <module>
    class DataCenterAssetFactory(DjangoModelFactory):
  File "/home/vagrant/src/ralph/src/ralph/data_center/tests/factories.py", line 89, in DataCenterAssetFactory
    price = factory.fuzzy.FuzzyDecimal(10, 300)
AttributeError: 'module' object has no attribute 'fuzzy'


----------------------------------------------------------------------
Ran 2 tests in 0.001s

FAILED (errors=2)
Destroying test database for alias 'default'...
```
