### PR TITLE
Dunder lookup in polymorphic models by extended filters

### DIFF
--- a/docs/user/api.md
+++ b/docs/user/api.md
@@ -148,3 +148,16 @@ Notice in this example that:
 * to set related object (not-simple, like string or number) just pass it's ID (see service_env)
 * to set many of related objects, pass IDs of them in list (see licences)
 * you could pass text value for choice fields (status), even if it's stored as number
+
+## Filtering
+
+Ralph API supports multiple query filers:
+
+> You could check possible fields to filter by sending `OPTIONS` request to particular resource (look at `filtering` item).
+
+* filter by (exact) field value (ex. `<URL>?hostname=s1234.local`)
+* lookup filters using Django's `__` convention (check [Django Field lookups documentation](https://docs.djangoproject.com/en/1.8/ref/models/querysets/#field-lookups) for details), ex. `<URL>?hostname__startswith=s123` or `<URL>?invoice_date__lte=2015-01-01`
+* extended filters - allows to filter for multiple fields using single query param - it's usefull especially for polymorphic models (like `BaseObject`) - for example filtering by `name` param, you'll filter by `DataCenterAsset` hostname, `BackOfficeAssetHostname` etc. Example: `<URL>/base-objects/?name=s1234.local`
+* filter by tags using `tag` query param. Multiple tags could be specified in url query. Example: `<URL>?tag=abc&tag=def&tag=123`
+
+> Fields lookups work with extended filters in `BaseObject` too, ex. `<URL>/base-objects/?name__startswith=s123`

