### PR TITLE
BaseObject API improvements

### DIFF
--- a/src/ralph/api/fields.py
+++ b/src/ralph/api/fields.py
@@ -1,0 +1,58 @@
+from collections import OrderedDict
+
+from rest_framework.fields import ChoiceField, Field
+
+
+class StrField(Field):
+    def __init__(self, **kwargs):
+        self._show_type = kwargs.pop('show_type', False)
+        kwargs['read_only'] = True
+        if 'label' not in kwargs:
+            kwargs['label'] = '__str__'
+        super().__init__(**kwargs)
+
+    def get_attribute(self, obj):
+        # return obj to pass whole object to `to_representation`
+        return obj
+
+    def to_representation(self, obj):
+        if self._show_type:
+            return '{}: {}'.format(obj._meta.verbose_name, str(obj))
+        else:
+            return str(obj)
+
+
+class ReversedChoiceField(ChoiceField):
+    """
+    Choice field serializer which allow to pass value by name instead of key.
+    Additionally it present value in user-friendly format by-name.
+
+    Notice that requirement for this field to work properly is uniqueness of
+    choice values.
+
+    This field works perfectly with `dj.choices.Choices`.
+    """
+    def __init__(self, choices, **kwargs):
+        super(ReversedChoiceField, self).__init__(choices, **kwargs)
+        # mapping by value
+        self.reversed_choices = OrderedDict([(v, k) for (k, v) in choices])
+
+    def to_representation(self, obj):
+        """
+        Return choice name (value) instead of default key.
+        """
+        try:
+            return self.choices[obj]
+        except KeyError:
+            return super().to_representation(obj)
+
+    def to_internal_value(self, data):
+        """
+        Try to get choice by value first. If it doesn't succeed fallback to
+        default action (get by key).
+        """
+        try:
+            return self.reversed_choices[data]
+        except KeyError:
+            pass
+        return super(ReversedChoiceField, self).to_internal_value(data)

--- a/src/ralph/api/tests/api.py
+++ b/src/ralph/api/tests/api.py
@@ -2,11 +2,15 @@
 from django.conf.urls import include, url
 
 from ralph.api import RalphAPISerializer, RalphAPIViewSet
+from ralph.api.fields import StrField
 from ralph.api.routers import RalphRouter
 from ralph.tests.models import Bar, Car, Foo, Manufacturer
 
 
 class FooSerializer(RalphAPISerializer):
+    __str__ = StrField()
+    str_with_type = StrField(show_type=True, label='__str2__')
+
     class Meta:
         model = Foo
         # include view namespace for hyperlinked field

--- a/src/ralph/api/tests/test_fields.py
+++ b/src/ralph/api/tests/test_fields.py
@@ -1,0 +1,64 @@
+# -*- coding: utf-8 -*-
+from collections import OrderedDict
+
+from dj.choices import Choices
+from rest_framework.exceptions import ValidationError
+
+from ralph.api.fields import ReversedChoiceField, StrField
+from ralph.tests import RalphTestCase
+from ralph.tests.models import Foo
+
+
+class TestChoices(Choices):
+    _ = Choices.Choice
+
+    foo = _('foo11')
+    bar = _('bar22')
+
+
+class TestStrField(RalphTestCase):
+    def setUp(self):
+        self.foo = Foo(bar='abc')
+        self.str_field = StrField()
+        self.str_field_with_type = StrField(show_type=True)
+
+    def test_str_field_representation(self):
+        self.assertEqual(
+            self.str_field.to_representation(self.foo), str(self.foo)
+        )
+
+    def test_str_field_with_type(self):
+        self.assertEqual(
+            self.str_field_with_type.to_representation(self.foo),
+            '{}: {}'.format(Foo._meta.verbose_name, str(self.foo))
+        )
+
+
+class TestReversedChoiceField(RalphTestCase):
+    def setUp(self):
+        self.reversed_choice_field = ReversedChoiceField(TestChoices())
+
+    def test_reversed_choices(self):
+        self.assertEqual(
+            self.reversed_choice_field.reversed_choices,
+            OrderedDict([
+                ('foo11', TestChoices.foo.id),
+                ('bar22', TestChoices.bar.id)
+            ])
+        )
+
+    def test_to_representation_should_return_choice_text(self):
+        self.assertEqual(
+            self.reversed_choice_field.to_representation(TestChoices.foo.id),
+            'foo11'
+        )
+
+    def test_to_internal_value_should_map_choice_text_to_id(self):
+        self.assertEqual(
+            self.reversed_choice_field.to_internal_value('foo11'),
+            TestChoices.foo.id,
+        )
+
+    def test_to_internal_value_with_choice_not_found_should_raise_validation_error(self):  # noqa
+        with self.assertRaises(ValidationError):
+            self.reversed_choice_field.to_internal_value('foo33')

