### PR TITLE
Improved (and fixed) filters for DataCenterAsset in API

### DIFF
--- a/src/ralph/api/filters.py
+++ b/src/ralph/api/filters.py
@@ -6,7 +6,7 @@ from functools import reduce
 from django.contrib.contenttypes.models import ContentType
 from django.core.exceptions import FieldDoesNotExist
 from django.db import models
-from rest_framework.filters import BaseFilterBackend
+from rest_framework.filters import BaseFilterBackend, DjangoFilterBackend
 
 from ralph.admin.helpers import get_field_by_relation_path
 from ralph.admin.sites import ralph_site
@@ -14,6 +14,15 @@ from ralph.data_importer.models import ImportedObjects
 from ralph.lib.mixins.models import TaggableMixin
 
 logger = logging.getLogger(__name__)
+
+
+class AdditionalDjangoFilterBackend(DjangoFilterBackend):
+    """
+    Allows to spcify additional FilterSet for viewset (besides standard one,
+    which uses fields from `filter_fields` property.
+    """
+    def get_filter_class(self, view, queryset=None):
+        return getattr(view, 'additional_filter_class', None)
 
 
 class TagsFilterBackend(BaseFilterBackend):

--- a/src/ralph/api/viewsets.py
+++ b/src/ralph/api/viewsets.py
@@ -6,6 +6,7 @@ from rest_framework import filters, permissions, relations, viewsets
 
 from ralph.admin.sites import ralph_site
 from ralph.api.filters import (
+    AdditionalDjangoFilterBackend,
     ExtendedFiltersBackend,
     ImportedIdFilterBackend,
     LookupFilterBackend,
@@ -61,7 +62,7 @@ class RalphAPIViewSetMixin(QuerysetRelatedMixin, AdminSearchFieldsMixin):
         PermissionsForObjectFilter, filters.OrderingFilter,
         ExtendedFiltersBackend, LookupFilterBackend,
         PolymorphicDescendantsFilterBackend, TagsFilterBackend,
-        ImportedIdFilterBackend,
+        ImportedIdFilterBackend, AdditionalDjangoFilterBackend
     ]
     permission_classes = [RalphPermission]
     save_serializer_class = None
@@ -128,6 +129,10 @@ class RalphAPIViewSetMetaclass(type):
         queryset = getattr(new_cls, 'queryset', None)
         if queryset is not None:  # don't evaluate queryset
             _viewsets_registry[queryset.model] = new_cls
+        # filter_class should not be overwrited for RalphViewSet
+        # use dedicated filter backend if you have specific needs
+        if 'filter_class' in attrs:
+            raise TypeError('Cannot define filter_class for RalphAPIViewSet')
         return new_cls
 
 

--- a/src/ralph/assets/api/filters.py
+++ b/src/ralph/assets/api/filters.py
@@ -1,0 +1,16 @@
+import django_filters
+
+
+class NetworkableObjectFilters(django_filters.FilterSet):
+    """
+    Base filter for all networkable objects for example with IP address.
+    """
+    configuration_path = django_filters.CharFilter(
+        name='configuration_path__path'
+    )
+    ip = django_filters.CharFilter(name='ethernet__ipaddress__address')
+
+    class Meta:
+        fields = [
+            'configuration_path__module__name',
+        ]

--- a/src/ralph/assets/api/views.py
+++ b/src/ralph/assets/api/views.py
@@ -77,7 +77,7 @@ class BaseObjectViewSet(PolymorphicViewSetMixin, RalphAPIViewSet):
         )),
     ]
     filter_fields = [
-        'id', 'service_env', 'service_env__service__uid', 'content_type'
+        'id', 'service_env', 'service_env', 'content_type'
     ]
     extended_filter_fields = {
         'name': ['asset__hostname'],
@@ -112,3 +112,12 @@ class ConfigurationClassViewSet(RalphAPIViewSet):
     queryset = models.ConfigurationClass.objects.all()
     serializer_class = serializers.ConfigurationClassSerializer
     filter_fields = ('module', 'module__name', 'class_name', 'path')
+
+
+class BaseObjectViewSetMixin(object):
+    """
+    Base class for viewsets that inherits from BaseObject
+    """
+    extended_filter_fields = {
+        'service': ['service_env__service__uid', 'service_env__service__name']
+    }

--- a/src/ralph/data_center/api/views.py
+++ b/src/ralph/data_center/api/views.py
@@ -1,8 +1,9 @@
 # -*- coding: utf-8 -*-
-import django_filters
+
 
 from ralph.api import RalphAPIViewSet
-from ralph.assets.api.views import BaseObjectViewSet
+from ralph.assets.api.filters import NetworkableObjectFilters
+from ralph.assets.api.views import BaseObjectViewSet, BaseObjectViewSetMixin
 from ralph.data_center.admin import DataCenterAssetAdmin
 from ralph.data_center.api.serializers import (
     AccessorySerializer,
@@ -32,24 +33,12 @@ from ralph.data_center.models import (
 )
 
 
-class DataCenterAssetFilterSet(django_filters.FilterSet):
-    configuration_path = django_filters.CharFilter(
-        name='configuration_path__path'
-    )
-
-    class Meta:
+class DataCenterAssetFilterSet(NetworkableObjectFilters):
+    class Meta(NetworkableObjectFilters.Meta):
         model = DataCenterAsset
-        fields = [
-            'service_env__service__uid',
-            'service_env__service__name',
-            'service_env__service__id',
-            'configuration_path__path',
-            'configuration_path__module__name',
-            'configuration_path',
-        ]
 
 
-class DataCenterAssetViewSet(RalphAPIViewSet):
+class DataCenterAssetViewSet(BaseObjectViewSetMixin, RalphAPIViewSet):
     queryset = DataCenterAsset.objects.all()
     serializer_class = DataCenterAssetSerializer
     select_related = DataCenterAssetAdmin.list_select_related + [
@@ -64,7 +53,7 @@ class DataCenterAssetViewSet(RalphAPIViewSet):
         'connections',
         'tags',
     ]
-    filter_class = DataCenterAssetFilterSet
+    additional_filter_class = DataCenterAssetFilterSet
 
 
 class AccessoryViewSet(RalphAPIViewSet):


### PR DESCRIPTION
- fixed DataCenterAsset filters from admin (ex. by hostname)
- improved filtering by configuration_path, ip and service