--- a/src/ralph/api/filters.py
+++ b/src/ralph/api/filters.py
@@ -1,0 +1,316 @@
+import inspect
+import logging
+import operator
+from functools import reduce
+
+from django.contrib.contenttypes.models import ContentType
+from django.core.exceptions import FieldDoesNotExist
+from django.db import models
+from rest_framework.filters import BaseFilterBackend
+
+from ralph.admin.helpers import get_field_by_relation_path
+from ralph.admin.sites import ralph_site
+from ralph.data_importer.models import ImportedObjects
+from ralph.lib.mixins.models import TaggableMixin
+
+logger = logging.getLogger(__name__)
+
+
+class TagsFilterBackend(BaseFilterBackend):
+    """
+    Filter queryset by tags. Multiple tags could be specified in url query:
+    `<URL>?tag=abc&tag=def&tag=123`.
+    """
+    def _handle_tags_filter(self, queryset, tags):
+        query = models.Q()
+        for tag in tags:
+            query &= models.Q(tags__name=tag)
+        queryset = queryset.filter(query)
+        return queryset
+
+    def filter_queryset(self, request, queryset, view):
+        tags = request.query_params.getlist('tag')
+        if tags and issubclass(queryset.model, TaggableMixin):
+            queryset = self._handle_tags_filter(queryset, tags)
+        return queryset
+
+
+class ImportedIdFilterBackend(BaseFilterBackend):
+    """
+    Filter by imported object id
+    """
+    def filter_queryset(self, request, queryset, view):
+        imported_object_id = request.query_params.get(
+            '_imported_object_id'
+        )
+        if imported_object_id:
+            try:
+                imported_obj = ImportedObjects.objects.get(
+                    content_type=ContentType.objects.get_for_model(
+                        queryset.model
+                    ),
+                    old_object_pk=imported_object_id,
+                )
+            except ImportedObjects.DoesNotExist:
+                return queryset.model.objects.none()
+            else:
+                queryset = queryset.filter(pk=imported_obj.object_pk)
+        return queryset
+
+
+class ExtendedFiltersBackend(BaseFilterBackend):
+    """
+    Apply filters defined by extended filters in view (usefull in Polymorphic
+    objects).
+
+    For example, when
+    `view.extended_filter_fields = {'name': ['asset__hostname', 'ip__address']}`
+    using `name` filter (query param), `asset_hostname` and `ip_address` will
+    be filtered by.
+    """
+    def _handle_extended_filters(
+        self, request, queryset, extended_filter_fields
+    ):
+        for field, field_filters in extended_filter_fields.items():
+            value = request.query_params.get(field, None)
+            if value:
+                q_param = models.Q()
+                for field_name in field_filters:
+                    q_param |= models.Q(**{field_name: value})
+                queryset = queryset.filter(q_param)
+        return queryset
+
+    def filter_queryset(self, request, queryset, view):
+        """
+        Resolve extended filters
+        """
+        extended_filter_fields = getattr(view, 'extended_filter_fields', {})
+        if extended_filter_fields:
+            logger.debug('Applying ExtendedFiltersBackend filters')
+            queryset = self._handle_extended_filters(
+                request, queryset, extended_filter_fields
+            )
+        return queryset
+
+
+class LookupFilterBackend(BaseFilterBackend):
+    """
+    Filter by lookups (using Django's __ convention) in query params.
+
+    This filter supports also lookups in extended filters.
+    """
+    # allowed lookups depending on field type (using Django's __ convention)
+    # for other types of fields, only strict lookup is allowed
+    field_type_lookups = {
+        models.IntegerField: {
+            'lte', 'gte', 'lt', 'gt', 'exact', 'in', 'range', 'isnull'
+        },
+        models.CharField: {
+            'startswith', 'istartswith', 'endswith', 'icontains', 'contains',
+            'in', 'iendswith', 'isnull', 'regex', 'iregex'
+        },
+        models.DateField: {
+            'year', 'month', 'day', 'week_day', 'range', 'isnull'
+        },
+        models.DateTimeField: {'hour', 'minute', 'second'},
+        models.DecimalField: {
+            'lte', 'gte', 'lt', 'gt', 'exact', 'in', 'range', 'isnull'
+        }
+    }
+
+    def _validate_single_query_lookup(
+        self, model, model_field_name, lookup, value
+    ):
+        """
+        Validate single query param lookup.
+
+        Args:
+            model: Django model
+            model_field_name: name of model field extracted from field_name
+            lookup: name of lookup (ex. `startswith')
+            value: value to look for
+
+        Returns: dict with filter params (containing eiter 0 or 1 elem). Result
+            is not empty if lookup for field is valid. Result is empty when
+            field path is not valid or lookup for field is not valid.
+        """
+        result = {}
+        logger.debug('Validating {}__{} lookup for model {}; value: {}'.format(
+            model_field_name, lookup, model, value
+        ))
+        try:
+            model_field = get_field_by_relation_path(
+                model, model_field_name
+            )
+        except FieldDoesNotExist:
+            logger.debug(
+                '{} not found for model {}'.format(model_field_name, model)
+            )
+        else:
+            field_lookups = set()
+            # process every class from which field is inheriting
+            for cl in inspect.getmro(model_field.__class__):
+                field_lookups |= self.field_type_lookups.get(cl, set())
+            logger.debug('Available lookups for {}.{} : {}'.format(
+                model, model_field_name, field_lookups
+            ))
+            if lookup in field_lookups:
+                result = {'{}__{}'.format(model_field_name, lookup): value}
+        return result
+
+    def _validate_query_lookups(
+        self, model, request, filter_fields, extended_filter_fields
+    ):
+        """
+        Validates all lookups from query params.
+
+        Args:
+            model: Django model
+            request: current request
+            filter_fields: list of fields available for filtering (ex. ['name'])
+            extended_filter_fields: dict with extended filters for single field
+                name, ex. `{'name': ['asset__hostname', 'ip__address']}`.
+                Usefull especially with polymorphic models (when searching by
+                field `name` could be later expanded to filter by many fields
+                in descendants models)
+
+        Returns: 2-element tuple with:
+            * list with positional filters (using Q objects)
+            * dict with keywords filters
+        """
+        result = []
+        kw_result = {}
+        logger.debug(
+            'Processing {} filters with filter fields={} and extended filter '
+            'fields={}'.format(model, filter_fields, extended_filter_fields)
+        )
+        for field_name, value in request.query_params.items():
+            logger.debug(
+                'Processing query param {}:{}'.format(field_name, value)
+            )
+            model_field_name, _, lookup = field_name.rpartition('__')
+
+            # try if this field search could be expanded to other fields
+            extended_filters = {}
+            for extended_field_name in extended_filter_fields.get(
+                model_field_name, []
+            ):
+                extended_filters.update(
+                    self._validate_single_query_lookup(
+                        model,
+                        extended_field_name,
+                        lookup,
+                        value
+                    )
+                )
+            if extended_filters:
+                logger.debug('Using {} extended filters for query {}:{}'.format(
+                    extended_filters, field_name, value
+                ))
+                result.append(reduce(
+                    operator.or_,
+                    [models.Q(**{k: v}) for k, v in extended_filters.items()]
+                ))
+
+            # skip if field is not available to filter for
+            if model_field_name in filter_fields:
+                filters = self._validate_single_query_lookup(
+                    model, model_field_name, lookup, value
+                )
+                logger.debug('Using {} filters for query {}:{}'.format(
+                    filters, field_name, value
+                ))
+                kw_result.update(filters)
+        return result, kw_result
+
+    def filter_queryset(self, request, queryset, view):
+        lookups, kw_lookups = self._validate_query_lookups(
+            queryset.model, request, view.filter_fields,
+            getattr(view, 'extended_filter_fields', {})
+        )
+        if lookups or kw_lookups:
+            logger.debug('Applying LookupFilterBackend filters')
+            queryset = queryset.filter(*lookups, **kw_lookups)
+        return queryset
+
+
+class PolymorphicDescendantsFilterBackend(LookupFilterBackend):
+    """
+    Filter descendants of polymorphic models (especially by extended filters).
+    """
+    def _process_model(
+        self, model, request, filter_fields, extended_filter_fields
+    ):
+        ids = set()
+        is_lookup_used = False
+        lookups, kw_lookups = self._validate_query_lookups(
+            model, request, filter_fields, extended_filter_fields
+        )
+        if lookups or kw_lookups:
+            is_lookup_used = True
+            ids = set(model.objects.filter(
+                *lookups, **kw_lookups
+            ).values_list('pk', flat=True))
+        return ids, is_lookup_used
+
+    def _get_polymorphic_ids(
+        self, base_model, polymorphic_models, request, view
+    ):
+        """
+        Returns ids of polymorphic objects based on query filters.
+
+        Args:
+            base_model: (polymorphic) parent model
+            polymorphic_models: list of models to consider (descendants of
+                base model)
+            request: current request
+            view: current view
+
+        Returns: tuple (
+            * set of ids,
+            * True if at least one of the lookups was applied
+        )
+        """
+        ids = set()
+        is_lookup_used = False
+
+        # process base model
+        # used only with extended filters
+        model_ids, model_is_lookup_used = self._process_model(
+            base_model, request, view.filter_fields,
+            getattr(view, 'extended_filter_fields', {})
+        )
+        ids |= model_ids
+        is_lookup_used |= model_is_lookup_used
+        for model in polymorphic_models:
+            filter_fields = []
+            model_viewset = view._viewsets_registry.get(model)
+            if model_viewset:
+                # get filters which are applicable to descdenant type
+                filter_fields = getattr(model_viewset, 'filter_fields', [])
+            if not filter_fields:
+                # if not filter_fields from API viewset get fields
+                # from django model admin
+                filter_fields = ralph_site._registry[model].search_fields
+
+            model_ids, model_is_lookup_used = self._process_model(
+                model, request, filter_fields, {}
+            )
+            ids |= model_ids
+            is_lookup_used |= model_is_lookup_used
+        return ids, is_lookup_used
+
+    def filter_queryset(self, request, queryset, view):
+        polymorphic_descendants = getattr(
+            queryset.model, '_polymorphic_descendants', []
+        )
+        if polymorphic_descendants:
+            ids, is_lookup_used = self._get_polymorphic_ids(
+                queryset.model, polymorphic_descendants, request, view
+            )
+            if is_lookup_used:
+                logger.debug(
+                    'Applying PolymorphicDescendantsFilterBackend filters'
+                )
+                queryset = queryset.filter(pk__in=list(ids))
+        return queryset

