### PR TITLE
Added `skip_first` to cache and check if dnsaas integration is enabled in view

### DIFF
--- a/src/ralph/dns/dnsaas.py
+++ b/src/ralph/dns/dnsaas.py
@@ -97,7 +97,7 @@ class DNSaaS:
         if request.status_code != 200:
             return request.json()
 
-    @cache()
+    @cache(skip_first=True)
     def get_domain(self, domain_name):
         """
         Return domain URL base on record name.

--- a/src/ralph/dns/tests.py
+++ b/src/ralph/dns/tests.py
@@ -1,10 +1,11 @@
 # -*- coding: utf-8 -*-
 from unittest.mock import patch
 
-from django.test import TestCase
+from django.test import override_settings, TestCase
 
 from ralph.dns.dnsaas import DNSaaS
 from ralph.dns.forms import RecordType
+from ralph.dns.views import DNSaaSIntegrationNotEnabledError, DNSView
 
 
 class TestGetDnsRecords(TestCase):
@@ -32,3 +33,15 @@ class TestGetDnsRecords(TestCase):
         self.assertEqual(found_dns[0]['content'], data['content'])
         self.assertEqual(found_dns[0]['name'], data['name'])
         self.assertEqual(found_dns[0]['type'], RecordType.a)
+
+
+class TestDNSView(TestCase):
+    @override_settings(ENABLE_DNSAAS_INTEGRATION=False)
+    def test_dnsaasintegration_disabled(self):
+        with self.assertRaises(DNSaaSIntegrationNotEnabledError):
+            DNSView()
+
+    @override_settings(ENABLE_DNSAAS_INTEGRATION=True)
+    def test_dnsaasintegration_enabled(self):
+        # should not raise exception
+        DNSView()

--- a/src/ralph/dns/views.py
+++ b/src/ralph/dns/views.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 import logging
 
+from django.conf import settings
 from django.http import HttpResponseRedirect
 
 from ralph.admin.views.extra import RalphDetailView
@@ -8,6 +9,10 @@ from ralph.dns.dnsaas import DNSaaS
 from ralph.dns.forms import DNSRecordForm
 
 logger = logging.getLogger(__name__)
+
+
+class DNSaaSIntegrationNotEnabledError(Exception):
+    pass
 
 
 class DNSView(RalphDetailView):
@@ -18,6 +23,8 @@ class DNSView(RalphDetailView):
     template_name = 'dns/dns_edit.html'
 
     def __init__(self, *args, **kwargs):
+        if not settings.ENABLE_DNSAAS_INTEGRATION:
+            raise DNSaaSIntegrationNotEnabledError()
         self.dnsaas = DNSaaS()
         return super().__init__(*args, **kwargs)
 

--- a/src/ralph/helpers.py
+++ b/src/ralph/helpers.py
@@ -48,16 +48,23 @@ def _cache_key_hash(func, *args, **kwargs):
     return pickle.dumps((func.__module__, func.__name__, args, kwargs))
 
 
-def cache(seconds=300, cache_name=DEFAULT_CACHE_ALIAS):
+def cache(seconds=300, cache_name=DEFAULT_CACHE_ALIAS, skip_first=False):
     """
     Cache the result of a function call with particular parameters for specified
     number of seconds.
+
+    Args:
+        * skip_first - set to True if first argument should not be considered
+          when calculating hash of arguments (useful when first argument
+          is instance of a class (self)).
     """
     def _cache(func):
         @wraps(func)
         def wrapper(*args, **kwargs):
             cache_proxy = caches[cache_name]
-            key = _cache_key_hash(func, *args, **kwargs)
+            key = _cache_key_hash(
+                func, *(args[1:] if skip_first else args), **kwargs
+            )
             result = cache_proxy.get(key, default=CACHE_DEFAULT)
             if result is CACHE_DEFAULT:
                 logger.debug('Recalculating result of {}'.format(func.__name__))


### PR DESCRIPTION
- Now you could use `skip_first` param in cache decorator - when set to True, first param (usually class instance a.k.a self) will not be used to calculate hash of params
- dnsview not checks if dnsaas integration is enabled
