### PR TITLE
Fixed bulk-edit fill fields

### DIFF
--- a/src/ralph/static/src/js/fill-fields.js
+++ b/src/ralph/static/src/js/fill-fields.js
@@ -7,7 +7,10 @@
         // Disable autocomplete without cluttering html attributes
         $('input').attr('autocomplete', 'off');
 
-        var $fill_elements = $('.bulk-edit input[type=text]:not(.no-fillable), .bulk-edit select, .bulk-edit textarea, .bulk-edit input[type=number]:not(.no-fillable), .bulk-edit auto-complete:not(.no-fillable)');
+        var $fill_elements = $(
+            'input[type=text]:not(.no-fillable), select, textarea, input[type=number]:not(.no-fillable), auto-complete:not(.no-fillable)',
+            $('.bulk-edit.result-list')
+        );
 
         var toggle_toolbar = function(element) {
             var $parent = element.closest('td');


### PR DESCRIPTION
f724344855ba8b0bae6022522a10a6c3bb828993 added bulk-edit css class to body, which breaks lookup of inputs for fill-fields (ex. search input was included to fill-fields). This fix narrows down possible inputs to be searched only in div with result list.
