### PR TITLE
Network form & API fixes and improvements

### DIFF
--- a/src/ralph/admin/templates/admin/edit_inline/tabular.html
+++ b/src/ralph/admin/templates/admin/edit_inline/tabular.html
@@ -55,7 +55,7 @@
                     {% endfor %}
                   {% endfor %}
                     <td class="delete">
-                      {% if inline_admin_formset.formset.can_delete %}
+                      {% if inline_admin_formset.formset.can_delete and not inline_admin_form.forbid_delete %}
                         {% if inline_admin_form.original %}
                           {{ inline_admin_form.deletion_field.field }}
                         {% endif %}

--- a/src/ralph/admin/templates/admin/edit_inline/tabular.html
+++ b/src/ralph/admin/templates/admin/edit_inline/tabular.html
@@ -55,7 +55,7 @@
                     {% endfor %}
                   {% endfor %}
                     <td class="delete">
-                      {% if inline_admin_formset.formset.can_delete and not inline_admin_form.forbid_delete %}
+                      {% if inline_admin_formset.formset.can_delete %}
                         {% if inline_admin_form.original %}
                           {{ inline_admin_form.deletion_field.field }}
                         {% endif %}

--- a/src/ralph/assets/migrations/0019_auto_20160525_1113.py
+++ b/src/ralph/assets/migrations/0019_auto_20160525_1113.py
@@ -1,0 +1,27 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+import re
+import ralph.lib.mixins.fields
+import django.core.validators
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('assets', '0018_auto_20160512_0842'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='asset',
+            name='hostname',
+            field=ralph.lib.mixins.fields.NullableCharField(verbose_name='hostname', default=None, blank=True, max_length=255, null=True),
+        ),
+        migrations.AlterField(
+            model_name='ethernet',
+            name='mac',
+            field=ralph.lib.mixins.fields.NullableCharField(unique=True, max_length=24, verbose_name='MAC address', blank=True, null=True, validators=[django.core.validators.RegexValidator(message="'%(value)s' is not a valid MAC address.", regex=re.compile('^\\s*([0-9a-fA-F]{2}[:-]){5}[0-9a-fA-F]{2}\\s*$', 32))]),
+        ),
+    ]

--- a/src/ralph/assets/models/assets.py
+++ b/src/ralph/assets/models/assets.py
@@ -282,12 +282,14 @@ class BudgetInfo(NamedMixin, TimeStampMixin, models.Model):
 
 class Asset(AdminAbsoluteUrlMixin, BaseObject):
     model = models.ForeignKey(AssetModel, related_name='assets')
