### PR TITLE
Filter IPAddress by address in API

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -3,7 +3,7 @@
 Django==1.8.12
 dj.choices==0.10.0
 django-extensions==1.5.9
-django-filter==0.11.0
+django-filter==0.13.0
 django-import-export==0.4.2
 django-mptt==0.7.4
 django-reversion==1.8.6

--- a/src/ralph/networks/api.py
+++ b/src/ralph/networks/api.py
@@ -1,11 +1,44 @@
 # -*- coding: utf-8 -*-
 from ralph.api import RalphAPISerializer, RalphAPIViewSet, router
 from ralph.assets.api.serializers import EthernetSerializer
-from ralph.networks.models import IPAddress
+from ralph.networks.models import (
+    IPAddress,
+    Network,
+    NetworkEnvironment,
+    NetworkKind
+)
+
+
+class NetworkEnvironmentSerializer(RalphAPISerializer):
+    class Meta:
+        model = NetworkEnvironment
+        depth = 1
+
+
+class NetworkKindSerializer(RalphAPISerializer):
+    class Meta:
+        model = NetworkKind
+        depth = 1
+
+
+class NetworkSimpleSerializer(RalphAPISerializer):
+    class Meta:
+        model = Network
+        fields = (
+            'id', 'url', 'name', 'remarks', 'vlan', 'dhcp_broadcast', 'parent',
+            'network_environment'
+        )
+
+
+class NetworkSerializer(RalphAPISerializer):
+    class Meta:
+        model = Network
+        depth = 1
 
 
 class IPAddressSerializer(RalphAPISerializer):
     ethernet = EthernetSerializer()
+    network = NetworkSimpleSerializer()
 
     class Meta:
         model = IPAddress
@@ -23,5 +56,25 @@ class IPAddressViewSet(RalphAPIViewSet):
         'network',
     ]
 
+
+class NetworkViewSet(RalphAPIViewSet):
+    queryset = Network.objects.all()
+    serializer_class = NetworkSerializer
+    select_related = ['network_environment', 'kind']
+    prefetch_related = ['racks', 'dns_servers']
+
+
+class NetworkEnvironmentViewSet(RalphAPIViewSet):
+    queryset = NetworkEnvironment.objects.all()
+    serializer_class = NetworkEnvironmentSerializer
+
+
+class NetworkKindViewSet(RalphAPIViewSet):
+    queryset = NetworkKind.objects.all()
+    serializer_class = NetworkKindSerializer
+
 router.register(r'ipaddresses', IPAddressViewSet)
+router.register(r'networks', NetworkViewSet)
+router.register(r'network-environments', NetworkEnvironmentViewSet)
+router.register(r'network-kinds', NetworkKindViewSet)
 urlpatterns = []


### PR DESCRIPTION
- bumped django-filter to 0.13.0 (0.11.0 doesn't support GenericIPAddressField)
- serializers & viewsets for Network, NetworkEnvironment, NetworkKind