--- a/src/ralph/api/tests/api.py
+++ b/src/ralph/api/tests/api.py
@@ -63,8 +63,8 @@ class ManufacturerViewSet(RalphAPIViewSet):
     queryset = Manufacturer.objects.all()
     serializer_class = ManufacturerSerializer
     save_serializer_class = ManufacturerSerializer2
-    extend_filter_fields = {
-        'name': ['name', 'country'],
+    extended_filter_fields = {
+        'some_field': ['name', 'country'],
     }
 
 

--- a/src/ralph/api/tests/test_filters.py
+++ b/src/ralph/api/tests/test_filters.py
@@ -1,0 +1,174 @@
+# -*- coding: utf-8 -*-
+from datetime import date
+from decimal import Decimal
+from urllib.parse import urlencode
+
+from django.contrib.auth import get_user_model
+from django.http import QueryDict
+from rest_framework.test import APIClient, APIRequestFactory
+
+from ralph.api.filters import ExtendedFiltersBackend, LookupFilterBackend
+from ralph.api.tests.api import (
+    Bar,
+    BarViewSet,
+    Manufacturer,
+    ManufacturerViewSet
+)
+from ralph.tests import RalphTestCase
+from ralph.tests.factories import ManufacturerFactory
+
+
+class TestExtendedFiltersBackend(RalphTestCase):
+    def setUp(self):
+        super().setUp()
+        self.request_factory = APIRequestFactory()
+        self.manufacture_1 = ManufacturerFactory(
+            name='test', country='Poland'
+        )
+        self.manufacture_2 = ManufacturerFactory(
+            name='test2', country='test'
+        )
+        get_user_model().objects.create_superuser(
+            'test', 'test@test.test', 'test'
+        )
+        self.client = APIClient()
+        self.client.login(username='test', password='test')
+        self.extended_filters_backend = ExtendedFiltersBackend()
+
+    def test_extended_filter_fields(self):
+        request = self.request_factory.get('/')
+        request.query_params = QueryDict(urlencode({'some_field': 'test'}))
+        mvs = ManufacturerViewSet()
+        mvs.request = request
+        self.assertEqual(len(self.extended_filters_backend.filter_queryset(
+            request, Manufacturer.objects.all(), mvs)
+        ), 2)
+
+        request.query_params = QueryDict(urlencode({'some_field': 'test2'}))
+        mvs.request = request
+        self.assertEqual(len(self.extended_filters_backend.filter_queryset(
+            request, Manufacturer.objects.all(), mvs)
+        ), 1)
+
+
+class TestLookupFilterBackend(RalphTestCase):
+    def setUp(self):
+        super().setUp()
+        self.request_factory = APIRequestFactory()
+        get_user_model().objects.create_superuser(
+            'test', 'test@test.test', 'test'
+        )
+        self.client = APIClient()
+        self.client.login(username='test', password='test')
+
+        Bar.objects.create(
+            name='Bar11',
+            date=date(2015, 3, 1),
+            price=Decimal('21.4'),
+            count=1
+        )
+        Bar.objects.create(
+            name='Bar22',
+            date=date(2014, 4, 1),
+            price=Decimal('11.4'),
+            count=2
+        )
+        Bar.objects.create(
+            name='Bar33',
+            date=date(2013, 5, 1),
+            price=Decimal('31.4'),
+            count=3
+        )
+        self.lookup_filter = LookupFilterBackend()
+
+    def test_query_filters_charfield(self):
+        request = self.request_factory.get('/api/bar')
+        bvs = BarViewSet()
+        request.query_params = QueryDict(
+            urlencode({'name__icontains': 'bar1'})
+        )
+        bvs.request = request
+        self.assertEqual(len(self.lookup_filter.filter_queryset(
+            request, Bar.objects.all(), bvs)
+        ), 1)
+
+        # Failed filter
+        request.query_params = QueryDict(urlencode({'name__range': 10}))
+        self.assertEqual(len(self.lookup_filter.filter_queryset(
+            request, Bar.objects.all(), bvs)
+        ), 3)
+
+    def test_query_filters_decimalfield(self):
+        request = self.request_factory.get('/api/bar')
+        bvs = BarViewSet()
+        request.query_params = QueryDict(urlencode({'price__gte': 20}))
+        bvs.request = request
+        self.assertEqual(len(self.lookup_filter.filter_queryset(
+            request, Bar.objects.all(), bvs)
+        ), 2)
+
+        # Failed filter
+        request.query_params = QueryDict(urlencode({'price__istartswith': 10}))
+        self.assertEqual(len(self.lookup_filter.filter_queryset(
+            request, Bar.objects.all(), bvs)
+        ), 3)
+
+    def test_query_filters_integerfield(self):
+        request = self.request_factory.get('/api/bar')
+        bvs = BarViewSet()
+        request.query_params = QueryDict(urlencode({'count__gte': 2}))
+        bvs.request = request
+        self.assertEqual(len(self.lookup_filter.filter_queryset(
+            request, Bar.objects.all(), bvs)
+        ), 2)
+
+        # Failed filter
+        request.query_params = QueryDict(urlencode({'count__istartswith': 10}))
+        self.assertEqual(len(self.lookup_filter.filter_queryset(
+            request, Bar.objects.all(), bvs)
+        ), 3)
+
+    def test_query_filters_datefield(self):
+        request = self.request_factory.get('/api/bar')
+        bvs = BarViewSet()
+        request.query_params = QueryDict(urlencode({'date__year': 2015}))
+        bvs.request = request
+        self.assertEqual(len(self.lookup_filter.filter_queryset(
+            request, Bar.objects.all(), bvs)
+        ), 1)
+
+        # Failed filter
+        request.query_params = QueryDict(urlencode({'date__istartswith': 10}))
+        self.assertEqual(len(self.lookup_filter.filter_queryset(
+            request, Bar.objects.all(), bvs)
+        ), 3)
+
+    def test_query_filters_datetimefield(self):
+        request = self.request_factory.get('/api/bar')
+        bvs = BarViewSet()
+        request.query_params = QueryDict(urlencode(
+            {'created__year': date.today().year})
+        )
+        bvs.request = request
+        self.assertEqual(len(self.lookup_filter.filter_queryset(
+            request, Bar.objects.all(), bvs)
+        ), 3)
+
+        request.query_params = QueryDict(
+            urlencode({
+                'date__year': 2014,
+                'created__month': date.today().month
+            })
+        )
+        bvs.request = request
+        self.assertEqual(len(self.lookup_filter.filter_queryset(
+            request, Bar.objects.all(), bvs)
+        ), 1)
+
+        # Failed filter
+        request.query_params = QueryDict(
+            urlencode({'created__istartswith': 10})
+        )
+        self.assertEqual(len(self.lookup_filter.filter_queryset(
+            request, Bar.objects.all(), bvs)
+        ), 3)

--- a/src/ralph/api/tests/test_viewsets.py
+++ b/src/ralph/api/tests/test_viewsets.py
@@ -1,17 +1,13 @@
 # -*- coding: utf-8 -*-
 from datetime import date
 from decimal import Decimal
-from urllib.parse import urlencode
 
 from django.contrib.auth import get_user_model
-from django.http import QueryDict
 from rest_framework import relations
 from rest_framework.test import APIClient, APIRequestFactory
 
 from ralph.api.serializers import ReversedChoiceField
 from ralph.api.tests.api import (
-    Bar,
-    BarViewSet,
     Car,
     CarSerializer,
     CarViewSet,
@@ -46,25 +42,6 @@ class TestRalphViewset(RalphTestCase):
         )
         self.client = APIClient()
         self.client.login(username='test', password='test')
-
-        Bar.objects.create(
-            name='Bar11',
-            date=date(2015, 3, 1),
-            price=Decimal('21.4'),
-            count=1
-        )
-        Bar.objects.create(
-            name='Bar22',
-            date=date(2014, 4, 1),
-            price=Decimal('11.4'),
-            count=2
-        )
-        Bar.objects.create(
-            name='Bar33',
-            date=date(2013, 5, 1),
-            price=Decimal('31.4'),
-            count=3
-        )
 
     def test_should_raise_attributeerror_when_ralph_permission_missing(self):
         with self.assertRaises(AttributeError):
@@ -101,87 +78,6 @@ class TestRalphViewset(RalphTestCase):
         mvs = ManufacturerViewSet()
         mvs.request = request
         self.assertEqual(mvs.get_serializer_class(), ManufacturerSerializer2)
-
-    def test_extend_filter_fields(self):
-        request = self.request_factory.get('/')
-        request.query_params = QueryDict(urlencode({'name': 'test'}))
-        mvs = ManufacturerViewSet()
-        mvs.request = request
-        self.assertEqual(len(mvs.get_queryset()), 2)
-
-        request.query_params = QueryDict(urlencode({'name': 'test2'}))
-        mvs.request = request
-        self.assertEqual(len(mvs.get_queryset()), 1)
-
-    def test_query_filters_charfield(self):
-        request = self.request_factory.get('/api/bar')
-        bvs = BarViewSet()
-        request.query_params = QueryDict(
-            urlencode({'name__icontains': 'bar1'})
-        )
-        bvs.request = request
-        self.assertEqual(len(bvs.get_queryset()), 1)
-
-        # Failed filter
-        request.query_params = QueryDict(urlencode({'name__range': 10}))
-        self.assertEqual(len(bvs.get_queryset()), 3)
-
-    def test_query_filters_decimalfield(self):
-        request = self.request_factory.get('/api/bar')
-        bvs = BarViewSet()
-        request.query_params = QueryDict(urlencode({'price__gte': 20}))
-        bvs.request = request
-        self.assertEqual(len(bvs.get_queryset()), 2)
-
-        # Failed filter
-        request.query_params = QueryDict(urlencode({'price__istartswith': 10}))
-        self.assertEqual(len(bvs.get_queryset()), 3)
-
-    def test_query_filters_integerfield(self):
-        request = self.request_factory.get('/api/bar')
-        bvs = BarViewSet()
-        request.query_params = QueryDict(urlencode({'count__gte': 2}))
-        bvs.request = request
-        self.assertEqual(len(bvs.get_queryset()), 2)
-
-        # Failed filter
-        request.query_params = QueryDict(urlencode({'count__istartswith': 10}))
-        self.assertEqual(len(bvs.get_queryset()), 3)
-
-    def test_query_filters_datefield(self):
-        request = self.request_factory.get('/api/bar')
-        bvs = BarViewSet()
-        request.query_params = QueryDict(urlencode({'date__year': 2015}))
-        bvs.request = request
-        self.assertEqual(len(bvs.get_queryset()), 1)
-
-        # Failed filter
-        request.query_params = QueryDict(urlencode({'date__istartswith': 10}))
-        self.assertEqual(len(bvs.get_queryset()), 3)
-
-    def test_query_filters_datetimefield(self):
-        request = self.request_factory.get('/api/bar')
-        bvs = BarViewSet()
-        request.query_params = QueryDict(urlencode(
-            {'created__year': date.today().year})
-        )
-        bvs.request = request
-        self.assertEqual(len(bvs.get_queryset()), 3)
-
-        request.query_params = QueryDict(
-            urlencode({
-                'date__year': 2014,
-                'created__month': date.today().month
-            })
-        )
-        bvs.request = request
-        self.assertEqual(len(bvs.get_queryset()), 1)
-
-        # Failed filter
-        request.query_params = QueryDict(
-            urlencode({'created__istartswith': 10})
-        )
-        self.assertEqual(len(bvs.get_queryset()), 3)
 
     def test_options_filtering(self):
         response = self.client.options('/api/manufacturers/')

--- a/src/ralph/assets/admin.py
+++ b/src/ralph/assets/admin.py
@@ -126,6 +126,7 @@ class GenericComponentAdmin(RalphAdmin):
 @register(Asset)
 class AssetAdmin(RalphAdmin):
     raw_id_fields = ['parent', 'service_env', 'model']
+    search_fields = ['hostname', 'sn', 'barcode']
 
 
 @register(BaseObject)

--- a/src/ralph/assets/api/views.py
+++ b/src/ralph/assets/api/views.py
@@ -76,7 +76,7 @@ class BaseObjectViewSet(PolymorphicViewSetMixin, RalphAPIViewSet):
         )),
     ]
     filter_fields = ['id']