-    hostname = models.CharField(
+    # TODO: unify hostname for DCA, VirtualServer, Cluster and CloudHost
+    # (use another model?)
+    hostname = NullableCharField(
         blank=True,
         default=None,
         max_length=255,
         null=True,
-        verbose_name=_('hostname'),
+        verbose_name=_('hostname'),  # TODO: unique
     )
     sn = NullableCharField(
         blank=True,

--- a/src/ralph/assets/models/components.py
+++ b/src/ralph/assets/models/components.py
@@ -110,6 +110,9 @@ class Ethernet(Component):
         return '{} ({})'.format(self.label, self.mac)
 
     def _validate_expose_in_dhcp_and_mac(self):
+        """
+        Check if mac is not empty when exposing in DHCP.
+        """
         from ralph.networks.models import IPAddress
         try:
             if not self.mac and self.ipaddress.dhcp_expose:
@@ -121,7 +124,7 @@ class Ethernet(Component):
 
     def _validate_change_when_exposing_in_dhcp(self):
         """
-        Check if mas had changed when entry is exposed in DHCP.
+        Check if mas has changed when entry is exposed in DHCP.
         """
         if self.pk and settings.DHCP_ENTRY_FORBID_CHANGE:
             from ralph.networks.models import IPAddress

--- a/src/ralph/assets/models/components.py
+++ b/src/ralph/assets/models/components.py
@@ -1,10 +1,9 @@
 # -*- coding: utf-8 -*-
 import re
 
+from django.conf import settings
 from django.core.exceptions import ValidationError
 from django.core.validators import RegexValidator
-
-from django.conf import settings
 from django.db import models
 from django.utils.translation import ugettext_lazy as _
 

--- a/src/ralph/assets/models/components.py
+++ b/src/ralph/assets/models/components.py
@@ -1,7 +1,9 @@
 # -*- coding: utf-8 -*-
 import re
 
+from django.core.exceptions import ValidationError
 from django.core.validators import RegexValidator
+
 from django.db import models
 from django.utils.translation import ugettext_lazy as _
 
@@ -106,3 +108,13 @@ class Ethernet(Component):
 
     def __str__(self):
         return '{} ({})'.format(self.label, self.mac)
+
+    def clean(self):
+        from ralph.networks.models import IPAddress
+        try:
+            if not self.mac and self.ipaddress.dhcp_expose:
+                raise ValidationError(
+                    _('MAC cannot be empty if record is exposed in DHCP')
+                )
+        except IPAddress.DoesNotExist:
+            pass

--- a/src/ralph/assets/models/components.py
+++ b/src/ralph/assets/models/components.py
@@ -90,7 +90,7 @@ class Ethernet(Component):
     label = NullableCharField(
         verbose_name=_('name'), max_length=255, blank=True, null=True
     )
-    mac = models.CharField(
+    mac = NullableCharField(
         verbose_name=_('MAC address'), unique=True,
         validators=[mac_validator], max_length=24, null=True, blank=True
     )

--- a/src/ralph/assets/tests/test_api.py
+++ b/src/ralph/assets/tests/test_api.py
@@ -47,7 +47,6 @@ from ralph.networks.tests.factories import IPAddressFactory
 from ralph.supports.models import Support
 from ralph.supports.tests.factories import SupportFactory
 from ralph.tests.models import PolymorphicTestModel
-from ralph.tests.factories import PolymorphicTestModelFactory
 from ralph.virtual.models import (
     CloudFlavor,
     CloudHost,

--- a/src/ralph/assets/tests/test_api.py
+++ b/src/ralph/assets/tests/test_api.py
@@ -741,3 +741,19 @@ class ConfigurationClassAPITests(RalphAPITestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.conf_class_1.refresh_from_db()
         self.assertEqual(self.conf_class_1.class_name, 'test_2')
+
+
+class EthernetAPITests(RalphAPITestCase):
+    def setUp(self):
+        super().setUp()
+        self.ip = IPAddressFactory(dhcp_expose=True)
+        self.eth = self.ip.ethernet
+
+    def test_cannot_delete_when_exposed_in_dhcp(self):
+        url = reverse('ethernet-detail', args=(self.eth.id,))
+        response = self.client.delete(url, format='json')
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn(
+            'Could not delete Ethernet when it is exposed in DHCP',
+            response.data
+        )

--- a/src/ralph/assets/tests/test_api.py
+++ b/src/ralph/assets/tests/test_api.py
@@ -46,6 +46,8 @@ from ralph.licences.tests.factories import LicenceFactory
 from ralph.networks.tests.factories import IPAddressFactory
 from ralph.supports.models import Support
 from ralph.supports.tests.factories import SupportFactory
+from ralph.tests.models import PolymorphicTestModel
+from ralph.tests.factories import PolymorphicTestModelFactory
 from ralph.virtual.models import (
     CloudFlavor,
     CloudHost,
@@ -466,7 +468,7 @@ BASE_OBJECTS_FACTORIES = {
     Support: SupportFactory,
     VIP: VIPFactory,
     VirtualServer: VirtualServerFactory,
-    Cluster: ClusterFactory
+    Cluster: ClusterFactory,
 }
 
 
@@ -595,6 +597,10 @@ class BaseObjectAPITests(RalphAPITestCase):
     def test_str_field(self):
         count = 0
         for descendant in BaseObject._polymorphic_descendants:
+            if descendant in [
+                PolymorphicTestModel
+            ]:
+                continue
             if not descendant._polymorphic_descendants:
                 count += 1
                 obj = BASE_OBJECTS_FACTORIES[descendant]()

--- a/src/ralph/assets/tests/test_models.py
+++ b/src/ralph/assets/tests/test_models.py
@@ -4,7 +4,7 @@ from django.core.exceptions import ValidationError
 from ralph.assets.tests.factories import (
     ConfigurationClassFactory,
     ConfigurationModuleFactory,
-    EthernetFactory,
+    EthernetFactory
 )
 from ralph.networks.tests.factories import IPAddressFactory
 from ralph.tests import RalphTestCase

--- a/src/ralph/assets/tests/test_models.py
+++ b/src/ralph/assets/tests/test_models.py
@@ -63,3 +63,13 @@ class EthernetTest(RalphTestCase):
             msg='MAC cannot be empty if record is exposed in DHCP'
         ):
             self.ip1.ethernet.clean()
+
+    def test_change_mac_address_with_ip_with_dhcp_exposition_should_not_pass(self):  # noqa
+        self.ip1.dhcp_expose = True
+        self.ip1.save()
+        self.ip1.ethernet.mac = '11:12:13:14:15:16'
+        with self.assertRaises(
+            ValidationError,
+            msg='Cannot change MAC when exposing in DHCP'
+        ):
+            self.ip1.ethernet.clean()

--- a/src/ralph/data_center/admin.py
+++ b/src/ralph/data_center/admin.py
@@ -41,11 +41,7 @@ from ralph.data_importer import resources
 from ralph.lib.table import Table
 from ralph.lib.transitions.admin import TransitionAdminMixin
 from ralph.licences.models import BaseObjectLicence
-from ralph.networks.forms import (
-    NetworkForm,
-    NetworkInlineFormset,
-    SimpleNetworkForm
-)
+from ralph.networks.forms import NetworkInline, SimpleNetworkForm
 from ralph.networks.models.networks import Network
 from ralph.operations.views import OperationViewReadOnlyForExisiting
 from ralph.supports.models import BaseObjectsSupport
@@ -135,13 +131,6 @@ class ClusterAdmin(RalphAdmin):
 class DataCenterAdmin(RalphAdmin):
 
     search_fields = ['name']
-
-
-class NetworkInline(RalphTabularInline):
-    form = NetworkForm
-    formset = NetworkInlineFormset
-    model = Ethernet
-    exclude = ['model']
 
 
 class NetworkTerminatorReadOnlyInline(RalphTabularM2MInline):

--- a/src/ralph/data_center/migrations/0015_auto_20160525_1113.py
+++ b/src/ralph/data_center/migrations/0015_auto_20160525_1113.py
@@ -1,0 +1,25 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+import ralph.lib.transitions.fields
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('data_center', '0014_auto_20160512_0841'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='cluster',
+            name='status',
+            field=ralph.lib.transitions.fields.TransitionField(default=1, choices=[(1, 'in use'), (2, 'for deploy')]),
+        ),
+        migrations.AlterField(
+            model_name='clustertype',
+            name='show_master_summary',
+            field=models.BooleanField(default=False, help_text='show master information on cluster page, ex. hostname, model, location etc.'),
+        ),
+    ]

--- a/src/ralph/dhcp/models.py
+++ b/src/ralph/dhcp/models.py
@@ -7,7 +7,9 @@ from ralph.networks.models.networks import IPAddress, IPAddressStatus
 
 class DHCPEntryManager(models.Manager):
     def get_queryset(self):
-        return super().get_queryset().select_related('ethernet').exclude(
+        return super().get_queryset().select_related('ethernet').filter(
+            dhcp_expose=True,
+        ).exclude(
             hostname=None,
             ethernet__base_object=None,
             ethernet=None,

--- a/src/ralph/networks/api.py
+++ b/src/ralph/networks/api.py
@@ -83,6 +83,14 @@ class IPAddressViewSet(RalphAPIViewSet):
         'status', 'is_public', 'is_management', 'dhcp_expose'
     ]
 
+    def destroy(self, request, *args, **kwargs):
+        instance = self.get_object()
+        if instance and instance.dhcp_expose:
+            raise ValidationError(
+                'Could not delete IPAddress when it is exposed in DHCP'
+            )
+        return super().destroy(request, *args, **kwargs)
+
 
 class NetworkViewSet(RalphAPIViewSet):
     queryset = Network.objects.all()

--- a/src/ralph/networks/api.py
+++ b/src/ralph/networks/api.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 from ralph.api import RalphAPISerializer, RalphAPIViewSet, router
+from ralph.api.serializers import RalphAPISaveSerializer
 from ralph.assets.api.serializers import EthernetSerializer
 from ralph.networks.models import (
     IPAddress,
@@ -43,17 +44,25 @@ class IPAddressSerializer(RalphAPISerializer):
     class Meta:
         model = IPAddress
         depth = 1
-        exclude = (
-            # 'ethernet',
-        )
+        exclude = ('number',)
+
+
+class IPAddressSaveSerializer(RalphAPISaveSerializer):
+    class Meta:
+        model = IPAddress
 
 
 class IPAddressViewSet(RalphAPIViewSet):
     queryset = IPAddress.objects.all()
     serializer_class = IPAddressSerializer
+    save_serializer_class = IPAddressSaveSerializer
     prefetch_related = [
         'ethernet', 'ethernet__base_object', 'ethernet__base_object__tags',
         'network',
+    ]
+    filter_fields = [
+        'hostname', 'ethernet__base_object', 'network', 'network__address',
+        'status', 'is_public', 'is_management', 'dhcp_expose'
     ]
 
 

--- a/src/ralph/networks/api.py
+++ b/src/ralph/networks/api.py
@@ -1,4 +1,7 @@
 # -*- coding: utf-8 -*-
+from django.conf import settings
+from rest_framework.exceptions import ValidationError
+
 from ralph.api import RalphAPISerializer, RalphAPIViewSet, router
 from ralph.api.serializers import RalphAPISaveSerializer
 from ralph.assets.api.serializers import EthernetSerializer
@@ -50,6 +53,21 @@ class IPAddressSerializer(RalphAPISerializer):
 class IPAddressSaveSerializer(RalphAPISaveSerializer):
     class Meta:
         model = IPAddress
+
+    def validate_dhcp_expose(self, value):
+        """
+        Check if dhcp_expose value has changed from True to False.
+        """
+        if (
+            settings.DHCP_ENTRY_FORBID_CHANGE and
+            self.instance and
+            self.instance.dhcp_expose and
+            not value
+        ):
+            raise ValidationError(
+                'Cannot remove entry from DHCP. Use transition to do this.'
+            )
+        return value
 
 
 class IPAddressViewSet(RalphAPIViewSet):

--- a/src/ralph/networks/forms.py
+++ b/src/ralph/networks/forms.py
@@ -121,13 +121,13 @@ class SimpleNetworkForm(forms.ModelForm):
 
     def clean_mac(self):
         if self._dhcp_expose_should_lock_fields:
-            # if mac is locked, just return current address
+            # if mac is locked, just return current mac
             return self.instance.mac
         return self.cleaned_data['mac']
 
     def clean_hostname(self):
         if self._dhcp_expose_should_lock_fields:
-            # if mac is locked, just return current address
+            # if mac is locked, just return current hostname
             return self.ip.hostname
         return self.cleaned_data['hostname']
 

--- a/src/ralph/networks/forms.py
+++ b/src/ralph/networks/forms.py
@@ -40,7 +40,7 @@ class SimpleNetworkForm(forms.ModelForm):
 
     Validations and checks:
     * at least one of MAC and IP address is required
-    * when address is empty, none of ip fields (is_management_, hostname etc)
+    * when address is empty, none of ip fields (is_management, hostname etc)
         could be filled
 
     Notes:

--- a/src/ralph/networks/migrations/0014_ipaddress_dhcp_expose.py
+++ b/src/ralph/networks/migrations/0014_ipaddress_dhcp_expose.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('networks', '0013_auto_20160509_1309'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='ipaddress',
+            name='dhcp_expose',
+            field=models.BooleanField(default=False, verbose_name='Expose in DHCP'),
+        ),
+    ]

--- a/src/ralph/networks/models/networks.py
+++ b/src/ralph/networks/models/networks.py
@@ -419,7 +419,7 @@ class IPAddress(
         help_text=_('Presented as string.'),
         unique=True,
         blank=False,
-        default=None,
+        null=False,
     )
     hostname = NullableCharField(
         verbose_name=_('Hostname'),

--- a/src/ralph/networks/tests/test_api.py
+++ b/src/ralph/networks/tests/test_api.py
@@ -108,3 +108,12 @@ class IPAddressAPITests(RalphAPITestCase):
             'Cannot remove entry from DHCP. Use transition to do this.',
             response.data['dhcp_expose']
         )
+
+    def test_delete_when_exposing_in_dhcp_should_not_pass(self):
+        url = reverse('ipaddress-detail', args=(self.ip_with_dhcp.id,))
+        response = self.client.delete(url, format='json')
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn(
+            'Could not delete IPAddress when it is exposed in DHCP',
+            response.data
+        )

--- a/src/ralph/networks/tests/test_api.py
+++ b/src/ralph/networks/tests/test_api.py
@@ -2,20 +2,87 @@
 from django.core.urlresolvers import reverse
 from rest_framework import status
 
-from ralph.accounts.tests.factories import RegionFactory
 from ralph.api.tests._base import RalphAPITestCase
-from ralph.networks.models import IPAddress
+from ralph.assets.tests.factories import EthernetFactory
+from ralph.networks.models import IPAddressStatus
+from ralph.networks.tests.factories import IPAddressFactory, NetworkFactory
 
 
 class IPAddressAPITests(RalphAPITestCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.net = NetworkFactory(address='127.0.0.0/24')
+        cls.eth = EthernetFactory()
+
     def setUp(self):
         super().setUp()
-        self.licence1, self.licence2 = LicenceFactory.create_batch(2)
-        region_pl = RegionFactory(name='pl')
-        self.licence3 = LicenceFactory(region=region_pl)
-        self.base_object = BackOfficeAssetFactory()
-        self.base_object2 = BackOfficeAssetFactory(region=region_pl)
-        LicenceUser.objects.create(licence=self.licence1, user=self.user1)
-        BaseObjectLicence.objects.create(
-            licence=self.licence2, base_object=self.base_object
+        self.ip1 = IPAddressFactory(address='127.0.0.1')
+        self.ip_with_dhcp = IPAddressFactory(
+            address='127.0.0.2', dhcp_expose=True
         )
+
+    def test_get_ip_list_filter_by_dhcp_expose(self):
+        url = '{}?{}'.format(reverse('ipaddress-list'), 'dhcp_expose=True')
+        # TODO: 1 and true should also work
+        # see https://github.com/tomchristie/django-rest-framework/issues/2122
+        # for details
+        response = self.client.get(url, format='json')
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data['count'], 1)
+
+    def test_change_network_should_not_pass(self):
+        net = NetworkFactory(address='192.168.1.0/24')
+        data = {'network': net.id}
+        url = reverse('ipaddress-detail', args=(self.ip1.id,))
+        response = self.client.patch(url, format='json', data=data)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.ip1.refresh_from_db()
+        self.assertEqual(self.ip1.network, self.net)
+
+    def test_put_ip(self):
+        data = {
+            'address': '127.1.0.1',
+            'hostname': 'another-hostname',
+            'is_management': True,
+            'is_gateway': True,
+            'status': 'reserved',
+            'ethernet': self.eth.id,
+            'dhcp_expose': True,
+        }
+        url = reverse('ipaddress-detail', args=(self.ip1.id,))
+        response = self.client.put(url, format='json', data=data)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.ip1.refresh_from_db()
+        self.assertEqual(self.ip1.address, '127.1.0.1')
+        self.assertEqual(self.ip1.hostname, 'another-hostname')
+        self.assertTrue(self.ip1.is_management)
+        self.assertTrue(self.ip1.dhcp_expose)
+        self.assertTrue(self.ip1.is_gateway)
+        self.assertEqual(self.ip1.ethernet, self.eth)
+        self.assertEqual(self.ip1.status, IPAddressStatus.reserved)
+
+    def test_change_ip_address_already_occupied_should_not_pass(self):
+        data = {'address': '127.0.0.2'}
+        url = reverse('ipaddress-detail', args=(self.ip1.id,))
+        response = self.client.patch(url, format='json', data=data)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn('This field must be unique.', response.data['address'])
+
+    def test_change_ip_address_with_dhcp_exposition_should_not_pass(self):
+        data = {'address': '127.0.0.3'}
+        url = reverse('ipaddress-detail', args=(self.ip_with_dhcp.id,))
+        response = self.client.patch(url, format='json', data=data)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_change_ip_hostname_with_dhcp_exposition_should_not_pass(self):
+        data = {'hostname': 'some-hostname'}
+        url = reverse('ipaddress-detail', args=(self.ip_with_dhcp.id,))
+        response = self.client.patch(url, format='json', data=data)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_change_ip_ethernet_with_dhcp_exposition_should_not_pass(self):
+        data = {'ethernet': self.eth.id}
+        url = reverse('ipaddress-detail', args=(self.ip_with_dhcp.id,))
+        response = self.client.patch(url, format='json', data=data)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)

--- a/src/ralph/networks/tests/test_api.py
+++ b/src/ralph/networks/tests/test_api.py
@@ -74,15 +74,37 @@ class IPAddressAPITests(RalphAPITestCase):
         url = reverse('ipaddress-detail', args=(self.ip_with_dhcp.id,))
         response = self.client.patch(url, format='json', data=data)
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn(
+            'Cannot change address when exposing in DHCP',
+            response.data['__all__']
+        )
 
     def test_change_ip_hostname_with_dhcp_exposition_should_not_pass(self):
         data = {'hostname': 'some-hostname'}
         url = reverse('ipaddress-detail', args=(self.ip_with_dhcp.id,))
         response = self.client.patch(url, format='json', data=data)
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn(
+            'Cannot change hostname when exposing in DHCP',
+            response.data['__all__']
+        )
 
     def test_change_ip_ethernet_with_dhcp_exposition_should_not_pass(self):
         data = {'ethernet': self.eth.id}
         url = reverse('ipaddress-detail', args=(self.ip_with_dhcp.id,))
         response = self.client.patch(url, format='json', data=data)
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn(
+            'Cannot change ethernet when exposing in DHCP',
+            response.data['__all__']
+        )
+
+    def test_change_ip_dhcp_expose_with_dhcp_exposition_should_not_pass(self):
+        data = {'dhcp_expose': False}
+        url = reverse('ipaddress-detail', args=(self.ip_with_dhcp.id,))
+        response = self.client.patch(url, format='json', data=data)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn(
+            'Cannot remove entry from DHCP. Use transition to do this.',
+            response.data['dhcp_expose']
+        )

--- a/src/ralph/networks/tests/test_api.py
+++ b/src/ralph/networks/tests/test_api.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+from django.core.urlresolvers import reverse
+from rest_framework import status
+
+from ralph.accounts.tests.factories import RegionFactory
+from ralph.api.tests._base import RalphAPITestCase
+from ralph.networks.models import IPAddress
+
+
+class IPAddressAPITests(RalphAPITestCase):
+    def setUp(self):
+        super().setUp()
+        self.licence1, self.licence2 = LicenceFactory.create_batch(2)
+        region_pl = RegionFactory(name='pl')
+        self.licence3 = LicenceFactory(region=region_pl)
+        self.base_object = BackOfficeAssetFactory()
+        self.base_object2 = BackOfficeAssetFactory(region=region_pl)
+        LicenceUser.objects.create(licence=self.licence1, user=self.user1)
+        BaseObjectLicence.objects.create(
+            licence=self.licence2, base_object=self.base_object
+        )

--- a/src/ralph/networks/tests/test_forms.py
+++ b/src/ralph/networks/tests/test_forms.py
@@ -1,0 +1,626 @@
+from django.contrib.auth import get_user_model
+from django.test import RequestFactory
+
+from ralph.assets.models.components import Ethernet, EthernetSpeed
+from ralph.networks.models import IPAddress
+from ralph.networks.tests.factories import IPAddressFactory
+from ralph.tests import RalphTestCase
+from ralph.tests.models import PolymorphicTestModel
+
+
+class NetworkInlineTestCase(RalphTestCase):
+    def setUp(self):
+        self.inline_prefix = 'ethernet-'
+        self.obj1 = PolymorphicTestModel.objects.create(hostname='abc')
+        self.obj2 = PolymorphicTestModel.objects.create(hostname='xyz')
+        self.ip1 = IPAddressFactory(
+            ethernet__base_object=self.obj1,
+            address='127.0.0.1',
+            is_management=True,
+        )
+        self.ip2 = IPAddressFactory(
+            ethernet__base_object=self.obj2,
+            address='127.1.0.1',
+            is_management=True,
+        )
+        self.eth1 = self.ip1.ethernet
+        self.user = get_user_model().objects.create_superuser(
+            username='root',
+            password='password',
+            email='email@email.pl'
+        )
+        result = self.client.login(username='root', password='password')
+        self.assertEqual(result, True)
+        self.factory = RequestFactory()
+
+    def _prepare_inline_data(self, d):
+        return {
+            '{}{}'.format(self.inline_prefix, k): v for (k, v) in d.items()
+        }
+
+    def test_adding_new_record_should_pass(self):
+        inline_data = {
+            'TOTAL_FORMS': 2,
+            'INITIAL_FORMS': 1,
+            '0-id': self.eth1.id,
+            '0-base_object': self.obj1.id,
+            '0-hostname': self.ip1.hostname,
+            '0-address': self.ip1.address,
+            '0-mac': self.eth1.mac,
+            '0-label': '',
+            '0-speed': self.eth1.speed,
+            '0-is_management': 'on',
+
+            '1-base_object': self.obj1.id,
+            '1-hostname': 'def',
+            '1-address': '127.0.0.2',
+            '1-mac': '10:20:30:40:50:60',
+            '1-label': 'eth1',
+            '1-speed': EthernetSpeed.s100gbit.id,
+        }
+        data = {
+            'hostname': self.obj1.hostname,
+            'id': self.obj1.id,
+        }
+        data.update(self._prepare_inline_data(inline_data))
+        response = self.client.post(self.obj1.get_absolute_url(), data)
+        self.assertEqual(response.status_code, 302)
+        ip = IPAddress.objects.get(address='127.0.0.2')
+        self.assertEqual(ip.hostname, 'def')
+        self.assertFalse(ip.is_management)
+        self.assertFalse(ip.dhcp_expose)
+        self.assertEqual(ip.ethernet.mac, '10:20:30:40:50:60')
+        self.assertEqual(ip.ethernet.speed, EthernetSpeed.s100gbit.id)
+        self.assertEqual(ip.ethernet.label, 'eth1')
+        self.assertEqual(ip.ethernet.base_object.pk, self.obj1.pk)
+
+    def test_adding_new_record_without_ip_and_hostname_should_pass(self):
+        inline_data = {
+            'TOTAL_FORMS': 2,
+            'INITIAL_FORMS': 1,
+            '0-id': self.eth1.id,
+            '0-base_object': self.obj1.id,
+            '0-hostname': self.ip1.hostname,
+            '0-address': self.ip1.address,
+            '0-mac': self.eth1.mac,
+            '0-label': '',
+            '0-speed': self.eth1.speed,
+            '0-is_management': 'on',
+
+            '1-base_object': self.obj1.id,
+            # '1-hostname': 'def',
+            # '1-address': '127.0.0.2',
+            '1-mac': '10:20:30:40:50:60',
+            '1-label': 'eth1',
+            '1-speed': EthernetSpeed.s100gbit.id,
+        }
+        data = {
+            'hostname': self.obj1.hostname,
+            'id': self.obj1.id,
+        }
+        data.update(self._prepare_inline_data(inline_data))
+        response = self.client.post(self.obj1.get_absolute_url(), data)
+        self.assertEqual(response.status_code, 302)
+        eth = Ethernet.objects.get(mac='10:20:30:40:50:60')
+        # ip = IPAddress.objects.get(address='127.0.0.2')
+        # self.assertEqual(ip.hostname, 'def')
+        # self.assertFalse(ip.is_management)
+        # self.assertFalse(ip.dhcp_expose)
+        self.assertEqual(eth.speed, EthernetSpeed.s100gbit.id)
+        self.assertEqual(eth.label, 'eth1')
+        self.assertEqual(eth.base_object.pk, self.obj1.pk)
+        # ip should not be created
+        with self.assertRaises(IPAddress.DoesNotExist):
+            eth.ipaddress
+
+    def test_adding_new_record_without_mac_should_pass(self):
+        inline_data = {
+            'TOTAL_FORMS': 2,
+            'INITIAL_FORMS': 1,
+            '0-id': self.eth1.id,
+            '0-base_object': self.obj1.id,
+            '0-hostname': self.ip1.hostname,
+            '0-address': self.ip1.address,
+            '0-mac': self.eth1.mac,
+            '0-label': '',
+            '0-speed': self.eth1.speed,
+            '0-is_management': 'on',
+
+            '1-base_object': self.obj1.id,
+            '1-hostname': 'def',
+            '1-address': '127.0.0.2',
+            # '1-mac': '10:20:30:40:50:60',
+            # '1-label': 'eth1',
+            '1-speed': EthernetSpeed.unknown.id,
+        }
+        data = {
+            'hostname': self.obj1.hostname,
+            'id': self.obj1.id,
+        }
+        data.update(self._prepare_inline_data(inline_data))
+        response = self.client.post(self.obj1.get_absolute_url(), data)
+        self.assertEqual(response.status_code, 302)
+        ip = IPAddress.objects.get(address='127.0.0.2')
+        self.assertEqual(ip.hostname, 'def')
+        self.assertFalse(ip.is_management)
+        self.assertFalse(ip.dhcp_expose)
+        self.assertFalse(bool(ip.ethernet.mac))  # mac is either None or ''
+        self.assertEqual(ip.ethernet.speed, EthernetSpeed.unknown.id)
+        self.assertFalse(bool(ip.ethernet.label))
+        self.assertEqual(ip.ethernet.base_object.pk, self.obj1.pk)
+
+    def test_adding_multiple_new_record_without_mac_should_pass(self):
+        # test for storing mac as null
+        inline_data = {
+            'TOTAL_FORMS': 3,
+            'INITIAL_FORMS': 1,
+            '0-id': self.eth1.id,
+            '0-base_object': self.obj1.id,
+            '0-hostname': self.ip1.hostname,
+            '0-address': self.ip1.address,
+            '0-mac': self.eth1.mac,
+            '0-label': '',
+            '0-speed': self.eth1.speed,
+            '0-is_management': 'on',
+
+            '1-base_object': self.obj1.id,
+            '1-hostname': 'def',
+            '1-address': '127.0.0.2',
+            '1-speed': EthernetSpeed.unknown.id,
+
+            '2-base_object': self.obj1.id,
+            '2-hostname': 'def',
+            '2-address': '127.0.0.3',
+            '2-speed': EthernetSpeed.unknown.id,
+        }
+        data = {
+            'hostname': self.obj1.hostname,
+            'id': self.obj1.id,
+        }
+        data.update(self._prepare_inline_data(inline_data))
+        response = self.client.post(self.obj1.get_absolute_url(), data)
+        self.assertEqual(response.status_code, 302)
+
+    def test_adding_new_record_without_mac_and_ip_should_not_pass(self):
+        inline_data = {
+            'TOTAL_FORMS': 2,
+            'INITIAL_FORMS': 1,
+            '0-id': self.eth1.id,
+            '0-base_object': self.obj1.id,
+            '0-hostname': self.ip1.hostname,
+            '0-address': self.ip1.address,
+            '0-mac': self.eth1.mac,
+            '0-label': '',
+            '0-speed': self.eth1.speed,
+            '0-is_management': 'on',
+
+            '1-base_object': self.obj1.id,
+            '1-label': 'eth1',
+            '1-speed': EthernetSpeed.unknown.id,
+        }
+        data = {
+            'hostname': self.obj1.hostname,
+            'id': self.obj1.id,
+        }
+        data.update(self._prepare_inline_data(inline_data))
+        response = self.client.post(self.obj1.get_absolute_url(), data)
+        self.assertEqual(response.status_code, 200)
+        for err in response.context_data['errors']:
+            self.assertIn('At least one of mac, address is required', err)
+
+    def test_adding_new_record_with_existing_ip_should_not_pass(self):
+        inline_data = {
+            'TOTAL_FORMS': 2,
+            'INITIAL_FORMS': 1,
+            '0-id': self.eth1.id,
+            '0-base_object': self.obj1.id,
+            '0-hostname': self.ip1.hostname,
+            '0-address': self.ip1.address,
+            '0-mac': self.eth1.mac,
+            '0-label': '',
+            '0-speed': self.eth1.speed,
+            '0-is_management': 'on',
+
+            '1-base_object': self.obj1.id,
+            '1-hostname': 'def',
+            '1-mac': '11:12:13:14:15:16',
+            '1-address': self.ip2.address,  # duplicated ip!
+            '1-speed': EthernetSpeed.unknown.id,
+        }
+        data = {
+            'hostname': self.obj1.hostname,
+            'id': self.obj1.id,
+        }
+        data.update(self._prepare_inline_data(inline_data))
+        response = self.client.post(self.obj1.get_absolute_url(), data)
+        self.assertEqual(response.status_code, 200)
+        msg = 'Address {} already exist.'.format(self.ip2.address)
+        self.assertTrue(
+            any([msg in err for err in response.context_data['errors']])
+        )
+
+    def test_more_than_one_ip_is_management(self):
+        inline_data = {
+            'TOTAL_FORMS': 2,
+            'INITIAL_FORMS': 1,
+            '0-id': self.eth1.id,
+            '0-base_object': self.obj1.id,
+            '0-hostname': self.ip1.hostname,
+            '0-address': self.ip1.address,
+            '0-mac': self.eth1.mac,
+            '0-label': '',
+            '0-speed': self.eth1.speed,
+            '0-is_management': 'on',
+
+            '1-hostname': 'def',
+            '1-base_object': self.obj1.id,
+            '1-address': '127.0.0.2',
+            '1-mac': '',
+            '1-label': '',
+            '1-speed': EthernetSpeed.unknown.id,
+            '1-is_management': 'on',
+        }
+        data = {
+            'hostname': self.obj1.hostname,
+            'id': self.obj1.id,
+        }
+        data.update(self._prepare_inline_data(inline_data))
+        response = self.client.post(self.obj1.get_absolute_url(), data)
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(
+            'Only one managment IP address can be assigned to this asset',
+            response.context_data['errors']
+        )
+
+    def test_empty_address_and_not_empty_hostname_should_not_pass(self):
+        inline_data = {
+            'TOTAL_FORMS': 2,
+            'INITIAL_FORMS': 1,
+            '0-id': self.eth1.id,
+            '0-base_object': self.obj1.id,
+            '0-hostname': self.ip1.hostname,
+            '0-address': self.ip1.address,
+            '0-mac': self.eth1.mac,
+            '0-label': '',
+            '0-speed': self.eth1.speed,
+            '0-is_management': 'on',
+
+            '1-hostname': 'def',
+            '1-base_object': self.obj1.id,
+            '1-address': '',
+            '1-mac': '10:20:30:40:50:60',
+            '1-label': '',
+            '1-speed': EthernetSpeed.unknown.id,
+        }
+        data = {
+            'hostname': self.obj1.hostname,
+            'id': self.obj1.id,
+        }
+        data.update(self._prepare_inline_data(inline_data))
+        response = self.client.post(self.obj1.get_absolute_url(), data)
+        self.assertEqual(response.status_code, 200)
+        msg = (
+            'Address is required when one of hostname, is_management, '
+            'dhcp_expose is filled'
+        )
+        self.assertTrue(
+            any([msg in err for err in response.context_data['errors']])
+        )
+
+
+class NetworkInlineWithDHCPExposeTestCase(RalphTestCase):
+    def setUp(self):
+        self.inline_prefix = 'ethernet-'
+        self.obj1 = PolymorphicTestModel.objects.create(hostname='abc')
+        self.ip1 = IPAddressFactory(
+            ethernet__base_object=self.obj1,
+            ethernet__mac='10:20:30:40:50:60',
+            hostname='s11.dc.local',
+            address='127.0.0.1',
+            is_management=True,
+        )
+        self.eth1 = self.ip1.ethernet
+        self.user = get_user_model().objects.create_superuser(
+            username='root',
+            password='password',
+            email='email@email.pl'
+        )
+        result = self.client.login(username='root', password='password')
+        self.assertEqual(result, True)
+        self.factory = RequestFactory()
+
+    def _prepare_inline_data(self, d):
+        return {
+            '{}{}'.format(self.inline_prefix, k): v for (k, v) in d.items()
+        }
+
+    def test_dhcp_expose_readonly_fields_should_not_change_their_value(self):
+        self.ip1.dhcp_expose = True
+        self.ip1.save()
+        inline_data = {
+            'TOTAL_FORMS': 1,
+            'INITIAL_FORMS': 1,
+            '0-id': self.eth1.id,
+            '0-base_object': self.obj1.id,
+            '0-label': 'eth10',
+            '0-speed': EthernetSpeed.s100gbit.id,
+            # readonly fields modification!
+            '0-hostname': 's222.dc.local',
+            '0-address': '127.1.1.1',
+            '0-mac': '11:11:11:11:11:11',
+            # notice missing dhcp_expose field
+        }
+        data = {
+            'hostname': self.obj1.hostname,
+            'id': self.obj1.id,
+        }
+        data.update(self._prepare_inline_data(inline_data))
+        response = self.client.post(self.obj1.get_absolute_url(), data)
+        self.assertEqual(response.status_code, 302)
+        # besides 302, readonly fields are untouched
+        self.ip1.refresh_from_db()
+        self.assertEqual(self.ip1.address, '127.0.0.1')
+        self.assertEqual(self.ip1.hostname, 's11.dc.local')
+        self.assertEqual(self.ip1.dhcp_expose, True)
+        self.eth1.refresh_from_db()
+        self.assertEqual(self.eth1.mac, '10:20:30:40:50:60')
+        # other fields could be changed
+        self.assertEqual(self.eth1.label, 'eth10')
+        self.assertEqual(self.eth1.speed, EthernetSpeed.s100gbit.id)
+
+    def test_dhcp_expose_delete_should_not_work(self):
+        self.ip1.dhcp_expose = True
+        self.ip1.save()
+        inline_data = {
+            'TOTAL_FORMS': 1,
+            'INITIAL_FORMS': 1,
+            '0-id': self.eth1.id,
+            '0-base_object': self.obj1.id,
+            '0-label': 'eth10',
+            '0-speed': EthernetSpeed.s100gbit.id,
+            '0-hostname': 's222.dc.local',
+            '0-address': '127.1.1.1',
+            '0-mac': '11:11:11:11:11:11',
+            '0-DELETE': 'on',  # deleting row with DHCP entry!
+        }
+        data = {
+            'hostname': self.obj1.hostname,
+            'id': self.obj1.id,
+        }
+        data.update(self._prepare_inline_data(inline_data))
+        response = self.client.post(self.obj1.get_absolute_url(), data)
+        self.assertEqual(response.status_code, 200)
+        msg = 'Cannot delete entry if its exposed in DHCP'
+        self.assertTrue(
+            any([msg in err for err in response.context_data['errors']])
+        )
+
+    def test_dhcp_expose_for_new_record_should_pass(self):
+        self.ip1.dhcp_expose = True
+        self.ip1.save()
+        inline_data = {
+            'TOTAL_FORMS': 2,
+            'INITIAL_FORMS': 1,
+            '0-id': self.eth1.id,
+            '0-base_object': self.obj1.id,
+            '0-label': 'eth10',
+            '0-speed': EthernetSpeed.s100gbit.id,
+
+            '1-base_object': self.obj1.id,
+            '1-hostname': 'def',
+            '1-address': '127.0.0.2',
+            '1-mac': '10:10:10:10:10:10',
+            '1-label': 'eth10',
+            '1-speed': EthernetSpeed.unknown.id,
+            '1-dhcp_expose': 'on',
+        }
+        data = {
+            'hostname': self.obj1.hostname,
+            'id': self.obj1.id,
+        }
+        data.update(self._prepare_inline_data(inline_data))
+        response = self.client.post(self.obj1.get_absolute_url(), data)
+        self.assertEqual(response.status_code, 302)
+        ip = IPAddress.objects.get(address='127.0.0.2')
+        self.assertEqual(ip.hostname, 'def')
+        self.assertTrue(ip.dhcp_expose)
+        self.assertEqual(ip.ethernet.mac, '10:10:10:10:10:10')
+        self.assertEqual(ip.ethernet.speed, EthernetSpeed.unknown.id)
+        self.assertEqual(ip.ethernet.label, 'eth10')
+        self.assertEqual(ip.ethernet.base_object.pk, self.obj1.pk)
+
+    def test_dhcp_expose_for_existing_record_should_pass(self):
+        inline_data = {
+            'TOTAL_FORMS': 1,
+            'INITIAL_FORMS': 1,
+            '0-id': self.eth1.id,
+            '0-base_object': self.obj1.id,
+            '0-label': 'eth10',
+            '0-speed': EthernetSpeed.s100gbit.id,
+            '0-hostname': 's11.dc.local',
+            '0-address': '127.0.0.1',
+            '0-mac': '10:20:30:40:50:60',
+            '0-dhcp_expose': 'on',
+        }
+        data = {
+            'hostname': self.obj1.hostname,
+            'id': self.obj1.id,
+        }
+        data.update(self._prepare_inline_data(inline_data))
+        response = self.client.post(self.obj1.get_absolute_url(), data)
+        self.assertEqual(response.status_code, 302)
+        ip = IPAddress.objects.get(address='127.0.0.1')
+        self.assertEqual(ip.hostname, 's11.dc.local')
+        self.assertTrue(ip.dhcp_expose)
+        self.assertEqual(ip.ethernet.mac, '10:20:30:40:50:60')
+        self.assertEqual(ip.ethernet.speed, EthernetSpeed.s100gbit.id)
+        self.assertEqual(ip.ethernet.label, 'eth10')
+        self.assertEqual(ip.ethernet.base_object.pk, self.obj1.pk)
+
+    def test_dhcp_expose_without_address_for_new_record_should_not_pass(self):
+        self.ip1.dhcp_expose = True
+        self.ip1.save()
+        inline_data = {
+            'TOTAL_FORMS': 2,
+            'INITIAL_FORMS': 1,
+            '0-id': self.eth1.id,
+            '0-base_object': self.obj1.id,
+            '0-label': 'eht10',
+            '0-speed': EthernetSpeed.s100gbit.id,
+
+            '1-base_object': self.obj1.id,
+            '1-hostname': '',
+            '1-address': '',
+            '1-mac': '10:10:10:10:10:10',
+            '1-label': 'eth10',
+            '1-speed': EthernetSpeed.unknown.id,
+            '1-dhcp_expose': 'on',
+        }
+        data = {
+            'hostname': self.obj1.hostname,
+            'id': self.obj1.id,
+        }
+        data.update(self._prepare_inline_data(inline_data))
+        response = self.client.post(self.obj1.get_absolute_url(), data)
+        self.assertEqual(response.status_code, 200)
+        msg = 'Cannot expose in DHCP without IP address'
+        self.assertTrue(
+            any([msg in err for err in response.context_data['errors']])
+        )
+
+    def test_dhcp_expose_without_mac_for_new_record_should_not_pass(self):
+        self.ip1.dhcp_expose = True
+        self.ip1.save()
+        inline_data = {
+            'TOTAL_FORMS': 2,
+            'INITIAL_FORMS': 1,
+            '0-id': self.eth1.id,
+            '0-base_object': self.obj1.id,
+            '0-label': 'eht10',
+            '0-speed': EthernetSpeed.s100gbit.id,
+
+            '1-base_object': self.obj1.id,
+            '1-hostname': 'def',
+            '1-address': '127.0.0.2',
+            '1-mac': '',
+            '1-label': 'eth10',
+            '1-speed': EthernetSpeed.unknown.id,
+            '1-dhcp_expose': 'on',
+        }
+        data = {
+            'hostname': self.obj1.hostname,
+            'id': self.obj1.id,
+        }
+        data.update(self._prepare_inline_data(inline_data))
+        response = self.client.post(self.obj1.get_absolute_url(), data)
+        self.assertEqual(response.status_code, 200)
+        msg = 'Cannot expose in DHCP without MAC address'
+        self.assertTrue(
+            any([msg in err for err in response.context_data['errors']])
+        )
+
+    def test_dhcp_expose_without_hostname_for_new_record_should_not_pass(self):
+        self.ip1.dhcp_expose = True
+        self.ip1.save()
+        inline_data = {
+            'TOTAL_FORMS': 2,
+            'INITIAL_FORMS': 1,
+            '0-id': self.eth1.id,
+            '0-base_object': self.obj1.id,
+            '0-label': 'eht10',
+            '0-speed': EthernetSpeed.s100gbit.id,
+
+            '1-base_object': self.obj1.id,
+            '1-hostname': '',
+            '1-address': '127.0.0.2',
+            '1-mac': '10:10:10:10:10:10',
+            '1-label': 'eth10',
+            '1-speed': EthernetSpeed.unknown.id,
+            '1-dhcp_expose': 'on',
+        }
+        data = {
+            'hostname': self.obj1.hostname,
+            'id': self.obj1.id,
+        }
+        data.update(self._prepare_inline_data(inline_data))
+        response = self.client.post(self.obj1.get_absolute_url(), data)
+        self.assertEqual(response.status_code, 200)
+        msg = 'Cannot expose in DHCP without hostname'
+        self.assertTrue(
+            any([msg in err for err in response.context_data['errors']])
+        )
+
+    def test_dhcp_expose_without_address_for_existing_record_should_not_pass(self):  # noqa
+        inline_data = {
+            'TOTAL_FORMS': 1,
+            'INITIAL_FORMS': 1,
+            '0-id': self.eth1.id,
+            '0-base_object': self.obj1.id,
+            '0-label': 'eht10',
+            '0-speed': EthernetSpeed.s100gbit.id,
+            '0-hostname': '',
+            '0-address': '',
+            '0-mac': '10:10:10:10:10:10',
+            '0-dhcp_expose': 'on',
+        }
+        data = {
+            'hostname': self.obj1.hostname,
+            'id': self.obj1.id,
+        }
+        data.update(self._prepare_inline_data(inline_data))
+        response = self.client.post(self.obj1.get_absolute_url(), data)
+        self.assertEqual(response.status_code, 200)
+        msg = 'Cannot expose in DHCP without IP address'
+        self.assertTrue(
+            any([msg in err for err in response.context_data['errors']])
+        )
+
+    def test_dhcp_expose_without_mac_for_existing_record_should_not_pass(self):
+        inline_data = {
+            'TOTAL_FORMS': 1,
+            'INITIAL_FORMS': 1,
+            '0-id': self.eth1.id,
+            '0-base_object': self.obj1.id,
+            '0-label': 'eht10',
+            '0-speed': EthernetSpeed.s100gbit.id,
+            '0-hostname': 'def',
+            '0-address': '127.0.0.2',
+            '0-mac': '',
+            '0-dhcp_expose': 'on',
+        }
+        data = {
+            'hostname': self.obj1.hostname,
+            'id': self.obj1.id,
+        }
+        data.update(self._prepare_inline_data(inline_data))
+        response = self.client.post(self.obj1.get_absolute_url(), data)
+        self.assertEqual(response.status_code, 200)
+        msg = 'Cannot expose in DHCP without MAC address'
+        self.assertTrue(
+            any([msg in err for err in response.context_data['errors']])
+        )
+
+    def test_dhcp_expose_without_hostname_for_existing_record_should_not_pass(self):  # noqa
+        inline_data = {
+            'TOTAL_FORMS': 1,
+            'INITIAL_FORMS': 1,
+            '0-id': self.eth1.id,
+            '0-base_object': self.obj1.id,
+            '0-label': 'eht10',
+            '0-speed': EthernetSpeed.s100gbit.id,
+            '0-hostname': '',
+            '0-address': '127.0.0.2',
+            '0-mac': '10:10:10:10:10:10',
+            '0-dhcp_expose': 'on',
+        }
+        data = {
+            'hostname': self.obj1.hostname,
+            'id': self.obj1.id,
+        }
+        data.update(self._prepare_inline_data(inline_data))
+        response = self.client.post(self.obj1.get_absolute_url(), data)
+        self.assertEqual(response.status_code, 200)
+        msg = 'Cannot expose in DHCP without hostname'
+        self.assertTrue(
+            any([msg in err for err in response.context_data['errors']])
+        )

--- a/src/ralph/networks/tests/test_forms.py
+++ b/src/ralph/networks/tests/test_forms.py
@@ -88,8 +88,6 @@ class NetworkInlineTestCase(RalphTestCase):
             '0-is_management': 'on',
 
             '1-base_object': self.obj1.id,
-            # '1-hostname': 'def',
-            # '1-address': '127.0.0.2',
             '1-mac': '10:20:30:40:50:60',
             '1-label': 'eth1',
             '1-speed': EthernetSpeed.s100gbit.id,
@@ -102,10 +100,6 @@ class NetworkInlineTestCase(RalphTestCase):
         response = self.client.post(self.obj1.get_absolute_url(), data)
         self.assertEqual(response.status_code, 302)
         eth = Ethernet.objects.get(mac='10:20:30:40:50:60')
-        # ip = IPAddress.objects.get(address='127.0.0.2')
-        # self.assertEqual(ip.hostname, 'def')
-        # self.assertFalse(ip.is_management)
-        # self.assertFalse(ip.dhcp_expose)
         self.assertEqual(eth.speed, EthernetSpeed.s100gbit.id)
         self.assertEqual(eth.label, 'eth1')
         self.assertEqual(eth.base_object.pk, self.obj1.pk)
@@ -129,8 +123,6 @@ class NetworkInlineTestCase(RalphTestCase):
             '1-base_object': self.obj1.id,
             '1-hostname': 'def',
             '1-address': '127.0.0.2',
-            # '1-mac': '10:20:30:40:50:60',
-            # '1-label': 'eth1',
             '1-speed': EthernetSpeed.unknown.id,
         }
         data = {

--- a/src/ralph/networks/tests/test_models.py
+++ b/src/ralph/networks/tests/test_models.py
@@ -4,6 +4,7 @@ from ddt import data, ddt, unpack
 from django.core.exceptions import ValidationError
 
 from ralph.assets.models import AssetLastHostname
+from ralph.assets.tests.factories import EthernetFactory
 from ralph.networks.models.choices import IPAddressStatus
 from ralph.networks.models.networks import IPAddress, Network
 from ralph.networks.tests.factories import (
@@ -374,5 +375,36 @@ class IPAddressTest(RalphTestCase):
         with self.assertRaises(
             ValidationError,
             msg='Cannot expose in DHCP without MAC address'
+        ):
+            self.ip.clean()
+
+    def test_change_hostname_with_dhcp_exposition_should_not_pass(self):  # noqa
+        self.ip.dhcp_expose = True
+        self.ip.save()
+        self.ip.hostname = 'another-hostname'
+        with self.assertRaises(
+            ValidationError,
+            msg='Cannot change hostname when exposing in DHCP'
+        ):
+            self.ip.clean()
+
+    def test_change_address_with_dhcp_exposition_should_not_pass(self):  # noqa
+        self.ip.dhcp_expose = True
+        self.ip.save()
+        self.ip.address = '127.0.0.2'
+        with self.assertRaises(
+            ValidationError,
+            msg='Cannot change address when exposing in DHCP'
+        ):
+            self.ip.clean()
+
+    def test_change_ethernet_with_dhcp_exposition_should_not_pass(self):  # noqa
+        eth = EthernetFactory()
+        self.ip.dhcp_expose = True
+        self.ip.save()
+        self.ip.ethernet = eth
+        with self.assertRaises(
+            ValidationError,
+            msg='Cannot change ethernet when exposing in DHCP'
         ):
             self.ip.clean()

--- a/src/ralph/networks/tests/test_models.py
+++ b/src/ralph/networks/tests/test_models.py
@@ -5,7 +5,10 @@ from ddt import data, ddt, unpack
 from ralph.assets.models import AssetLastHostname
 from ralph.networks.models.choices import IPAddressStatus
 from ralph.networks.models.networks import IPAddress, Network
-from ralph.networks.tests.factories import NetworkEnvironmentFactory
+from ralph.networks.tests.factories import (
+    IPAddressFactory,
+    NetworkEnvironmentFactory
+)
 from ralph.tests import RalphTestCase
 
 
@@ -314,3 +317,20 @@ class NetworkEnvironmentTest(RalphTestCase):
         # check if hostname is not increased
         self.assertEqual(ne.next_free_hostname, 's12300001.dc.local')
         self.assertEqual(ne.next_free_hostname, 's12300001.dc.local')
+
+
+class IPAddressTest(RalphTestCase):
+    def setUp(self):
+        self.ip = IPAddressFactory()
+
+    def test_delete_ethernet_should_delete_related_ip(self):
+        ip = IPAddressFactory()
+        ip.ethernet.delete()
+        with self.assertRaises(IPAddress.DoesNotExist):
+            ip.refresh_from_db()
+
+    def test_delete_ip_should_not_delete_ethernet(self):
+        ip = IPAddressFactory()
+        eth = ip.ethernet
+        ip.delete()
+        eth.refresh_from_db()

--- a/src/ralph/settings/base.py
+++ b/src/ralph/settings/base.py
@@ -309,6 +309,9 @@ ISSUE_TRACKER_URL = os.environ.get('ISSUE_TRACKER_URL', '')
 
 # Networks
 DEFAULT_NETWORK_MARGIN = int(os.environ.get('DEFAULT_NETWORK_MARGIN', 10))
+# when set to True, network records (IP/Ethernet) can't be modified until
+# 'expose in DHCP' is selected
+DHCP_ENTRY_FORBID_CHANGE = os_env_true('DHCP_ENTRY_FORBID_CHANGE', 'True')
 
 # enable integration with DNSaaS, for details see
 # https://github.com/allegro/django-powerdns-dnssec

--- a/src/ralph/tests/admin.py
+++ b/src/ralph/tests/admin.py
@@ -5,7 +5,16 @@ from ralph.admin import RalphAdmin, register
 from ralph.admin.m2m import RalphTabularM2MInline
 from ralph.attachments.admin import AttachmentsMixin
 from ralph.lib.transitions.admin import TransitionAdminMixin
-from ralph.tests.models import Bar, Car, Car2, Foo, Manufacturer, Order
+from ralph.networks.forms import NetworkInline
+from ralph.tests.models import (
+    Bar,
+    Car,
+    Car2,
+    Foo,
+    Manufacturer,
+    Order,
+    PolymorphicTestModel
+)
 
 
 @register(Car)
@@ -45,3 +54,9 @@ class ManufacturerAdmin(RalphAdmin):
 @register(Order)
 class OrderAdmin(AttachmentsMixin, TransitionAdminMixin, RalphAdmin):
     change_views = []
+
+
+@register(PolymorphicTestModel)
+class PolymorphicTestModelAdmin(RalphAdmin):
+    inlines = [NetworkInline]
+    exclude = ['service_env', 'parent', 'content_type']

--- a/src/ralph/tests/factories.py
+++ b/src/ralph/tests/factories.py
@@ -1,7 +1,7 @@
 import factory
 from django.contrib.auth import get_user_model
 
-from ralph.tests.models import Manufacturer, PolymorphicTestModel
+from ralph.tests.models import Manufacturer
 
 
 class UserFactory(factory.Factory):
@@ -43,10 +43,3 @@ class ManufacturerFactory(factory.django.DjangoModelFactory):
     class Meta:
         model = Manufacturer
         django_get_or_create = ['name', 'country']
-
-
-class PolymorphicTestModelFactory(factory.django.DjangoModelFactory):
-    hostname = factory.Sequence(lambda n: 'h{}'.format(n))
-
-    class Meta:
-        model = PolymorphicTestModel

--- a/src/ralph/tests/factories.py
+++ b/src/ralph/tests/factories.py
@@ -1,7 +1,7 @@
 import factory
 from django.contrib.auth import get_user_model
 
-from ralph.tests.models import Manufacturer
+from ralph.tests.models import Manufacturer, PolymorphicTestModel
 
 
 class UserFactory(factory.Factory):
@@ -43,3 +43,10 @@ class ManufacturerFactory(factory.django.DjangoModelFactory):
     class Meta:
         model = Manufacturer
         django_get_or_create = ['name', 'country']
+
+
+class PolymorphicTestModelFactory(factory.django.DjangoModelFactory):
+    hostname = factory.Sequence(lambda n: 'h{}'.format(n))
+
+    class Meta:
+        model = PolymorphicTestModel

--- a/src/ralph/tests/migrations/0008_polymorphictestmodel.py
+++ b/src/ralph/tests/migrations/0008_polymorphictestmodel.py
@@ -1,0 +1,26 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('assets', '0019_auto_20160525_1113'),
+        ('tests', '0007_order_remarks'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='PolymorphicTestModel',
+            fields=[
+                ('baseobject_ptr', models.OneToOneField(serialize=False, auto_created=True, primary_key=True, to='assets.BaseObject', parent_link=True)),
+                ('hostname', models.CharField(max_length=50)),
+            ],
+            options={
+                'abstract': False,
+            },
+            bases=('assets.baseobject',),
+        ),
+    ]

--- a/src/ralph/tests/models.py
+++ b/src/ralph/tests/models.py
@@ -190,3 +190,7 @@ class BaseObjectForeignKeyModel(models.Model):
             'data_center.DataCenterAsset'
         ]
     )
+
+
+class PolymorphicTestModel(AdminAbsoluteUrlMixin, BaseObject):
+    hostname = models.CharField(max_length=50)


### PR DESCRIPTION
Added additional field to IP address: `dhcp_expose`. When it's checked, trio (hostname, mac, ip) will be exposed in DHCP config. There are some constraints for this (when `dhcp_expose` is selected) in GUI and API:
- mac, hostname or ip could not be changed
- `dhcp_expose` could be changed only by transition

So it's easy to add entry to DHCP, but more complicated to remove it from DHCP (requires executing transition).
