### PR TITLE
force download files from /media/*

### DIFF
--- a/contrib/ralph.conf.nginx
+++ b/contrib/ralph.conf.nginx
@@ -14,6 +14,7 @@ server {
 
     location /media {
        alias /opt/media;
+       add_header Content-disposition "attachment";
     }
 
     location / {


### PR DESCRIPTION
Added following header to nginx config when `/media` url is called:

```
add_header Content-disposition "attachment";
```

Not-forcing downloading of the media file could cause running dangerous script in client browser.
