### PR TITLE
Fix for travis sqlite segfault

### DIFF
--- a/src/ralph/back_office/tests/test_models.py
+++ b/src/ralph/back_office/tests/test_models.py
@@ -250,6 +250,7 @@ class TestBackOfficeAsset(RalphTestCase):
         self.assertEqual(self.category_2.get_default_depreciation_rate(), 25)
         self.assertEqual(self.category_3.get_default_depreciation_rate(), 30)
 
+
 class TestBackOfficeAssetTransitions(TransitionTestCase, RalphTestCase):
     @classmethod
     def setUpClass(cls):
@@ -371,7 +372,7 @@ class TestBackOfficeAssetTransitions(TransitionTestCase, RalphTestCase):
             _check_instances_for_transition([self.bo_asset], transition)
 
     @patch.object(ExternalService, "run")
-    def test_report_is_generated(self, mock_method):
+    def test_a_report_is_generated(self, mock_method):
         GENERATED_FILE_CONTENT = REPORT_TEMPLATE = b'some-content'
         mock_method.return_value = GENERATED_FILE_CONTENT
         report_template = ReportTemplateFactory(template__data=REPORT_TEMPLATE)


### PR DESCRIPTION
This is rather workaround that full fix.

Resources:
- https://code.djangoproject.com/ticket/24080
- (maybe) https://www.sqlite.org/src/info/7f7f8026eda38

This bug is fully reproductible on travis and in docker environment on sqlite in-memory DB. Cleanup after `test_convert_to_data_center_asset` test crashes on `'ROLLBACK TO SAVEPOINT "s47191573737664_x1351"'` sql command. Brief traceback:

```
* django/test/testcases.py(853)_post_teardown()
* django/test/testcases.py(998)_fixture_teardown()
* django/test/testcases.py(941)_rollback_atomics()
* django/db/transaction.py(245)__exit__()
* django/db/backends/base/base.py(254)savepoint_rollback()
* django/db/backends/base/base.py(214)_savepoint_rollback()
```

In my opinion currently is not possible to comprehensively solve this problem, so I propose a temporary workaround (probably until it'd be fixed in Django and/or sqlite) to rename the test, which will case running them in different order (which magically resolves segfault problem).
