### PR TITLE
Networks improvements

### DIFF
--- a/src/ralph/admin/filters.py
+++ b/src/ralph/admin/filters.py
@@ -475,7 +475,9 @@ def register_custom_filters():
             RelatedFieldListFilter
         ),
         (
-            lambda f: isinstance(f, models.ForeignKey),
+            lambda f: isinstance(f, (
+                models.ForeignKey, models.ManyToManyField
+            )),
             RelatedAutocompleteFieldListFilter
         ),
         (lambda f: isinstance(f, TaggableManager), TagsListFilter),

--- a/src/ralph/assets/models/base.py
+++ b/src/ralph/assets/models/base.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+from django.contrib.contenttypes.models import ContentType
 from django.db import models
 
 from ralph.lib.mixins.models import TaggableMixin, TimeStampMixin
@@ -32,3 +33,10 @@ class BaseObject(
     )
     remarks = models.TextField(blank=True)
     service_env = models.ForeignKey('ServiceEnvironment', null=True)
+
+    @property
+    def _str_with_type(self):
+        return '{}: {}'.format(
+            ContentType.objects.get_for_id(self.content_type_id),
+            str(self)
+        )

--- a/src/ralph/data_center/admin.py
+++ b/src/ralph/data_center/admin.py
@@ -4,6 +4,7 @@ from django.utils.translation import ugettext_lazy as _
 
 from ralph.admin import RalphAdmin, RalphTabularInline, register
 from ralph.admin.filters import LiquidatedStatusFilter, TagsListFilter
+from ralph.admin.m2m import RalphTabularM2MInline
 from ralph.admin.mixins import BulkEditChangeListMixin
 from ralph.admin.views.extra import RalphDetailViewAdmin
 from ralph.admin.views.multiadd import MulitiAddAdminMixin
@@ -26,7 +27,7 @@ from ralph.data_importer import resources
 from ralph.lib.transitions.admin import TransitionAdminMixin
 from ralph.licences.models import BaseObjectLicence
 from ralph.networks.forms import NetworkInlineFormset
-from ralph.networks.models.networks import IPAddress
+from ralph.networks.models.networks import IPAddress, Network
 from ralph.operations.views import OperationViewReadOnlyForExisiting
 from ralph.supports.models import BaseObjectsSupport
 
@@ -46,6 +47,23 @@ class DataCenterAdmin(RalphAdmin):
 class NetworkInline(RalphTabularInline):
     formset = NetworkInlineFormset
     model = IPAddress
+    exclude = ['status']
+
+
+class NetworkTerminatorReadOnlyInline(RalphTabularM2MInline):
+    model = Network
+    extra = 0
+    show_change_link = True
+    verbose_name_plural = _('Terminators of')
+    fields = [
+        'name', 'address',
+    ]
+
+    def get_readonly_fields(self, request, obj=None):
+        return self.get_fields(request, obj)
+
+    def has_add_permission(self, request):
+        return False
 
 
 class NetworkView(RalphDetailViewAdmin):
@@ -54,7 +72,7 @@ class NetworkView(RalphDetailViewAdmin):
     label = 'Network'
     url_name = 'network'
 
-    inlines = [NetworkInline]
+    inlines = [NetworkInline, NetworkTerminatorReadOnlyInline]
 
 
 class DataCenterAssetSupport(RalphDetailViewAdmin):

--- a/src/ralph/networks/migrations/0003_auto_20160322_1457.py
+++ b/src/ralph/networks/migrations/0003_auto_20160322_1457.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+import ralph.lib.mixins.fields
+import django.db.models.deletion
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('networks', '0002_auto_20160310_1425'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='ipaddress',
+            name='base_object',
+            field=ralph.lib.mixins.fields.BaseObjectForeignKey(to='assets.BaseObject', on_delete=django.db.models.deletion.SET_NULL, blank=True, null=True, default=None, verbose_name='Base object'),
+        ),
+    ]

--- a/src/ralph/networks/models/__init__.py
+++ b/src/ralph/networks/models/__init__.py
@@ -1,0 +1,17 @@
+from ralph.networks.models.choices import IPAddressStatus
+from ralph.networks.models.networks import (
+    DiscoveryQueue,
+    IPAddress,
+    Network,
+    NetworkEnvironment,
+    NetworkKind
+)
+
+__all__ = [
+    'DiscoveryQueue',
+    'IPAddress',
+    'IPAddressStatus',
+    'Network',
+    'NetworkEnvironment',
+    'NetworkKind',
+]

--- a/src/ralph/networks/models/networks.py
+++ b/src/ralph/networks/models/networks.py
@@ -12,7 +12,7 @@ from django.utils.translation import ugettext_lazy as _
 from mptt.models import MPTTModel, TreeForeignKey
 
 from ralph.lib import network as network_tools
-from ralph.lib.mixins.fields import NullableCharField
+from ralph.lib.mixins.fields import BaseObjectForeignKey, NullableCharField
 from ralph.lib.mixins.models import (
     AdminAbsoluteUrlMixin,
     LastSeenMixin,
@@ -316,13 +316,21 @@ class DiscoveryQueue(NamedMixin, models.Model):
 class IPAddress(LastSeenMixin, TimeStampMixin, NetworkMixin, models.Model):
     _parent_attr = 'network'
 
-    base_object = models.ForeignKey(
+    base_object = BaseObjectForeignKey(
         'assets.BaseObject',
         verbose_name=_('Base object'),
         null=True,
         blank=True,
         default=None,
         on_delete=models.SET_NULL,
+        limit_models=[
+            'data_center.Database',
+            'data_center.DataCenterAsset',
+            'data_center.VIP',
+            'virtual.CloudHost',
+            'virtual.VirtualServer',
+
+        ]
     )
     network = models.ForeignKey(
         Network,

--- a/src/ralph/settings/base.py
+++ b/src/ralph/settings/base.py
@@ -283,3 +283,6 @@ OPENSTACK_INSTANCES = json.loads(os.environ.get('OPENSTACK_INSTANCES', '[]'))
 
 # issue tracker url for Operations urls (issues ids) - should end with /
 ISSUE_TRACKER_URL = os.environ.get('ISSUE_TRACKER_URL', '')
+
+# Networks
+DEFAULT_NETWORK_MARGIN = int(os.environ.get('DEFAULT_NETWORK_MARGIN', 10))

--- a/src/ralph/virtual/models.py
+++ b/src/ralph/virtual/models.py
@@ -154,7 +154,7 @@ class CloudHost(AdminAbsoluteUrlMixin, BaseObject):
         verbose_name_plural = _('Cloud hosts')
 
     def __str__(self):
-        return 'Cloud Host: {}'.format(self.hostname)
+        return self.hostname
 
     @property
     def ip_addresses(self):


### PR DESCRIPTION
- default margin (top and bottom) set to 10
- status field added to IP form
- IP baseobject limited to [DataCenterAsset, Database, VIP, VirtualServer, CloudHost]
- added list of networks in which object (DC Asset) is a terminator
- "pretty name" of linked object in IP Address list view
- other small fixes & improvements (queries count, additional fields etc)
