### PR TITLE
Configuration path improvements

### DIFF
--- a/src/ralph/admin/filters.py
+++ b/src/ralph/admin/filters.py
@@ -422,9 +422,6 @@ class TreeRelatedAutocompleteFilterWithDescendants(
     filtering by object and all its descendants.
     """
     def _get_descendants(self, request, root_id):
-        """
-        Return descendants of root object.
-        """
         try:
             root = self.field.rel.to.objects.get(pk=root_id)
         except self.field.rel.to.DoesNotExist:
@@ -447,9 +444,11 @@ class TreeRelatedAutocompleteFilterWithDescendants(
             if id_ == self.empty_value:
                 q_param |= Q(**{'{}__isnull'.format(self.field_path): True})
             else:
-                q_param |= Q(**{self.field_path + '__in': self._get_descendants(
-                    request, id_
-                )})
+                q_param |= Q(**{
+                    '{}__in'.format(self.field_path): self._get_descendants(
+                        request, id_
+                    )
+                })
         try:
             queryset = queryset.filter(q_param)
         except ValueError:

--- a/src/ralph/assets/admin.py
+++ b/src/ralph/assets/admin.py
@@ -33,15 +33,15 @@ from ralph.lib.table import Table, TableWithUrl
 
 @register(ConfigurationClass)
 class ConfigurationClassAdmin(RalphAdmin):
-    fields = ['name', 'module', 'path']
+    fields = ['class_name', 'module', 'path']
     readonly_fields = ['path']
     raw_id_fields = ['module']
     search_fields = [
         'path',
     ]
-    list_display = ['name', 'module', 'path', 'objects_count']
+    list_display = ['class_name', 'module', 'path', 'objects_count']
     list_select_related = ['module']
-    list_filter = ['name', 'module']
+    list_filter = ['class_name', 'module']
 
     def get_queryset(self, request):
         qs = super().get_queryset(request)
@@ -56,18 +56,16 @@ class ConfigurationClassAdmin(RalphAdmin):
 
 @register(ConfigurationModule)
 class ConfigurationModuleAdmin(RalphMPTTAdmin):
-    list_display = ['name', 'path']
-    search_fields = [
-        'path',
-    ]
+    list_display = ['name']
+    search_fields = ['name']
     readonly_fields = [
-        'path', 'show_children_modules', 'show_children_classes'
+        'show_children_modules', 'show_children_classes'
     ]
     raw_id_fields = ['parent']
     fieldsets = (
         (_('Basic info'), {
             'fields': [
-                'name', 'parent', 'path', 'support_team'
+                'name', 'parent', 'support_team'
             ]
         }),
         (_('Relations'), {
@@ -82,8 +80,8 @@ class ConfigurationModuleAdmin(RalphMPTTAdmin):
             return '&ndash;'
         return TableWithUrl(
             module.children_modules.all(),
-            ['path'],
-            url_field='path'
+            ['name'],
+            url_field='name'
         ).render()
     show_children_modules.allow_tags = True
     show_children_modules.short_description = _('Children modules')
@@ -93,8 +91,8 @@ class ConfigurationModuleAdmin(RalphMPTTAdmin):
             return '&ndash;'
         return TableWithUrl(
             module.configuration_classes.all(),
-            ['path'],
-            url_field='path'
+            ['name'],
+            url_field='name'
         ).render()
     show_children_classes.allow_tags = True
     show_children_classes.short_description = _('Children classes')

--- a/src/ralph/assets/api/serializers.py
+++ b/src/ralph/assets/api/serializers.py
@@ -209,7 +209,7 @@ class BaseObjectSimpleSerializer(RalphAPISerializer):
 class ConfigurationModuleSimpleSerializer(RalphAPISerializer):
     class Meta:
         model = ConfigurationModule
-        fields = ('id', 'url', 'name', 'path', 'parent', 'support_team')
+        fields = ('id', 'url', 'name', 'parent', 'support_team')
 
 
 class ConfigurationModuleSerializer(ConfigurationModuleSimpleSerializer):

--- a/src/ralph/assets/api/views.py
+++ b/src/ralph/assets/api/views.py
@@ -80,6 +80,7 @@ class BaseObjectViewSet(PolymorphicViewSetMixin, RalphAPIViewSet):
         'name': ['asset__hostname'],
         'sn': ['asset__sn'],
         'barcode': ['asset__barcode'],
+        'price': ['asset__price'],
     }
 
 
@@ -105,4 +106,4 @@ class ConfigurationModuleViewSet(RalphAPIViewSet):
 class ConfigurationClassViewSet(RalphAPIViewSet):
     queryset = models.ConfigurationClass.objects.all()
     serializer_class = serializers.ConfigurationClassSerializer
-    filter_fields = ('module', 'module__path', 'name')
+    filter_fields = ('module', 'module__name', 'class_name', 'path')

--- a/src/ralph/assets/migrations/0017_auto_20160510_1436.py
+++ b/src/ralph/assets/migrations/0017_auto_20160510_1436.py
@@ -1,0 +1,32 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('assets', '0016_auto_20160429_1125'),
+    ]
+
+    operations = [
+        migrations.RemoveField(
+            model_name='configurationmodule',
+            name='path',
+        ),
+        migrations.RenameField(
+            model_name='configurationclass',
+            old_name='name',
+            new_name='class_name',
+        ),
+        migrations.AlterField(
+            model_name='configurationclass',
+            name='path',
+            field=models.TextField(blank=True, verbose_name='path', editable=False, help_text='path is constructed from name of module and name of class', default=''),
+        ),
+        migrations.AlterUniqueTogether(
+            name='configurationclass',
+            unique_together=set([('module', 'class_name')]),
+        ),
+    ]

--- a/src/ralph/assets/tests/factories.py
+++ b/src/ralph/assets/tests/factories.py
@@ -193,9 +193,9 @@ class ConfigurationModuleFactory(DjangoModelFactory):
 
 
 class ConfigurationClassFactory(DjangoModelFactory):
-    name = factory.Iterator(['www', 'db', 'worker', 'cache'])
+    class_name = factory.Iterator(['www', 'db', 'worker', 'cache'])
     module = factory.SubFactory(ConfigurationModuleFactory)
 
     class Meta:
         model = ConfigurationClass
-        django_get_or_create = ['name']
+        django_get_or_create = ['class_name']

--- a/src/ralph/assets/tests/test_api.py
+++ b/src/ralph/assets/tests/test_api.py
@@ -484,8 +484,12 @@ class BaseObjectAPITests(RalphAPITestCase):
         url = reverse('baseobject-list')
         response = self.client.get(url, format='json')
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(response.data['count'], 2)
-        barcodes = [item['barcode'] for item in response.data['results']]
+        self.assertEqual(response.data['count'], BaseObject.objects.count())
+        barcodes = [
+            item['barcode']
+            for item in response.data['results']
+            if 'barcode' in item
+        ]
         self.assertCountEqual(barcodes, set(['12345', '12543']))
 
     def test_get_asset_model_details(self):
@@ -524,11 +528,11 @@ class BaseObjectAPITests(RalphAPITestCase):
     def test_lte_polymorphic(self):
         url = '{}?{}'.format(
             reverse('baseobject-list'), urlencode(
-                {'price__lte': '1'}
+                {'price__lte': '20'}
             )
         )
         response = self.client.get(url, format='json')
-        self.assertEqual(len(response.data['results']), 2)
+        self.assertEqual(len(response.data['results']), 1)
 
     def test_is_lookup_used(self):
         url = '{}?{}'.format(
@@ -591,16 +595,12 @@ class ConfigurationModuleAPITests(RalphAPITestCase):
         self.assertEqual(
             response.data['results'][0]['name'], self.conf_module_1.name
         )
-        self.assertEqual(
-            response.data['results'][0]['path'], self.conf_module_1.path
-        )
 
     def test_get_configuration_module_details(self):
         url = reverse('configurationmodule-detail', args=(self.conf_module_1.id,))
         response = self.client.get(url, format='json')
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data['name'], self.conf_module_1.name)
-        self.assertEqual(response.data['path'], self.conf_module_1.path)
         self.assertTrue(
             response.data['children_modules'][0].endswith(
                 reverse('configurationmodule-detail', args=(self.conf_module_2.id,))
@@ -639,7 +639,6 @@ class ConfigurationModuleAPITests(RalphAPITestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.conf_module_2.refresh_from_db()
         self.assertEqual(self.conf_module_2.name, 'test_2')
-        self.assertTrue(self.conf_module_2.path.endswith('test_2'))
 
 
 class ConfigurationClassAPITests(RalphAPITestCase):
@@ -657,7 +656,8 @@ class ConfigurationClassAPITests(RalphAPITestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data['count'], 1)
         self.assertEqual(
-            response.data['results'][0]['name'], self.conf_class_1.name
+            response.data['results'][0]['class_name'],
+            self.conf_class_1.class_name
         )
         self.assertEqual(
             response.data['results'][0]['module']['id'],
@@ -671,7 +671,10 @@ class ConfigurationClassAPITests(RalphAPITestCase):
         url = reverse('configurationclass-detail', args=(self.conf_class_1.id,))
         response = self.client.get(url, format='json')
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(response.data['name'], self.conf_class_1.name)
+        self.assertEqual(
+            response.data['class_name'],
+            self.conf_class_1.class_name
+        )
         self.assertEqual(response.data['path'], self.conf_class_1.path)
         self.assertTrue(
             response.data['module']['url'].endswith(
@@ -682,22 +685,22 @@ class ConfigurationClassAPITests(RalphAPITestCase):
     def test_create_configuration_class(self):
         url = reverse('configurationclass-list')
         data = {
-            'name': 'test_1',
+            'class_name': 'test_1',
             'module': self.conf_module_2.pk,
         }
         response = self.client.post(url, data, format='json')
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
         self.assertEqual(ConfigurationClass.objects.count(), 2)
         conf_class = ConfigurationClass.objects.get(pk=response.data['id'])
-        self.assertEqual(conf_class.name, 'test_1')
+        self.assertEqual(conf_class.class_name, 'test_1')
         self.assertEqual(conf_class.module, self.conf_module_2)
 
     def test_patch_configuration_class(self):
         url = reverse('configurationclass-detail', args=(self.conf_class_1.id,))
         data = {
-            'name': 'test_2'
+            'class_name': 'test_2'
         }
         response = self.client.patch(url, data, format='json')
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.conf_class_1.refresh_from_db()
-        self.assertEqual(self.conf_class_1.name, 'test_2')
+        self.assertEqual(self.conf_class_1.class_name, 'test_2')

--- a/src/ralph/assets/tests/test_api.py
+++ b/src/ralph/assets/tests/test_api.py
@@ -476,7 +476,7 @@ class BaseObjectAPITests(RalphAPITestCase):
         )
         self.bo_asset.tags.add('tag1')
         self.dc_asset = DataCenterAssetFactory(
-            barcode='12543', price='10.00'
+            barcode='12543', price='9.00'
         )
         self.dc_asset.tags.add('tag2')
 
@@ -528,7 +528,7 @@ class BaseObjectAPITests(RalphAPITestCase):
     def test_lte_polymorphic(self):
         url = '{}?{}'.format(
             reverse('baseobject-list'), urlencode(
-                {'price__lte': '20'}
+                {'price__lte': '9'}
             )
         )
         response = self.client.get(url, format='json')

--- a/src/ralph/assets/tests/test_models.py
+++ b/src/ralph/assets/tests/test_models.py
@@ -19,28 +19,17 @@ class ConfigurationTest(RalphTestCase):
             module=self.conf_module_3
         )
 
-    def test_path_creation(self):
-        self.assertEqual(
-            self.conf_module_2.path,
-            self.conf_module_1.path + '/' + self.conf_module_2.name
+    def test_update_module_children_path(self):
+        self.conf_module_3.name = 'updated_name'
+        self.conf_module_3.save()
+
+        self.conf_class_1.refresh_from_db()
+        self.assertTrue(
+            self.conf_class_1.path.startswith('updated_name'),
         )
 
-    def test_update_module_children_path(self):
-        self.conf_module_1.name = 'updated_name'
-        self.conf_module_1.save()
-
-        for conf in [
-            self.conf_module_1, self.conf_module_2, self.conf_module_3,
-            self.conf_class_1
-        ]:
-            conf.refresh_from_db()
-            self.assertTrue(
-                conf.path.startswith('updated_name'),
-                msg='{} has not-updated path'.format(conf)
-            )
-
     def test_update_class_path_update(self):
-        self.conf_class_1.name = 'updated_name'
+        self.conf_class_1.class_name = 'updated_name'
         self.conf_class_1.save()
         self.conf_class_1.refresh_from_db()
         self.assertTrue(self.conf_class_1.path.endswith('updated_name'))

--- a/src/ralph/data_center/admin.py
+++ b/src/ralph/data_center/admin.py
@@ -4,7 +4,12 @@ from django.core.urlresolvers import reverse
 from django.utils.translation import ugettext_lazy as _
 
 from ralph.admin import RalphAdmin, RalphTabularInline, register
-from ralph.admin.filters import IPFilter, LiquidatedStatusFilter, TagsListFilter
+from ralph.admin.filters import (
+    IPFilter,
+    LiquidatedStatusFilter,
+    TagsListFilter,
+    TreeRelatedAutocompleteFilterWithDescendants
+)
 from ralph.admin.helpers import generate_html_link
 from ralph.admin.m2m import RalphTabularM2MInline
 from ralph.admin.mixins import BulkEditChangeListMixin
@@ -213,7 +218,8 @@ class DataCenterAssetAdmin(
     search_fields = ['barcode', 'sn', 'hostname', 'invoice_no', 'order_no']
     list_filter = [
         'status', 'barcode', 'sn', 'hostname', 'invoice_no', 'invoice_date',
-        'order_no', 'model__name', 'service_env', 'configuration_path',
+        'order_no', 'model__name', 'service_env',
+        ('configuration_path__module', TreeRelatedAutocompleteFilterWithDescendants),  # noqa
         'depreciation_end_date', 'force_depreciation', 'remarks', 'budget_info',
         'rack', 'rack__server_room', 'rack__server_room__data_center',
         'position', 'property_of', LiquidatedStatusFilter, IPFilter,

--- a/src/ralph/data_center/api/views.py
+++ b/src/ralph/data_center/api/views.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+import django_filters
 
 from ralph.api import RalphAPIViewSet
 from ralph.assets.api.views import BaseObjectViewSet
@@ -29,6 +30,23 @@ from ralph.data_center.models import (
 )
 
 
+class DataCenterAssetFilterSet(django_filters.FilterSet):
+    configuration_path = django_filters.CharFilter(
+        name='configuration_path__path'
+    )
+
+    class Meta:
+        model = DataCenterAsset
+        fields = [
+            'service_env__service__uid',
+            'service_env__service__name',
+            'service_env__service__id',
+            'configuration_path__path',
+            'configuration_path__module__name',
+            'configuration_path',
+        ]
+
+
 class DataCenterAssetViewSet(RalphAPIViewSet):
     queryset = DataCenterAsset.objects.all()
     serializer_class = DataCenterAssetSerializer
@@ -43,11 +61,7 @@ class DataCenterAssetViewSet(RalphAPIViewSet):
         'connections',
         'tags',
     ]
-    filter_fields = [
-        'service_env__service__uid',
-        'service_env__service__name',
-        'service_env__service__id'
-    ]
+    filter_class = DataCenterAssetFilterSet
 
 
 class AccessoryViewSet(RalphAPIViewSet):

--- a/src/ralph/data_center/tests/factories.py
+++ b/src/ralph/data_center/tests/factories.py
@@ -8,6 +8,7 @@ from ralph.assets.models.choices import AssetSource
 from ralph.assets.tests.factories import (
     AssetHolderFactory,
     BudgetInfoFactory,
+    ConfigurationClassFactory,
     DataCenterAssetModelFactory,
     ServiceEnvironmentFactory
 )
@@ -107,6 +108,8 @@ class DataCenterAssetFactory(DjangoModelFactory):
         AssetSource.shipment.id, AssetSource.salvaged.id
     ])
     price = FuzzyDecimal(10, 300)
+    service_env = factory.SubFactory(ServiceEnvironmentFactory)
+    configuration_path = factory.SubFactory(ConfigurationClassFactory)
 
     class Meta:
         model = DataCenterAsset

--- a/src/ralph/data_center/tests/test_api.py
+++ b/src/ralph/data_center/tests/test_api.py
@@ -107,6 +107,16 @@ class DataCenterAssetAPITests(RalphAPITestCase):
         self.assertTrue(self.dc_asset.force_depreciation)
         self.assertEqual(self.dc_asset.tags.count(), 1)
 
+    def test_filter_by_configuration_path(self):
+        url = reverse('datacenterasset-list') + '?configuration_path={}'.format(
+            self.dc_asset.configuration_path.path,
+        )
+        response = self.client.get(url, format='json')
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(
+            response.data['count'], 1
+        )
+
 
 class RackAPITests(RalphAPITestCase):
     def setUp(self):

--- a/src/ralph/reports/tests.py
+++ b/src/ralph/reports/tests.py
@@ -181,8 +181,9 @@ class TestReportAssetAndLicence(RalphTestCase):
             ],
             [
                 str(self.dc_1.id), '', self.dc_1.barcode, self.dc_1.sn,
-                'Keyboard', 'M1', '1', 'None', str(self.dc_1.invoice_date),
-                str(self.dc_1.invoice_no), self.dc_1.hostname
+                'Keyboard', 'M1', '1', self.dc_1.service_env.service.name,
+                str(self.dc_1.invoice_date), str(self.dc_1.invoice_no),
+                self.dc_1.hostname
             ]
         ]
         self.assertEqual(report_result, result)


### PR DESCRIPTION
- removed confusing field "path" from configuration module
- configuration class "**str**" is now only last module + class name
- renamed "name" field in ConfigurationClass to "class_name"
- added filtering by configuration module and all its descendants
- added filtering by configuration_path in API