-    extend_filter_fields = {
+    extended_filter_fields = {
         'name': ['asset__hostname'],
         'sn': ['asset__sn'],
         'barcode': ['asset__barcode'],

--- a/src/ralph/assets/tests/test_api.py
+++ b/src/ralph/assets/tests/test_api.py
@@ -428,7 +428,7 @@ class BaseObjectAPITests(RalphAPITestCase):
         )
         self.bo_asset.tags.add('tag1')
         self.dc_asset = DataCenterAssetFactory(
-            barcode='54321', price='10.00'
+            barcode='12543', price='10.00'
         )
         self.dc_asset.tags.add('tag2')
 
@@ -438,7 +438,7 @@ class BaseObjectAPITests(RalphAPITestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data['count'], 2)
         barcodes = [item['barcode'] for item in response.data['results']]
-        self.assertCountEqual(barcodes, set(['12345', '54321']))
+        self.assertCountEqual(barcodes, set(['12345', '12543']))
 
     def test_get_asset_model_details(self):
         url = reverse('baseobject-detail', args=(self.bo_asset.id,))
@@ -454,6 +454,24 @@ class BaseObjectAPITests(RalphAPITestCase):
         )
         response = self.client.get(url, format='json')
         self.assertEqual(len(response.data['results']), 1)
