### PR TITLE
API root sorted alphabetically

### DIFF
--- a/src/ralph/api/routers.py
+++ b/src/ralph/api/routers.py
@@ -15,13 +15,14 @@ class RalphRouter(routers.DefaultRouter):
     Viewsets for which user doesn't have permissions are hidden in root view.
     """
     def get_api_root_view(self):
-        api_root_dict = OrderedDict()
+        api_root_dict = {}
         list_name = self.routes[0].name
         for prefix, viewset, basename in self.registry:
             api_root_dict[prefix] = (
                 list_name.format(basename=basename), viewset
             )
-
+        # present resources in alphabetical order (sort by key, which is url)
+        api_root_dict = OrderedDict(sorted(api_root_dict.items()))
         from rest_framework import views
 
         class APIRoot(views.APIView):


### PR DESCRIPTION
Sort API root entries (url) alphabetically.

Before: 
<img width="695" alt="screen shot 2016-04-27 at 18 17 52" src="https://cloud.githubusercontent.com/assets/107437/14859442/72aa4780-0ca4-11e6-9252-d535b8d155b1.png">

After: 
<img width="713" alt="screen shot 2016-04-27 at 18 17 13" src="https://cloud.githubusercontent.com/assets/107437/14859446/77c8f748-0ca4-11e6-8a82-d4d8c19c0aeb.png">
