### PR TITLE
[WIP] Timezone support

### DIFF
--- a/src/ralph/security/tests/factories.py
+++ b/src/ralph/security/tests/factories.py
@@ -1,7 +1,8 @@
 # -*- coding: utf-8 -*-
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 import factory
+from django.utils import timezone as dj_timezone
 from factory.django import DjangoModelFactory
 
 from ralph.assets.tests.factories import BaseObjectFactory
@@ -13,9 +14,9 @@ class SecurityScanFactory(DjangoModelFactory):
     class Meta:
         model = SecurityScan
 
-    last_scan_date = datetime(2015, 1, 1)
+    last_scan_date = datetime(2015, 1, 1, tzinfo=timezone.utc)
     scan_status = ScanStatus.ok
-    next_scan_date = datetime(2016, 1, 1)
+    next_scan_date = datetime(2016, 1, 1, tzinfo=timezone.utc)
     details_url = 'https://www.example.com/details'
     rescan_url = 'https://www.example.com/rescan'
     base_object = factory.SubFactory(BaseObjectFactory)
@@ -39,7 +40,7 @@ class VulnerabilityFactory(DjangoModelFactory):
 
     name = factory.Sequence(lambda n: 'vulnserability %d' % n)
     patch_deadline = factory.LazyAttribute(
-        lambda o: datetime.now() + timedelta(days=10)
+        lambda o: dj_timezone.now() + timedelta(days=10)
     )
     risk = Risk.low
     external_vulnerability_id = factory.Sequence(lambda n: n)

--- a/src/ralph/settings/base.py
+++ b/src/ralph/settings/base.py
@@ -125,7 +125,7 @@ LOCALE_PATHS = (os.path.join(BASE_DIR, 'locale'), )
 TIME_ZONE = 'Europe/Warsaw'
 USE_I18N = True
 USE_L10N = True
-USE_TZ = False
+USE_TZ = True
 
 STATIC_URL = '/static/'
 STATICFILES_DIRS = (

--- a/src/ralph/settings/base.py
+++ b/src/ralph/settings/base.py
@@ -122,7 +122,7 @@ LOGIN_URL = '/login/'
 
 LANGUAGE_CODE = 'en-us'
 LOCALE_PATHS = (os.path.join(BASE_DIR, 'locale'), )
-TIME_ZONE = 'Europe/Warsaw'
+TIME_ZONE = os.environ.get('TIME_ZONE', 'Europe/Warsaw')
 USE_I18N = True
 USE_L10N = True
 USE_TZ = True

--- a/src/ralph/settings/base.py
+++ b/src/ralph/settings/base.py
@@ -125,7 +125,7 @@ LOCALE_PATHS = (os.path.join(BASE_DIR, 'locale'), )
 TIME_ZONE = os.environ.get('TIME_ZONE', 'Europe/Warsaw')
 USE_I18N = True
 USE_L10N = True
-USE_TZ = True
+USE_TZ = os_env_true('USE_TZ', 'False')
 
 STATIC_URL = '/static/'
 STATICFILES_DIRS = (

--- a/src/ralph/virtual/management/commands/openstack_sync.py
+++ b/src/ralph/virtual/management/commands/openstack_sync.py
@@ -2,7 +2,6 @@
 import logging
 import re
 from collections import defaultdict
-from datetime import datetime
 from functools import lru_cache
 
 import reversion as revisions

--- a/src/ralph/virtual/management/commands/openstack_sync.py
+++ b/src/ralph/virtual/management/commands/openstack_sync.py
@@ -6,6 +6,7 @@ from datetime import datetime
 from functools import lru_cache
 
 import reversion as revisions
+from dateutil import parser
 from django.conf import settings
 from django.core.exceptions import ObjectDoesNotExist
 from django.core.management.base import BaseCommand
@@ -306,8 +307,7 @@ class Command(BaseCommand):
 
         # workaround - created field has auto_now_add attribute
         new_server.save()
-        new_server.created = datetime.strptime(openstack_server['created'],
-                                               self.DATETIME_FORMAT)
+        new_server.created = parser.parse(openstack_server['created'])
         self._save_object(new_server, 'add server %s'
                           % new_server.hostname)
 

--- a/src/ralph/virtual/management/commands/openstack_sync.py
+++ b/src/ralph/virtual/management/commands/openstack_sync.py
@@ -46,7 +46,6 @@ class EmptyListError(Exception):
 class Command(BaseCommand):
     def __init__(self):
         super().__init__()
-        self.DATETIME_FORMAT = '%Y-%m-%dT%H:%M:%SZ'
         self.summary = defaultdict(int)
         self.openstack_projects = {}
         self.openstack_flavors = {}

--- a/src/ralph/virtual/tests/test_openstack_sync.py
+++ b/src/ralph/virtual/tests/test_openstack_sync.py
@@ -3,6 +3,7 @@ from datetime import datetime
 
 from django.core.exceptions import ObjectDoesNotExist
 
+from dateutil import parser
 from ralph.assets.models.components import ComponentModel
 from ralph.assets.tests.factories import DataCenterAssetModelFactory
 from ralph.data_center.models.networks import IPAddress
@@ -85,11 +86,7 @@ class TestOpenstackSync(RalphTestCase):
             # check the creation date only for new hosts
             if host_id.find('_os_') != -1:
                 self.assertEqual(
-                    datetime.strptime(
-                        test_host['created'],
-                        self.cmd.DATETIME_FORMAT
-                    ),
-                    host.created,
+                    parser.parse(test_host['created']), host.created,
                 )
 
     def test_check_add_flavor(self):

--- a/src/ralph/virtual/tests/test_openstack_sync.py
+++ b/src/ralph/virtual/tests/test_openstack_sync.py
@@ -1,9 +1,9 @@
 # -*- coding: utf-8 -*-
 from datetime import datetime
 
+from dateutil import parser
 from django.core.exceptions import ObjectDoesNotExist
 
-from dateutil import parser
 from ralph.assets.models.components import ComponentModel
 from ralph.assets.tests.factories import DataCenterAssetModelFactory
 from ralph.data_center.models.networks import IPAddress


### PR DESCRIPTION
Successor of #2263 (i needed to add one more commit/fix)

We are using the following settings regarding timezone:

TIME_ZONE = 'Europe/Warsaw'
USE_TZ = False
When USE_TZ is False, Django would store timestamps in the timezone of TIME_ZONE, and this is how ralph is storing time. After I realised I should change TIME_ZONE, even if I changed TIME_ZONE to 'Asia/Beijing', the stored time are still in the old timezone (GMT+1). How about it that we change USE_TZ to True, to make sue time is always saved as UTC? This is also recommended by Django.