+
+    def test_icontains_polymorphic_with_extended_filters(self):
+        url = '{}?{}'.format(
+            reverse('baseobject-list'), urlencode(
+                {'name__startswith': 'host'}
+            )
+        )
+        response = self.client.get(url, format='json')
+        self.assertEqual(len(response.data['results']), 1)
+
+    def test_startswith_polymorphic_different_types(self):
+        url = '{}?{}'.format(
+            reverse('baseobject-list'), urlencode(
+                {'barcode__startswith': '12'}
+            )
+        )
+        response = self.client.get(url, format='json')
+        self.assertEqual(len(response.data['results']), 2)
 
     def test_lte_polymorphic(self):
         url = '{}?{}'.format(

--- a/src/ralph/lib/api/utils.py
+++ b/src/ralph/lib/api/utils.py
@@ -10,7 +10,7 @@ class RalphApiMetadata(SimpleMetadata):
         data = super().determine_metadata(request, view)
         filtering = getattr(view, 'filter_fields', [])[:]
         filtering.extend(
-            getattr(view, 'extend_filter_fields', {}).keys()
+            getattr(view, 'extended_filter_fields', {}).keys()
         )
         data['filtering'] = list(set(filtering))
         return data

--- a/src/ralph/settings/base.py
+++ b/src/ralph/settings/base.py
@@ -179,7 +179,7 @@ LOGGING = {
     },
     'handlers': {
         'console': {
-            'level': 'INFO',
+            'level': 'DEBUG',
             'class': 'logging.StreamHandler',
             'formatter': 'simple',
         },

--- a/src/ralph/settings/test.py
+++ b/src/ralph/settings/test.py
@@ -39,6 +39,8 @@ ROOT_URLCONF = 'ralph.urls.test'
 # see `ralph.tests.mixins.ReloadUrlsMixin` for details
 URLCONF_MODULES = ['ralph.urls.base', ROOT_URLCONF]
 
+LOGGING['loggers']['ralph'].update({'level': 'DEBUG', 'handlers': ['console']})
+
 SKIP_MIGRATIONS = os.environ.get('SKIP_MIGRATIONS', None)
 if SKIP_MIGRATIONS:
     print('skipping migrations')


### PR DESCRIPTION
Goal: allow to lookup filter in polymorphic models with extended filters, ex. `/api/base-objects/?name__startswith=s31`.

In this commit (PR):
- filters are refactored, moved to separated module (`filters.py`) and splitted to separated classes
- extended filters are now properly handled for polymorphic models

API filters right now:
- tags -> `tag=abc&tag=def`
- imported_id -> `_imported_object_id=12345`
- extended filters -> `name=abc => (asset__hostname=abc | cloudhost__hostname=abc | serviceenvironment__service__name=abc)`
- lookup -> `hostname__startswith=123&price__gte=23` - this also supports extended filters, ex. `name__startswith=abc => (name__startswith=abc | asset__hostname__startswith=abc | cloudhost__hostname__startswith=abc | serviceenvironment__service__name__startswith=abc)`
- polymorphic -> supports lookup + extended filters + extended filters with lookups
