### PR TITLE
DC Asset last hostname generator

### DIFF
--- a/src/ralph/admin/sitetrees.py
+++ b/src/ralph/admin/sitetrees.py
@@ -103,7 +103,6 @@ sitetrees = [
                 section(_('Server Rooms'), 'data_center', 'ServerRoom'),
                 section(_('VIPs'), 'data_center', 'VIP'),
                 section(_('Virtual Servers'), 'virtual', 'VirtualServer'),
-                section(_('IP Addresses'), 'data_center', 'ipaddress'),
                 section(_('Clusters'), 'data_center', 'cluster'),
             ],
         ),

--- a/src/ralph/assets/migrations/0015_auto_20160425_1335.py
+++ b/src/ralph/assets/migrations/0015_auto_20160425_1335.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('assets', '0014_auto_20160414_0958'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='assetlasthostname',
+            name='postfix',
+            field=models.CharField(max_length=30, db_index=True),
+        ),
+        migrations.AlterField(
+            model_name='assetlasthostname',
+            name='prefix',
+            field=models.CharField(max_length=30, db_index=True),
+        ),
+    ]

--- a/src/ralph/data_center/models/physical.py
+++ b/src/ralph/data_center/models/physical.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+import logging
 import re
 from collections import namedtuple
 from itertools import chain
@@ -8,6 +9,7 @@ from django.core.exceptions import ValidationError
 from django.core.validators import RegexValidator
 from django.db import models, transaction
 from django.db.models import Q
+from django.utils.functional import cached_property
 from django.utils.translation import ugettext_lazy as _
 
 from ralph.accounts.models import Region
@@ -27,7 +29,9 @@ from ralph.data_center.models.choices import (
 from ralph.lib.mixins.models import AdminAbsoluteUrlMixin
 from ralph.lib.transitions.decorators import transition_action
 from ralph.lib.transitions.fields import TransitionField
-from ralph.networks.models.networks import IPAddress
+from ralph.networks.models import IPAddress, NetworkEnvironment
+
+logger = logging.getLogger(__name__)
 
 # i.e. number in range 1-16 and optional postfix 'A' or 'B'
 VALID_SLOT_NUMBER_FORMAT = re.compile('^([1-9][A,B]?|1[0-6][A,B]?)$')
@@ -402,6 +406,24 @@ class DataCenterAsset(AutocompleteTooltipMixin, Asset):
                 is_management=True,
             )
 
+    @cached_property
+    def network_environment(self):
+        """
+        Return first found network environment for this `DataCenterAsset` based
+        on assigned rack.
+
+        Full algorithm:
+            * find networks which are "connected" to rack assigned to me
+            * find all (distinct) network environments assigned to these
+              networks
+            * return first founded network environment if there is any,
+              otherwise return `None`
+        """
+        if self.rack_id:
+            return NetworkEnvironment.objects.filter(
+                network__racks=self.rack
+            ).distinct().first()
+
     def _validate_orientation(self):
         """
         Validate if orientation is valid for given position.
@@ -500,6 +522,26 @@ class DataCenterAsset(AutocompleteTooltipMixin, Asset):
             Gap.generate_gaps(assets) for assets in assets_by_orientation
         ]
         return chain(*assets)
+
+    def get_next_free_hostname(self):
+        """
+        Returns next free hostname for this asset based on Rack's network
+        environment (hostnaming template).
+        """
+        if self.network_environment:
+            return self.network_environment.next_free_hostname
+        logger.warning('Network-environment not provided for {}'.format(self))
+        return ''
+
+    def issue_next_free_hostname(self):
+        """
+        Reserve next (currently) free hostname and return it. You should assign
+        this hostname to asset manually (or do with it whatever you like).
+        """
+        if self.network_environment:
+            return self.network_environment.issue_next_free_hostname()
+        logger.warning('Network-environment not provided for {}'.format(self))
+        return ''
 
     @classmethod
     def get_autocomplete_queryset(cls):

--- a/src/ralph/networks/admin.py
+++ b/src/ralph/networks/admin.py
@@ -26,7 +26,26 @@ from ralph.networks.models.networks import (
 
 @register(NetworkEnvironment)
 class NetworkEnvironmentAdmin(RalphAdmin):
-    pass
+    list_display = ['name', 'data_center']
+    fieldsets = (
+        (_('Basic info'), {
+            'fields': ['name', 'data_center', 'domain', 'remarks'],
+        }),
+        (_('Hostnames'), {
+            'fields': [
+                'hostname_template_counter_length',
+                'hostname_template_prefix',
+                'hostname_template_postfix',
+                'next_free_hostname',
+            ],
+        }),
+        (_('DHCP'), {
+            'fields': ['dhcp_next_server']
+        })
+    )
+    readonly_fields = ['next_free_hostname']
+    search_fields = ['name']
+    list_filter = ['data_center']
 
 
 @register(NetworkKind)

--- a/src/ralph/networks/migrations/0011_auto_20160425_1335.py
+++ b/src/ralph/networks/migrations/0011_auto_20160425_1335.py
@@ -1,0 +1,35 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('networks', '0010_auto_20160420_0928'),
+    ]
+
+    operations = [
+        migrations.RemoveField(
+            model_name='networkenvironment',
+            name='hosts_naming_template',
+        ),
+        migrations.AddField(
+            model_name='networkenvironment',
+            name='hostname_template_counter_length',
+            field=models.PositiveIntegerField(default=4, verbose_name='hostname template counter length'),
+        ),
+        migrations.AddField(
+            model_name='networkenvironment',
+            name='hostname_template_postfix',
+            field=models.CharField(max_length=30, help_text='This value will be used as a postfix when generating new hostname in this network environment. For example, when prefix is "s1", postfix is ".mydc.net" and counter length is 4, following  hostnames will be generated: s10000.mydc.net, s10001.mydc.net, ..., s19999.mydc.net.', verbose_name='hostname template prefix', default=''),
+            preserve_default=False,
+        ),
+        migrations.AddField(
+            model_name='networkenvironment',
+            name='hostname_template_prefix',
+            field=models.CharField(max_length=30, verbose_name='hostname template prefix', default=''),
+            preserve_default=False,
+        ),
+    ]

--- a/src/ralph/networks/tests/factories.py
+++ b/src/ralph/networks/tests/factories.py
@@ -14,6 +14,8 @@ from ralph.networks.models.networks import (
 class NetworkEnvironmentFactory(DjangoModelFactory):
     name = factory.Iterator(['DC1', 'DC2', 'Warehouse'])
     data_center = factory.SubFactory(DataCenterFactory)
+    hostname_template_prefix = 's1'
+    hostname_template_postfix = '.mydc.net'
 
     class Meta:
         model = NetworkEnvironment
@@ -21,6 +23,7 @@ class NetworkEnvironmentFactory(DjangoModelFactory):
 
 
 class NetworkFactory(DjangoModelFactory):
+    name = factory.Sequence(lambda n: 'Network #' + str(n))
     network_environment = factory.SubFactory(NetworkEnvironmentFactory)
 
     class Meta:


### PR DESCRIPTION
- it's possible now to get (or reserve) next (currently) free hostname for `DataCenterAsset`
- it's based on `AssetLastHostname`, used before for `BackOfficeAsset`
- template of hostname is specified for `NetworkEnvironment` (prefix, postfix and counter length)