--- a/src/ralph/api/utils.py
+++ b/src/ralph/api/utils.py
@@ -1,7 +1,11 @@
+import logging
+
 from django.db import models
 from rest_framework import serializers
 
 from ralph.admin.sites import ralph_site
+
+logger = logging.getLogger('__name__')
 
 
 class QuerysetRelatedMixin(object):
@@ -69,7 +73,9 @@ class PolymorphicViewSetMixin(QuerysetRelatedMixin):
                     args[0].__class__
                 ]
             except KeyError:
-                pass
+                logger.warning('Dedicated serializer not found for {}'.format(
+                    args[0].__class__
+                ))
         return serializer_class(*args, **kwargs)
 
 

--- a/src/ralph/assets/api/serializers.py
+++ b/src/ralph/assets/api/serializers.py
@@ -5,6 +5,7 @@ from rest_framework import serializers
 from ralph.accounts.api_simple import SimpleRalphUserSerializer
 from ralph.accounts.models import Team
 from ralph.api import RalphAPISerializer
+from ralph.api.fields import StrField
 from ralph.api.serializers import AdditionalLookupRelatedField
 from ralph.api.utils import PolymorphicSerializer
 from ralph.assets.models import (
@@ -137,6 +138,8 @@ class ServiceEnvironmentSimpleSerializer(RalphAPISerializer):
 
 
 class ServiceEnvironmentSerializer(RalphAPISerializer):
+    __str__ = StrField(show_type=True)
+
     class Meta:
         model = ServiceEnvironment
         depth = 1
@@ -192,6 +195,7 @@ class BaseObjectSerializer(RalphAPISerializer):
     """
     service_env = ServiceEnvironmentSimpleSerializer()
     licences = SimpleBaseObjectLicenceSerializer(read_only=True, many=True)
+    __str__ = StrField(show_type=True)
 
     class Meta:
         model = BaseObject

--- a/src/ralph/data_center/api/routers.py
+++ b/src/ralph/data_center/api/routers.py
@@ -2,17 +2,21 @@
 from ralph.api import router
 from ralph.data_center.api.views import (
     AccessoryViewSet,
+    DatabaseViewSet,
     DataCenterAssetViewSet,
     DataCenterViewSet,
     RackAccessoryViewSet,
     RackViewSet,
-    ServerRoomViewSet
+    ServerRoomViewSet,
+    VIPViewSet
 )
 
 router.register(r'accessories', AccessoryViewSet)
+router.register(r'databases', DatabaseViewSet)
 router.register(r'data-centers', DataCenterViewSet)
 router.register(r'data-center-assets', DataCenterAssetViewSet)
 router.register(r'racks', RackViewSet)
 router.register(r'rack-accessories', RackAccessoryViewSet)
 router.register(r'server-rooms', ServerRoomViewSet)
+router.register(r'vips', VIPViewSet)
 urlpatterns = []

--- a/src/ralph/data_center/api/serializers.py
+++ b/src/ralph/data_center/api/serializers.py
@@ -2,14 +2,16 @@
 from rest_framework import serializers
 
 from ralph.api import RalphAPISerializer
-from ralph.assets.api.serializers import AssetSerializer
-from ralph.data_center.models.physical import (
+from ralph.assets.api.serializers import AssetSerializer, BaseObjectSerializer
+from ralph.data_center.models import (
     Accessory,
+    Database,
     DataCenter,
     DataCenterAsset,
     Rack,
     RackAccessory,
-    ServerRoom
+    ServerRoom,
+    VIP
 )
 
 
@@ -67,4 +69,16 @@ class DataCenterAssetSerializer(AssetSerializer):
 
     class Meta(AssetSerializer.Meta):
         model = DataCenterAsset
+        depth = 1
+
+
+class DatabaseSerializer(BaseObjectSerializer):
+    class Meta(BaseObjectSerializer.Meta):
+        model = Database
+        depth = 1
+
+
+class VIPSerializer(BaseObjectSerializer):
+    class Meta(BaseObjectSerializer.Meta):
+        model = VIP
         depth = 1

--- a/src/ralph/data_center/api/views.py
+++ b/src/ralph/data_center/api/views.py
@@ -5,19 +5,23 @@ from ralph.assets.api.views import BaseObjectViewSet
 from ralph.data_center.admin import DataCenterAssetAdmin
 from ralph.data_center.api.serializers import (
     AccessorySerializer,
+    DatabaseSerializer,
     DataCenterAssetSerializer,
     DataCenterSerializer,
     RackAccessorySerializer,
     RackSerializer,
-    ServerRoomSerializer
+    ServerRoomSerializer,
+    VIPSerializer
 )
-from ralph.data_center.models.physical import (
+from ralph.data_center.models import (
     Accessory,
+    Database,
     DataCenter,
     DataCenterAsset,
     Rack,
     RackAccessory,
-    ServerRoom
+    ServerRoom,
+    VIP
 )
 
 
@@ -66,3 +70,13 @@ class ServerRoomViewSet(RalphAPIViewSet):
 class DataCenterViewSet(RalphAPIViewSet):
     queryset = DataCenter.objects.all()
     serializer_class = DataCenterSerializer
+
+
+class DatabaseViewSet(RalphAPIViewSet):
+    queryset = Database.objects.all()
+    serializer_class = DatabaseSerializer
+
+
+class VIPViewSet(RalphAPIViewSet):
+    queryset = VIP.objects.all()
+    serializer_class = VIPSerializer

--- a/src/ralph/data_center/tests/factories.py
+++ b/src/ralph/data_center/tests/factories.py
@@ -9,7 +9,8 @@ from ralph.assets.tests.factories import (
     AssetHolderFactory,
     BaseObjectFactory,
     BudgetInfoFactory,
-    DataCenterAssetModelFactory
+    DataCenterAssetModelFactory,
+    ServiceEnvironmentFactory
 )
 from ralph.data_center.models.networks import IPAddress
 from ralph.data_center.models.physical import (
@@ -21,6 +22,7 @@ from ralph.data_center.models.physical import (
     RackAccessory,
     ServerRoom
 )
+from ralph.data_center.models.virtual import Database, VIP
 
 date_now = datetime.now().date()
 
@@ -102,3 +104,17 @@ class IPAddressFactory(DjangoModelFactory):
 
     class Meta:
         model = IPAddress
+
+
+class DatabaseFactory(DjangoModelFactory):
+    service_env = factory.SubFactory(ServiceEnvironmentFactory)
+
+    class Meta:
+        model = Database
+
+
+class VIPFactory(DjangoModelFactory):
+    service_env = factory.SubFactory(ServiceEnvironmentFactory)
+
+    class Meta:
+        model = VIP

--- a/src/ralph/domains/api.py
+++ b/src/ralph/domains/api.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+from ralph.api import RalphAPIViewSet, router
+from ralph.assets.api.serializers import BaseObjectSerializer
+from ralph.domains.models import Domain
+
+
+class DomainSerializer(BaseObjectSerializer):
+    class Meta(BaseObjectSerializer.Meta):
+        model = Domain
+        depth = 1
+
+
+class DomainViewSet(RalphAPIViewSet):
+    queryset = Domain.objects.all()
+    serializer_class = DomainSerializer
+
+router.register(r'domains', DomainViewSet)
+urlpatterns = []

--- a/src/ralph/domains/models/__init__.py
+++ b/src/ralph/domains/models/__init__.py
@@ -1,0 +1,13 @@
+from ralph.domains.models.domains import (
+    Domain,
+    DomainContract,
+    DomainRegistrant,
+    DomainStatus
+)
+
+__all__ = [
+    'Domain',
+    'DomainContract',
+    'DomainRegistrant',
+    'DomainStatus',
+]

--- a/src/ralph/domains/tests/factories.py
+++ b/src/ralph/domains/tests/factories.py
@@ -1,0 +1,14 @@
+# -*- coding: utf-8 -*-
+import factory
+from factory.django import DjangoModelFactory
+
+from ralph.domains.models import Domain, DomainStatus
+
+
+class DomainFactory(DjangoModelFactory):
+
+    name = factory.Sequence(lambda n: 'www.domain{}.com'.format(n))
+    domain_status = DomainStatus.active
+
+    class Meta:
+        model = Domain

--- a/src/ralph/tests/models.py
+++ b/src/ralph/tests/models.py
@@ -26,6 +26,9 @@ class OrderStatus(Choices):
 class Foo(AdminAbsoluteUrlMixin, models.Model):
     bar = models.CharField('bar', max_length=50)
 
+    def __str__(self):
+        return 'Foo: {} / {}'.format(self.id, self.bar)
+
 
 class Manufacturer(models.Model):
     name = models.CharField(max_length=50)

--- a/src/ralph/urls/base.py
+++ b/src/ralph/urls/base.py
@@ -13,6 +13,7 @@ api_urls = list(map(lambda u: url(r'^', include(u)), [
     'ralph.back_office.api',
     'ralph.data_center.api.routers',
     'ralph.dc_view.urls.api',
+    'ralph.domains.api',
     'ralph.supports.api',
     'ralph.security.api',
     'ralph.virtual.api',

--- a/src/ralph/virtual/api.py
+++ b/src/ralph/virtual/api.py
@@ -13,11 +13,12 @@ from ralph.virtual.models import (
     CloudFlavor,
     CloudHost,
     CloudProject,
-    CloudProvider
+    CloudProvider,
+    VirtualServer
 )
 
 
-class CloudFlavorSimpleSerializer(RalphAPISerializer):
+class CloudFlavorSimpleSerializer(BaseObjectSerializer):
     class Meta:
         model = CloudFlavor
         fields = ['name', 'cores', 'memory', 'disk', 'url']
@@ -74,33 +75,32 @@ class SaveCloudHostSerializer(RalphAPISaveSerializer):
         exclude = ['content_type']
 
 
-class CloudFlavorSerializer(RalphAPISerializer):
+class CloudFlavorSerializer(BaseObjectSerializer):
     cores = serializers.IntegerField()
     memory = serializers.IntegerField()
     disk = serializers.IntegerField()
 
-    class Meta:
+    class Meta(BaseObjectSerializer.Meta):
         model = CloudFlavor
         exclude = ['content_type', 'service_env', 'parent']
 
 
-class CloudHostSerializer(RalphAPISerializer):
+class CloudHostSerializer(BaseObjectSerializer):
     ip_addresses = serializers.ListField()
     hypervisor = DataCenterAssetSimpleSerializer()
     parent = CloudProjectSimpleSerializer(source='cloudproject')
     cloudflavor = CloudFlavorSimpleSerializer()
     service_env = ServiceEnvironmentSimpleSerializer()
 
-    class Meta:
+    class Meta(BaseObjectSerializer.Meta):
         model = CloudHost
         depth = 1
-        exclude = ['content_type']
 
 
 class CloudProjectSerializer(BaseObjectSerializer):
     cloud_hosts = CloudHostSimpleSerializer(many=True, source='children')
 
-    class Meta:
+    class Meta(BaseObjectSerializer.Meta):
         model = CloudProject
         depth = 2
         exclude = ['content_type', 'parent']
@@ -109,6 +109,11 @@ class CloudProjectSerializer(BaseObjectSerializer):
 class CloudProviderSerializer(RalphAPISerializer):
     class Meta:
         model = CloudProvider
+
+
+class VirtualServerSerializer(BaseObjectSerializer):
+    class Meta(BaseObjectSerializer.Meta):
+        model = VirtualServer
 
 
 class CloudFlavorViewSet(RalphAPIViewSet):
@@ -142,8 +147,14 @@ class CloudProjectViewSet(RalphAPIViewSet):
     ]
 
 
+class VirtualServerViewSet(RalphAPIViewSet):
+    queryset = VirtualServer.objects.all()
+    serializer_class = VirtualServerSerializer
+
+
 router.register(r'cloud-flavors', CloudFlavorViewSet)
 router.register(r'cloud-hosts', CloudHostViewSet)
 router.register(r'cloud-projects', CloudProjectViewSet)
 router.register(r'cloud-providers', CloudProviderViewSet)
+router.register(r'virtual-servers', VirtualServerViewSet)
 urlpatterns = []

--- a/src/ralph/virtual/tests/factories.py
+++ b/src/ralph/virtual/tests/factories.py
@@ -1,11 +1,13 @@
 import factory
 from factory.django import DjangoModelFactory
 
+from ralph.assets.tests.factories import ServiceEnvironmentFactory
 from ralph.virtual.models import (
     CloudFlavor,
     CloudHost,
     CloudProject,
-    CloudProvider
+    CloudProvider,
+    VirtualServer
 )
 
 
@@ -59,3 +61,11 @@ class CloudHostFactory(DjangoModelFactory):
     class Meta:
         model = CloudHost
         django_get_or_create = ['host_id']
+
+
+class VirtualServerFactory(DjangoModelFactory):
+
+    service_env = factory.SubFactory(ServiceEnvironmentFactory)
+
+    class Meta:
+        model = VirtualServer

--- a/src/ralph/virtual/tests/test_openstack_sync.py
+++ b/src/ralph/virtual/tests/test_openstack_sync.py
@@ -33,7 +33,7 @@ class TestOpenstackSync(RalphTestCase):
     def setUp(self):
         asset_model = DataCenterAssetModelFactory()
         self.cloud_provider = CloudProviderFactory(name='openstack')
-        self.cloud_flavor = CloudFlavorFactory.create_batch(2)
+        self.cloud_flavor = CloudFlavorFactory.create_batch(3)
         self.test_model = ComponentModel(name='delete_test')
         VirtualComponent(
             model=self.test_model,


### PR DESCRIPTION
- added serializer for each descendant model of BaseObject
- added `__str__` field to BaseObject serializer - this field provides simple way to get string representation of BaseObject (not matter what descendant type is)
- added tests to check if every descendant model of BaseObject has `__str__` field attached
