### PR TITLE
Additional base object filters in API

### DIFF
--- a/src/ralph/assets/api/views.py
+++ b/src/ralph/assets/api/views.py
@@ -81,6 +81,8 @@ class BaseObjectViewSet(PolymorphicViewSetMixin, RalphAPIViewSet):
         'sn': ['asset__sn'],
         'barcode': ['asset__barcode'],
         'price': ['asset__price'],
+        'ip': ['ethernet__ipaddress__address'],
+        'service': ['service_env__service__uid', 'service_env__service__name'],
     }
 
 

--- a/src/ralph/assets/api/views.py
+++ b/src/ralph/assets/api/views.py
@@ -94,7 +94,7 @@ class AssetHolderViewSet(RalphAPIViewSet):
 class EthernetViewSet(RalphAPIViewSet):
     queryset = models.Ethernet.objects.all()
     serializer_class = serializers.EthernetSerializer
-
+    filter_fields = ['base_object']
     prefetch_related = ['model', 'base_object', 'base_object__tags']
 
 

--- a/src/ralph/assets/tests/factories.py
+++ b/src/ralph/assets/tests/factories.py
@@ -141,6 +141,7 @@ class EnvironmentFactory(DjangoModelFactory):
 class ServiceFactory(DjangoModelFactory):
 
     name = factory.Iterator(['Backup systems', 'load_balancing', 'databases'])
+    uid = factory.Sequence(lambda n: 'sc-{}'.format(n))
 
     class Meta:
         model = Service

--- a/src/ralph/networks/tests/factories.py
+++ b/src/ralph/networks/tests/factories.py
@@ -2,6 +2,7 @@ import factory
 from factory.django import DjangoModelFactory
 from factory.fuzzy import FuzzyText
 
+from ralph.assets.tests.factories import EthernetFactory
 from ralph.data_center.tests.factories import DataCenterFactory
 from ralph.networks.models.networks import (
     IPAddress,
@@ -34,6 +35,7 @@ class IPAddressFactory(DjangoModelFactory):
     hostname = FuzzyText(
         prefix='ralph.', suffix='.allegro.pl', length=40
     )
+    ethernet = factory.SubFactory(EthernetFactory)
 
     class Meta:
         model = IPAddress

--- a/src/ralph/networks/tests/factories.py
+++ b/src/ralph/networks/tests/factories.py
@@ -2,7 +2,6 @@ import factory
 from factory.django import DjangoModelFactory
 from factory.fuzzy import FuzzyText
 
-from ralph.assets.tests.factories import BaseObjectFactory
 from ralph.data_center.tests.factories import DataCenterFactory
 from ralph.networks.models.networks import (
     IPAddress,
@@ -35,7 +34,6 @@ class IPAddressFactory(DjangoModelFactory):
     hostname = FuzzyText(
         prefix='ralph.', suffix='.allegro.pl', length=40
     )
-    base_object = factory.SubFactory(BaseObjectFactory)
 
     class Meta:
         model = IPAddress


### PR DESCRIPTION
- Filter by ip address using `ip` param
- Filter by service name or uid using `service` param
