### PR TITLE
Reduced number of SQL queries in licences and supports export

### DIFF
--- a/docs/development/admin.md
+++ b/docs/development/admin.md
@@ -1,0 +1,37 @@
+# Ralph Admin
+
+Ralph Admin class (`ralph.admin.mixins.RalphAdmin`) is built on top of regular Django Admin and has bunch of extending features. Some of them are listed below.
+
+## Import-Export
+
+Ralph Admin has built-in support for importing and exporting objects (using [django-import-export](https://github.com/django-import-export/django-import-export)). Possible configuration:
+
+### Resource class
+
+Define `resouce_class` in your Admin to specify django-import-export's resource class used to handle importing and exporting of this model.
+
+Example:
+```
+class SupportAdmin(RalphAdmin):
+    ...
+    resource_class = resources.SupportResource
+    ...
+```
+
+### Export queryset
+
+Define `_export_queryset_manager` attribute in your Admin to specify which manager will be used to handle export queries. This should be string with model's attribute name for proper manager.
+
+Example:
+```
+class SupportAdmin(RalphAdmin):
+    ...
+    _export_queryset_manager = 'objects_with_related'
+    ...
+```
+
+> Export in Admin by default use `get_queryset` from Django's admin to properly handle all filters etc. During export from Admin, `get_queryset` defined in your Resource is not used, but it is a good practice, to point them to the same objects manager.
+
+### Fetching related objects
+
+Ralph Admin, by default, [select](https://docs.djangoproject.com/en/1.8/ref/models/querysets/#select-related) and [prefetch](https://docs.djangoproject.com/en/1.8/ref/models/querysets/#prefetch-related) all related objects that are defined in Resource's Meta.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -15,6 +15,7 @@ pages:
   - Developer guide:
       - Before you start: CONTRIBUTING.md
       - Architecture: development/overview.md
+      - RalphAdmin: development/admin.md
       - Transitions: development/transitions.md
       - Addons : development/addons.md
       - Packaging: development/packaging.md

--- a/src/ralph/admin/mixins.py
+++ b/src/ralph/admin/mixins.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+import logging
 import os
 import urllib
 from copy import copy
@@ -30,6 +31,8 @@ from ralph.lib.permissions.admin import (
 )
 from ralph.lib.permissions.models import PermByFieldMixin
 from ralph.lib.permissions.views import PermissionViewMetaClass
+
+logger = logging.getLogger(__name__)
 
 FORMFIELD_FOR_DBFIELD_DEFAULTS = {
     models.DateField: {'widget': widgets.AdminDateWidget},
@@ -283,6 +286,7 @@ class RalphAdminImportExportMixin(ImportExportModelAdmin):
     _export_queryset_manager = None
 
     def get_export_queryset(self, request):
+        # mark request as "exporter" request
         request._is_export = True
         queryset = super().get_export_queryset(request)
         resource = self.get_export_resource_class()
@@ -318,7 +322,12 @@ class RalphAdminImportExportMixin(ImportExportModelAdmin):
         return resource_class
 
     def get_queryset(self, request):
+        # if it is "exporter" request, try to use `_export_queryset_manager`
+        # manager defined in admin
         if hasattr(request, '_is_export') and self._export_queryset_manager:
+            logger.info('Using {} manager for export'.format(
+                self._export_queryset_manager
+            ))
             return getattr(self.model, self._export_queryset_manager).all()
         return super().get_queryset(request)
 

--- a/src/ralph/data_importer/management/commands/demodata.py
+++ b/src/ralph/data_importer/management/commands/demodata.py
@@ -38,8 +38,8 @@ from ralph.data_center.tests.factories import (
 from ralph.lib.transitions.models import Action, Transition, TransitionModel
 from ralph.licences.models import LicenceUser
 from ralph.licences.tests.factories import (
-    BaseObjectDataCenterLicenceFactory,
     BaseObjectLicenceFactory,
+    DataCenterAssetLicenceFactory,
     LicenceFactory
 )
 from ralph.reports.models import Report, ReportLanguage, ReportTemplate
@@ -1049,7 +1049,7 @@ class Command(BaseCommand):
                 user=self.get_user()
             )
             for j in range(3):
-                BaseObjectDataCenterLicenceFactory(
+                DataCenterAssetLicenceFactory(
                     licence=licence
                 )
 

--- a/src/ralph/data_importer/resources.py
+++ b/src/ralph/data_importer/resources.py
@@ -17,9 +17,9 @@ from ralph.data_importer.mixins import (
 )
 from ralph.data_importer.widgets import (
     AssetServiceEnvWidget,
-    BaseObjectThroughWidget,
     BaseObjectWidget,
     ImportedForeignKeyWidget,
+    ManyToManyThroughWidget,
     NullStringWidget,
     UserManyToManyWidget,
     UserWidget
@@ -316,8 +316,12 @@ class LicenceResource(RalphModelResource):
     )
     base_objects = ThroughField(
         column_name='base_objects',
-        attribute='base_objects',
-        widget=BaseObjectThroughWidget(model=base.BaseObject),
+        attribute='baseobjectlicence_set',
+        widget=ManyToManyThroughWidget(
+            model=BaseObjectLicence,
+            related_model=base.BaseObject,
+            through_field='base_object'
+        ),
         through_model=BaseObjectLicence,
         through_from_field_name='licence',
         through_to_field_name='base_object'
@@ -325,11 +329,11 @@ class LicenceResource(RalphModelResource):
 
     class Meta:
         model = Licence
-        prefetch_related = (
-            'tags', 'users', 'licenceuser_set__user',
-            'baseobjectlicence_set__base_object'
-        )
+        prefetch_related = ('tags')
         exclude = ('content_type', 'baseobject_ptr', )
+
+    def get_queryset(self):
+        return Licence.objects_used_free_with_related.all()
 
     def dehydrate_price(self, licence):
         return str(licence.price)
@@ -349,8 +353,12 @@ class SupportResource(RalphModelResource):
     )
     base_objects = ThroughField(
         column_name='base_objects',
-        attribute='base_objects',
-        widget=BaseObjectThroughWidget(model=base.BaseObject),
+        attribute='baseobjectssupport_set',
+        widget=ManyToManyThroughWidget(
+            model=BaseObjectsSupport,
+            related_model=base.BaseObject,
+            through_field='baseobject'
+        ),
         through_model=BaseObjectsSupport,
         through_from_field_name='support',
         through_to_field_name='baseobject'
@@ -379,11 +387,10 @@ class SupportResource(RalphModelResource):
     class Meta:
         model = Support
         exclude = ('content_type', 'baseobject_ptr',)
+        prefetch_related = ('tags',)
 
     def get_queryset(self):
-        return Support.objects.annotate(
-            assigned_objects_count=Count('base_objects')
-        )
+        return Support.objects_with_related.all()
 
     def dehydrate_assigned_objects_count(self, support):
         return support.assigned_objects_count

--- a/src/ralph/data_importer/resources.py
+++ b/src/ralph/data_importer/resources.py
@@ -329,7 +329,7 @@ class LicenceResource(RalphModelResource):
 
     class Meta:
         model = Licence
-        prefetch_related = ('tags')
+        prefetch_related = ('tags',)
         exclude = ('content_type', 'baseobject_ptr', )
 
     def get_queryset(self):

--- a/src/ralph/data_importer/tests/test_export.py
+++ b/src/ralph/data_importer/tests/test_export.py
@@ -1,0 +1,92 @@
+from django.core.urlresolvers import reverse
+from django.db import connections
+from django.test import RequestFactory, TestCase
+from django.test.utils import CaptureQueriesContext
+
+from ralph.accounts.tests.factories import UserFactory
+from ralph.admin import ralph_site
+from ralph.licences.models import Licence
+from ralph.licences.tests.factories import (
+    BackOfficeAssetLicenceFactory,
+    DataCenterAssetLicenceFactory,
+    LicenceFactory,
+    LicenceUserFactory
+)
+from ralph.supports.models import Support
+from ralph.supports.tests.factories import (
+    BackOfficeAssetSupportFactory,
+    DataCenterAssetSupportFactory,
+    SupportFactory
+)
+
+
+class RawFormat(object):
+    def export_data(self, data):
+        return data
+
+
+class SimulateAdminExportTestCase(TestCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.user = UserFactory(is_superuser=True, is_staff=True)
+
+    def _export(self, model, filters=None):
+        filters = filters or {}
+        admin_class = ralph_site._registry[model]
+        request = RequestFactory().get(
+            reverse('admin:{}_{}_export'.format(
+                model._meta.app_label, model._meta.model_name
+            )),
+            filters
+        )
+        request.user = self.user
+
+        file_format = RawFormat()
+        queryset = admin_class.get_export_queryset(request)
+        export_data = admin_class.get_export_data(file_format, queryset)
+        return export_data
+
+    def _init(self, num=10):
+        pass
+
+    def _test_queries_count(self, func, nums=(10, 20), max_queries=10):
+        # usually here we cannot specify exact number of queries since there is
+        # a lot of dependencies (permissions etc), so we're going to check if
+        # the number of queries do not change if the number of created objects
+        # change
+        queries_counts = set()
+        for num in nums:
+            self._init(num)
+            with CaptureQueriesContext(connections['default']) as cqc:
+                func()
+                queries_counts.add(len(cqc))
+        self.assertEqual(
+            len(queries_counts),
+            1,
+            msg='Different queries count: {}'.format(queries_counts)
+        )
+        self.assertLess(queries_counts.pop(), max_queries)
+
+
+class LicenceExporterTestCase(SimulateAdminExportTestCase):
+    def _init(self, num=10):
+        self.licences = LicenceFactory.create_batch(num)
+        for licence in self.licences:
+            DataCenterAssetLicenceFactory.create_batch(3, licence=licence)
+            BackOfficeAssetLicenceFactory.create_batch(2, licence=licence)
+            LicenceUserFactory.create_batch(3, licence=licence)
+
+    def test_licence_export_queries_count(self):
+        self._test_queries_count(func=lambda: self._export(Licence))
+
+
+class SupportExporterTestCase(SimulateAdminExportTestCase):
+    def _init(self, num=10):
+        self.supports = SupportFactory.create_batch(num)
+        for support in self.supports:
+            BackOfficeAssetSupportFactory.create_batch(3, support=support)
+            DataCenterAssetSupportFactory.create_batch(2, support=support)
+
+    def test_licence_export_queries_count(self):
+        self._test_queries_count(func=lambda: self._export(Support))

--- a/src/ralph/data_importer/tests/test_widgets.py
+++ b/src/ralph/data_importer/tests/test_widgets.py
@@ -1,0 +1,66 @@
+from django.test import TestCase
+
+from ralph.assets.models import BaseObject
+from ralph.data_importer.widgets import (
+    ExportManyToManyStrTroughWidget,
+    ManyToManyThroughWidget
+)
+from ralph.licences.models import BaseObjectLicence
+from ralph.licences.tests.factories import (
+    DataCenterAssetLicenceFactory,
+    LicenceFactory
+)
+
+
+class ManyToManyThroughWidgetTestCase(TestCase):
+    def setUp(self):
+        self.licence = LicenceFactory()
+        DataCenterAssetLicenceFactory.create_batch(3, licence=self.licence)
+        self.base_objects_ids = [
+            bo.pk for bo in self.licence.base_objects.all()
+        ]
+        self.widget = ManyToManyThroughWidget(
+            model=BaseObjectLicence,
+            related_model=BaseObject,
+            through_field='base_object'
+        )
+
+    def test_clean(self):
+        result = self.widget.clean(','.join(map(str, self.base_objects_ids)))
+        self.assertCountEqual(
+            result,
+            BaseObject.objects.filter(pk__in=self.base_objects_ids)
+        )
+
+    def test_clean_empty_value(self):
+        result = self.widget.clean('')
+        self.assertCountEqual(result, BaseObject.objects.none())
+        self.assertEqual(result.model, BaseObject)
+
+    def test_render(self):
+        result = self.widget.render(self.licence.baseobjectlicence_set.all())
+        self.assertCountEqual(
+            map(int, result.split(',')), self.base_objects_ids
+        )
+
+
+class ExportManyToManyStrThroughWidgetTestCase(TestCase):
+    def setUp(self):
+        self.licence = LicenceFactory()
+        DataCenterAssetLicenceFactory.create_batch(3, licence=self.licence)
+        self.base_objects_ids = [
+            bo.pk for bo in self.licence.base_objects.all()
+        ]
+        self.widget = ExportManyToManyStrTroughWidget(
+            model=BaseObjectLicence,
+            related_model=BaseObject,
+            through_field='base_object'
+        )
+
+    def test_render(self):
+        result = self.widget.render(self.licence.baseobjectlicence_set.all())
+        self.assertCountEqual(result.split(','), [
+            str(obj) for obj in BaseObject.objects.filter(
+                pk__in=self.base_objects_ids
+            )
+        ])

--- a/src/ralph/data_importer/widgets.py
+++ b/src/ralph/data_importer/widgets.py
@@ -6,7 +6,6 @@ from django.contrib.contenttypes.models import ContentType
 from import_export import widgets
 
 from ralph.assets.models.assets import ServiceEnvironment
-from ralph.assets.models.base import BaseObject
 from ralph.back_office.models import BackOfficeAsset
 from ralph.data_center.models.physical import DataCenterAsset
 from ralph.data_importer.models import ImportedObjects
@@ -80,18 +79,26 @@ class UserManyToManyWidget(widgets.ManyToManyWidget):
         return self.separator.join([obj.username for obj in value.all()])
 
 
-class BaseObjectThroughWidget(widgets.ManyToManyWidget):
+class ManyToManyThroughWidget(widgets.ManyToManyWidget):
+    """
+    Widget for many-to-many relations with through table. This widget accept
+    or return list of related models pks (other-end of through table).
+    """
+    def __init__(self, through_field, related_model, *args, **kwargs):
+        self.through_field = through_field
+        self.related_model = related_model
+        super().__init__(*args, **kwargs)
 
     def clean(self, value):
         if not value:
-            return BaseObject.objects.none()
-        return BaseObject.objects.filter(
+            return self.related_model.objects.none()
+        return self.related_model.objects.filter(
             pk__in=value.split(self.separator)
         )
 
     def render(self, value):
         return self.separator.join(
-            [str(obj.pk) for obj in value.all()]
+            [str(getattr(obj, self.through_field).pk) for obj in value.all()]
         )
 
 
@@ -107,6 +114,17 @@ class ExportManyToManyStrWidget(widgets.ManyToManyWidget):
         return self.separator.join([str(obj) for obj in value.all()])
 
 
+class ExportManyToManyStrTroughWidget(ManyToManyThroughWidget):
+    """
+    Exporter-equivalent of `ManyToManyThroughWidget` - return str of whole
+    object instead of pk.
+    """
+    def render(self, value):
+        return self.separator.join(
+            [str(getattr(obj, self.through_field)) for obj in value.all()]
+        )
+
+
 class BaseObjectManyToManyWidget(widgets.ManyToManyWidget):
 
     """Widget for BO/DC base objects."""
@@ -118,6 +136,7 @@ class BaseObjectManyToManyWidget(widgets.ManyToManyWidget):
         content_types = ContentType.objects.get_for_models(
             BackOfficeAsset,
             DataCenterAsset,
+            # TODO: more types
         )
         imported_obj_ids = ImportedObjects.objects.filter(
             content_type__in=content_types.values(),

--- a/src/ralph/data_importer/widgets.py
+++ b/src/ralph/data_importer/widgets.py
@@ -82,9 +82,17 @@ class UserManyToManyWidget(widgets.ManyToManyWidget):
 class ManyToManyThroughWidget(widgets.ManyToManyWidget):
     """
     Widget for many-to-many relations with through table. This widget accept
-    or return list of related models pks (other-end of through table).
+    or return list of related models PKs (other-end of through table).
     """
     def __init__(self, through_field, related_model, *args, **kwargs):
+        """
+        Args:
+            model: Django's through model
+            related_model: the-other-end model of m2m relation
+            through_field: name of field in through model pointing to
+                `related_model` (when used together with `ThroughField`, it
+                should be the same as `through_to_field_name`)
+        """
         self.through_field = through_field
         self.related_model = related_model
         super().__init__(*args, **kwargs)

--- a/src/ralph/licences/admin.py
+++ b/src/ralph/licences/admin.py
@@ -113,6 +113,7 @@ class LicenceAdmin(
         }),
     )
     _queryset_manager = 'objects_used_free'
+    _export_queryset_manager = 'objects_used_free_with_related'
 
 
 @register(LicenceType)

--- a/src/ralph/licences/tests/factories.py
+++ b/src/ralph/licences/tests/factories.py
@@ -88,7 +88,11 @@ class BaseObjectLicenceFactory(DjangoModelFactory):
         model = BaseObjectLicence
 
 
-class BaseObjectDataCenterLicenceFactory(DjangoModelFactory):
+class BackOfficeAssetLicenceFactory(BaseObjectLicenceFactory):
+    pass
+
+
+class DataCenterAssetLicenceFactory(DjangoModelFactory):
     licence = factory.SubFactory(LicenceFactory)
     base_object = factory.SubFactory(DataCenterAssetFactory)
 

--- a/src/ralph/supports/admin.py
+++ b/src/ralph/supports/admin.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-from django.db.models import Count
 from django.utils.translation import ugettext_lazy as _
 
 from ralph.admin import RalphAdmin, RalphTabularInline, register
@@ -79,10 +78,7 @@ class SupportAdmin(
         }),
     )
 
-    def get_queryset(self, request):
-        return Support.objects.annotate(
-            assigned_objects_count=Count('base_objects')
-        )
+    _export_queryset_manager = 'objects_with_related'
 
 
 @register(SupportType)

--- a/src/ralph/supports/tests/factories.py
+++ b/src/ralph/supports/tests/factories.py
@@ -8,6 +8,7 @@ from factory.fuzzy import FuzzyText
 from ralph.accounts.tests.factories import RegionFactory
 from ralph.assets.tests.factories import AssetHolderFactory, BudgetInfoFactory
 from ralph.back_office.tests.factories import BackOfficeAssetFactory
+from ralph.data_center.tests.factories import DataCenterAssetFactory
 from ralph.supports.models import (
     BaseObjectsSupport,
     Support,
@@ -65,3 +66,11 @@ class BaseObjectsSupportFactory(DjangoModelFactory):
 
     class Meta:
         model = BaseObjectsSupport
+
+
+class BackOfficeAssetSupportFactory(BaseObjectsSupportFactory):
+    pass
+
+
+class DataCenterAssetSupportFactory(BaseObjectsSupportFactory):
+    baseobject = factory.SubFactory(DataCenterAssetFactory)


### PR DESCRIPTION
- added new managers to Licence and Support to handle prefetching related base objects
- improved import-export m2m widgets
- introduced `_export_queryset_manager` admin property to point to proper manager for exporting

TODO:
- [x] tests
- [x] check if licences/suports import (using `ThroughField`) will not crash now
