### PR TITLE
Fixed admin permissions for non-model fields

### DIFF
--- a/src/ralph/lib/permissions/models.py
+++ b/src/ralph/lib/permissions/models.py
@@ -241,7 +241,7 @@ class PermByFieldMixin(models.Model, metaclass=PermissionsBase):
         :return: List of field names
         :rtype: list
         """
-        result = []
+        result = set()
         blacklist = cls._permissions.blacklist
 
         for field in (cls._meta.fields + cls._meta.many_to_many):
@@ -249,9 +249,12 @@ class PermByFieldMixin(models.Model, metaclass=PermissionsBase):
                 field.name not in blacklist and
                 cls.has_access_to_field(field.name, user, action)
             ):
-                result.append(field.name)
-
-        return set(result)
+                result.add(field.name)
+        # If the user does not have rights to view,
+        # but has the right to change he can view the field
+        if action == 'view':
+            result |= cls.allowed_fields(user, 'change')
+        return result
 
     class Meta:
         abstract = True

--- a/src/ralph/lib/permissions/tests/admin.py
+++ b/src/ralph/lib/permissions/tests/admin.py
@@ -8,8 +8,21 @@ from ralph.lib.permissions.tests.models import Article
 class ArticleAdmin(PermissionAdminMixin, admin.ModelAdmin):
     list_display = [
         'author', 'title', 'content', 'custom_field_1', 'sample_admin_field',
-        'sample_admin_field_with_permissions', '_sample_property'
+        'sample_admin_field_with_permissions', 'sample_non_model_field',
+        'sample_non_model_field_with_permissions', 'sample_property',
+        'sample_property_with_permissions'
     ]
+    fieldsets = (
+        ('all', {
+            'fields': [
+                'author', 'title', 'content', 'custom_field_1',
+                'sample_admin_field', 'sample_admin_field_with_permissions',
+                'sample_non_model_field',
+                'sample_non_model_field_with_permissions', 'sample_property',
+                'sample_property_with_permissions'
+            ]
+        }),
+    )
 
     def sample_admin_field(self, obj):
         return 'abc'

--- a/src/ralph/lib/permissions/tests/models.py
+++ b/src/ralph/lib/permissions/tests/models.py
@@ -37,13 +37,20 @@ class Article(PermByFieldMixin, PermissionsForObjectMixin, models.Model):
     def __str__(self):
         return self.title
 
-    def _sample_property(self):
+    def sample_non_model_field(self):
         return '123'
-    _sample_property._permission_field = 'content'
+
+    def sample_non_model_field_with_permissions(self):
+        return '321'
+    sample_non_model_field_with_permissions._permission_field = 'content'
 
     @property
     def sample_property(self):
-        return self._sample_property
+        return 'xyz'
+
+    @property
+    def sample_property_with_permissions(self):
+        return 'zyx'
 
 
 class LongArticle(Article):

--- a/src/ralph/lib/permissions/tests/test_admin.py
+++ b/src/ralph/lib/permissions/tests/test_admin.py
@@ -12,11 +12,18 @@ class PermissionPerFieldAdminMixinTestCase(PermissionsTestMixin, TestCase):
         self._create_users_and_articles()
         self.admin = site._registry[Article]
         self.request_factory = RequestFactory()
+        self._all_fields = self.admin.fieldsets[0][1]['fields'][:]
+        self.maxDiff = None
 
     def _get_list_display(self, user):
         request = self.request_factory.get('/')
         request.user = user
         return self.admin.get_list_display(request)
+
+    def _get_fieldsets(self, user, obj=None):
+        request = self.request_factory.get('/')
+        request.user = user
+        return self.admin.get_fieldsets(request, obj)
 
     def test_admin_list_display_for_superuser(self):
         list_display = self._get_list_display(self.superuser)
@@ -36,7 +43,7 @@ class PermissionPerFieldAdminMixinTestCase(PermissionsTestMixin, TestCase):
         user_list_display.remove('title')
         self.assertEqual(list_display, user_list_display)
 
-    def test_admin_list_display_without_model_property(self):
+    def test_admin_list_display_without_model_callable(self):
         self.user2.user_permissions.remove(Permission.objects.get(
             content_type=ContentType.objects.get_for_model(Article),
             codename='view_article_content_field'
@@ -47,16 +54,74 @@ class PermissionPerFieldAdminMixinTestCase(PermissionsTestMixin, TestCase):
         ))
         list_display = self._get_list_display(self.user2)
         user_list_display = self.admin.list_display[:]
-        # permission to sample_property is set based on content field
+        # permission to sample_non_model_field_with_permissions is set based
+        # on content field
         user_list_display.remove('content')
-        user_list_display.remove('_sample_property')
+        user_list_display.remove('sample_non_model_field_with_permissions')
         self.assertEqual(list_display, user_list_display)
 
     def test_admin_list_display_without_admin_field(self):
-        list_display = self._get_list_display(self.user1)
+        self.user2.user_permissions.remove(Permission.objects.get(
+            content_type=ContentType.objects.get_for_model(Article),
+            codename='view_article_custom_field_1_field'
+        ))
+        self.user2.user_permissions.remove(Permission.objects.get(
+            content_type=ContentType.objects.get_for_model(Article),
+            codename='change_article_custom_field_1_field'
+        ))
+        list_display = self._get_list_display(self.user2)
         user_list_display = self.admin.list_display[:]
         # permission to sample_admin_field_with_permissions is set based
         # on custom_field_1 field
         user_list_display.remove('custom_field_1')
         user_list_display.remove('sample_admin_field_with_permissions')
         self.assertEqual(list_display, user_list_display)
+
+    def test_admin_get_fieldsets_for_superuser(self):
+        fieldsets = self._get_fieldsets(self.superuser)[0][1]['fields']
+        self.assertEqual(fieldsets, self._all_fields)
+
+    def test_admin_get_fieldsets_without_model_field(self):
+        self.user2.user_permissions.remove(Permission.objects.get(
+            content_type=ContentType.objects.get_for_model(Article),
+            codename='view_article_title_field'
+        ))
+        self.user2.user_permissions.remove(Permission.objects.get(
+            content_type=ContentType.objects.get_for_model(Article),
+            codename='change_article_title_field'
+        ))
+        fieldsets = self._get_fieldsets(self.user2)[0][1]['fields']
+        self._all_fields.remove('title')
+        self.assertEqual(fieldsets, self._all_fields)
+
+    def test_admin_get_fieldsets_without_model_callable(self):
+        self.user2.user_permissions.remove(Permission.objects.get(
+            content_type=ContentType.objects.get_for_model(Article),
+            codename='view_article_content_field'
+        ))
+        self.user2.user_permissions.remove(Permission.objects.get(
+            content_type=ContentType.objects.get_for_model(Article),
+            codename='change_article_content_field'
+        ))
+        fieldsets = self._get_fieldsets(self.user2)[0][1]['fields']
+        # permission to sample_non_model_field_with_permissions is set based
+        # on content field
+        self._all_fields.remove('content')
+        self._all_fields.remove('sample_non_model_field_with_permissions')
+        self.assertEqual(fieldsets, self._all_fields)
+
+    def test_admin_get_fieldsets_without_admin_field(self):
+        self.user2.user_permissions.remove(Permission.objects.get(
+            content_type=ContentType.objects.get_for_model(Article),
+            codename='view_article_custom_field_1_field'
+        ))
+        self.user2.user_permissions.remove(Permission.objects.get(
+            content_type=ContentType.objects.get_for_model(Article),
+            codename='change_article_custom_field_1_field'
+        ))
+        fieldsets = self._get_fieldsets(self.user2)[0][1]['fields']
+        # permission to sample_admin_field_with_permissions is set based
+        # on custom_field_1 field
+        self._all_fields.remove('custom_field_1')
+        self._all_fields.remove('sample_admin_field_with_permissions')
+        self.assertEqual(fieldsets, self._all_fields)

--- a/src/ralph/virtual/admin.py
+++ b/src/ralph/virtual/admin.py
@@ -166,6 +166,7 @@ class CloudHostAdmin(RalphAdmin):
     get_cloudproject.short_description = _('Cloud Project')
     get_cloudproject.admin_order_field = 'parent'
     get_cloudproject.allow_tags = True
+    get_cloudproject._permission_field = 'parent'
 
     def get_cpu(self, obj):
         return obj.cloudflavor.cores


### PR DESCRIPTION
Before, only superuser users could access non-model fields (ex. property, admin method, model method) in admin change view. This commit fixes it - by default every such field is accessible by user who has view/change access to the model (this field is read-only either way). Additional permission could be set on this field using `_permission_field` property if necessary.
