### PR TITLE
Share params between transition actions

### DIFF
--- a/docs/development/transitions.md
+++ b/docs/development/transitions.md
@@ -1,7 +1,7 @@
 # Transitions
 The transition change state (e.g. status) of object from one to another - that's helps in product lifecycle management. For each object (asset, support, licence) you can define some workflow (set of transitions) and provide special actions for each transition.
 
-## Adding new action
+## Defining action
 You can easliy add new action by add method to your class and decorating with ``@transition_action``. For exmple:
 
 ```django
@@ -25,6 +25,8 @@ class Order(models.Model, metaclass=TransitionWorkflowBase):
 Now actions are available in admin panel when you can specify your workflow.
 
 ![Add transition](img/add_transitions.png)
+
+### Extra parameters
 
 If your action required extra parameters to execute you can add fields:
 ```django
@@ -59,6 +61,8 @@ Set ``only_one_action`` to ``True`` if the transition is to be only one action r
 
 Set ``return_attachment`` to ``True`` if action return attachment (e.g.: PDF document).
 
+### Storing additional data in transition history
+
 If you want to add additional information to the transition history, you need to add to the dictionary history_kwargs in your action:
 
 ```django
@@ -69,3 +73,13 @@ If you want to add additional information to the transition history, you need to
             ] = str(instance.user)
             instance.user = None
 ```
+
+### Share data between actions
+
+You could also share additional data between consecutive actions using `shared_params` in the same way as `history_kwargs`.
+
+### Rescheduling actions
+
+Asynchronous transition (action) is capable to reschedule it later (ex. when waiting for certain condition to be satisfied, instead of active waiting). To do this, just raise `ralph.lib.transitions.exceptions.RescheduleAsyncTransitionActionLater` exception in your action.
+
+> Both `history_kwargs` and `shared_params` are properly handled (and restored) when action is rescheduled later.

--- a/src/ralph/data_center/models/physical.py
+++ b/src/ralph/data_center/models/physical.py
@@ -31,7 +31,6 @@ from ralph.data_center.models.choices import (
 from ralph.lib.mixins.models import AdminAbsoluteUrlMixin
 from ralph.lib.transitions.decorators import transition_action
 from ralph.lib.transitions.fields import TransitionField
-from ralph.lib.transitions.exceptions import RescheduleAsyncTransitionActionLater
 from ralph.networks.models import IPAddress, NetworkEnvironment
 
 logger = logging.getLogger(__name__)
@@ -657,31 +656,6 @@ class DataCenterAsset(AutocompleteTooltipMixin, Asset):
                 # Save new asset to list, required to redirect url.
                 # RunTransitionView.get_success_url()
                 instances[i] = back_office_asset
-
-    @classmethod
-    @transition_action(
-        # is_async=True,
-        verbose_name='test_reschedule'
-    )
-    def test_reschedule(cls, instances, **kwargs):
-        reschedule = False
-        print(kwargs)
-        for instance in instances:
-            if not kwargs['shared_params'][instance.pk]:
-                reschedule = True
-            kwargs['shared_params'][instance.pk]['test'] = 1
-            kwargs['history_kwargs'][instance.pk]['test'] = 22
-        if reschedule:
-            raise RescheduleAsyncTransitionActionLater()
-
-    @classmethod
-    @transition_action(
-        # is_async=True,
-        verbose_name='test_reschedule22',
-        run_after=['test_reschedule']
-    )
-    def test_reschedule2(cls, instances, **kwargs):
-        print(kwargs)
 
 
 class Connection(models.Model):

--- a/src/ralph/lib/external_services/models.py
+++ b/src/ralph/lib/external_services/models.py
@@ -85,7 +85,7 @@ class Job(TimeStampMixin):
             ))
         return self._params
 
-    def _resave_params(self):
+    def _update_dumped_params(self):
         # re-save job to store updated params in DB
         self._dumped_params = self.prepare_params(**self.params)
         logger.debug('Updating _dumped_params to {}'.format(
@@ -98,7 +98,7 @@ class Job(TimeStampMixin):
         Reschedule the same job again.
         """
         # TODO: use rq scheduler
-        self._resave_params()
+        self._update_dumped_params()
         logger.info('Rescheduling {}'.format(self))
         service = InternalService(self.service_name)
         job = service.run_async(job_id=self.id)
@@ -108,7 +108,7 @@ class Job(TimeStampMixin):
         """
         Mark job as failed.
         """
-        self._resave_params()
+        self._update_dumped_params()
         logger.info('Job {} has failed. Reason: {}'.format(self, reason))
         self.status = JobStatus.FAILED
         self.save()
@@ -117,7 +117,7 @@ class Job(TimeStampMixin):
         """
         Mark job as successfuly ended.
         """
-        self._resave_params()
+        self._update_dumped_params()
         logger.info('Job {} has succeeded'.format(self))
         self.status = JobStatus.FINISHED
         self.save()

--- a/src/ralph/lib/transitions/async.py
+++ b/src/ralph/lib/transitions/async.py
@@ -2,7 +2,6 @@
 Asynchronous runner for transitions
 """
 import logging
-from collections import defaultdict
 
 from django.db import transaction
 

--- a/src/ralph/lib/transitions/conf.py
+++ b/src/ralph/lib/transitions/conf.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
 
-
+DEFAULT_ASYNC_TRANSITION_SERVICE_NAME = 'ASYNC_TRANSITIONS'
 TRANSITION_ATTR_TAG = 'transition_action'
+TRANSITION_ORIGINAL_STATUS = (0, 'Keep orginal status')

--- a/src/ralph/lib/transitions/exceptions.py
+++ b/src/ralph/lib/transitions/exceptions.py
@@ -14,3 +14,19 @@ class TransitionNotAllowedError(TransitionError):
 
 class TransitionModelNotFoundError(TransitionError):
     pass
+
+
+class RescheduleAsyncTransitionActionLater(Exception):
+    pass
+
+
+class AsyncTransitionError(TransitionError):
+    pass
+
+
+class MoreThanOneStartedActionError(AsyncTransitionError):
+    pass
+
+
+class FailedActionError(AsyncTransitionError):
+    pass

--- a/src/ralph/lib/transitions/models.py
+++ b/src/ralph/lib/transitions/models.py
@@ -588,6 +588,7 @@ class TransitionJobAction(TimeStampMixin):
         choices=TransitionJobActionStatus(),
         default=TransitionJobActionStatus.STARTED.id,
     )
+    # TODO: add retries field and max retries param for async action
 
 
 def update_models_attrs():

--- a/src/ralph/lib/transitions/models.py
+++ b/src/ralph/lib/transitions/models.py
@@ -226,7 +226,6 @@ def run_transition(instances, transition_obj_or_name, field, data={}, **kwargs):
                 instance,
                 transition=transition,
                 data=data,
-                # shared_params={instance.pk: {}},
                 **kwargs
             )
             job_ids.append(job_id)
@@ -553,7 +552,8 @@ class TransitionJob(Job):
             kwargs['data'] = {}
         for p in ['history_kwargs', 'shared_params']:
             if p not in kwargs:
-                # obj.pk will be casted to str when dumping json!
+                # obj.pk will be casted to str when dumping to json!
+                # (json needs str as the key of an object)
                 # we need to restore it in `_restore_params`
                 kwargs[p] = {obj.pk: {}}
         return super().run(service_name, defaults, request=request, **kwargs)

--- a/src/ralph/lib/transitions/models.py
+++ b/src/ralph/lib/transitions/models.py
@@ -33,24 +33,24 @@ from ralph.admin.helpers import (
 from ralph.attachments.models import Attachment
 from ralph.lib.external_services.models import Job
 from ralph.lib.mixins.models import TimeStampMixin
-from ralph.lib.transitions.conf import TRANSITION_ATTR_TAG
+from ralph.lib.transitions.conf import (
+    DEFAULT_ASYNC_TRANSITION_SERVICE_NAME,
+    TRANSITION_ATTR_TAG,
+    TRANSITION_ORIGINAL_STATUS
+)
 from ralph.lib.transitions.exceptions import (
     TransitionModelNotFoundError,
     TransitionNotAllowedError
 )
 from ralph.lib.transitions.fields import TransitionField
+from ralph.lib.transitions.utils import (
+    _compare_instances_types,
+    _sort_graph_topologically
+)
 
 _transitions_fields = {}
 
 logger = logging.getLogger(__name__)
-
-
-TRANSITION_ORIGINAL_STATUS = (0, 'Keep orginal status')
-DEFAULT_ASYNC_TRANSITION_SERVICE_NAME = 'ASYNC_TRANSITIONS'
-
-
-class CycleError(Exception):
-    pass
 
 
 def _generate_transition_history(
@@ -116,17 +116,6 @@ def _get_history_dict(data, instance, runned_funcs):
                 field_name = field.label
             history[str(field_name)] = value
     return history
-
-
-def _check_type_instances(instances):
-    """Function check type of instances.
-    Conditions:
-        - transition can run only objects with the same type.
-    """
-    if not all(
-        map(lambda x: isinstance(instances[0], x.__class__), instances)
-    ):
-        raise NotImplementedError()
 
 
 def _check_and_get_transition(obj, transition, field):
@@ -214,29 +203,6 @@ def _create_graph_from_actions(actions, instance):
     return {k: v for (k, v) in graph.items() if k in actions_set}
 
 
-def _sort_graph_topologically(graph):
-    # calculate input degree (number of nodes pointing to particular node)
-    indeg = {k: 0 for k in graph}
-    for node, edges in graph.items():
-        for edge in edges:
-            indeg[edge] += 1
-    # sort graph topologically
-    # return nodes which input degree is 0
-    no_requirements = set([a for a in indeg if indeg.get(a, 0) == 0])
-    while no_requirements:
-        action_name = no_requirements.pop()
-        # for each node to which this one is pointing - decrease input degree
-        for dependency in graph[action_name]:
-            indeg[dependency] -= 1
-            # add to set of nodes ready to be returned (without nodes pointing
-            # to it)
-            if indeg[dependency] == 0:
-                no_requirements.add(dependency)
-        yield action_name
-    if any(indeg.values()):
-        raise CycleError("Cycle detected during topological sort")
-
-
 def _order_actions_by_requirements(actions, instance):
     graph = _create_graph_from_actions(actions, instance)
     actions_by_name = {a.name: a for a in actions}
@@ -260,7 +226,7 @@ def run_transition(instances, transition_obj_or_name, field, data={}, **kwargs):
                 instance,
                 transition=transition,
                 data=data,
-                history={instance.pk: {}},
+                # shared_params={instance.pk: {}},
                 **kwargs
             )
             job_ids.append(job_id)
@@ -271,11 +237,26 @@ def run_transition(instances, transition_obj_or_name, field, data={}, **kwargs):
         )
 
 
-def _prepare_action_data(action, data, func_history_kwargs=None, **kwargs):
+def _prepare_action_data(
+    action, data, history_kwargs=None, shared_params=None, **kwargs
+):
+    """
+    Prepare data for single transition action
+
+    Args:
+        action: Action instance
+        data: dict with
+    """
     defaults = data.copy()
     defaults.update(kwargs)
-    if func_history_kwargs is not None:
-        defaults.update({'history_kwargs': func_history_kwargs})
+    if history_kwargs is not None:
+        defaults.update({'history_kwargs': history_kwargs})
+    if shared_params is not None:
+        defaults.update({'shared_params': shared_params})
+    # for current action, strip action name from param
+    # for example if current action is `test`, and it has param `abc`,
+    # `test__abc` is stored in and additional param `abc` will be passed to
+    # this action
     defaults.update({
         key.split('__')[1]: value
         for key, value in data.items()
@@ -289,13 +270,14 @@ def _save_instance_after_transition(instance, transition, user=None):
     if not any([a.disable_save_object for a in transition.get_pure_actions()]):
         with transaction.atomic(), reversion.create_revision():
             instance.save()
+            # TODO: store changed fields
             reversion.set_comment('Transition {}'.format(transition))
             if user:
                 reversion.set_user(user)
 
 
 def _create_instance_history_entry(
-    instance, transition, data, func_history_kwargs, user=None, attachment=None
+    instance, transition, data, history_kwargs, user=None, attachment=None
 ):
     funcs = transition.get_pure_actions()
     action_names = [str(getattr(
@@ -303,14 +285,14 @@ def _create_instance_history_entry(
         'verbose_name',
         func.__name__.replace('_', ' ').capitalize()
     )) for func in funcs]
-    history_kwargs = _get_history_dict(data, instance, funcs)
-    history_kwargs.update(func_history_kwargs[instance.pk])
+    history = _get_history_dict(data, instance, funcs)
+    history.update(history_kwargs.get(instance.pk, {}))
     transition_history = _generate_transition_history(
         instance=instance,
         transition=transition,
         user=user,
         attachment=attachment,
-        history_kwargs=history_kwargs,
+        history_kwargs=history,
         action_names=action_names,
         field=transition.model.field_name
     )
@@ -318,13 +300,13 @@ def _create_instance_history_entry(
 
 
 def _post_transition_instance_processing(
-    instance, transition, data, func_history_kwargs, user=None, attachment=None
+    instance, transition, data, history_kwargs, user=None, attachment=None
 ):
     # change transition field (ex. status) if not keeping orignial
     if not int(transition.target) == TRANSITION_ORIGINAL_STATUS[0]:
         setattr(instance, transition.model.field_name, int(transition.target))
     _create_instance_history_entry(
-        instance, transition, data, func_history_kwargs,
+        instance, transition, data, history_kwargs,
         user=user, attachment=attachment
     )
     _save_instance_after_transition(
@@ -340,14 +322,15 @@ def run_field_transition(
     Execute all actions assigned to the selected transition.
     """
     first_instance = instances[0]
-    _check_type_instances(instances)
+    _compare_instances_types(instances)
     transition = _check_and_get_transition(
         first_instance, transition_obj_or_name, field
     )
     _check_instances_for_transition(instances, transition)
     _check_action_with_instances(instances, transition)
     attachment = None
-    func_history_kwargs = defaultdict(dict)
+    history_kwargs = defaultdict(dict)
+    shared_params = defaultdict(dict)
     for action in _order_actions_by_requirements(
         transition.actions.all(), first_instance
     ):
@@ -356,7 +339,11 @@ def run_field_transition(
         ))
         func = getattr(first_instance, action.name)
         defaults = _prepare_action_data(
-            action, data, func_history_kwargs, **kwargs
+            action,
+            data,
+            history_kwargs=history_kwargs,
+            shared_params=shared_params,
+            **kwargs
         )
         try:
             result = func(instances=instances, **defaults)
@@ -368,7 +355,7 @@ def run_field_transition(
             attachment = result
     for instance in instances:
         _post_transition_instance_processing(
-            instance, transition, data, func_history_kwargs,
+            instance, transition, data, history_kwargs=history_kwargs,
             user=kwargs['request'].user, attachment=attachment,
         )
     return True, attachment
@@ -564,9 +551,29 @@ class TransitionJob(Job):
         )
         if 'data' not in kwargs:
             kwargs['data'] = {}
-        if 'history_kwargs' not in kwargs:
-            kwargs['history_kwargs'] = {obj.pk: {}}
+        for p in ['history_kwargs', 'shared_params']:
+            if p not in kwargs:
+                # obj.pk will be casted to str when dumping json!
+                # we need to restore it in `_restore_params`
+                kwargs[p] = {obj.pk: {}}
         return super().run(service_name, defaults, request=request, **kwargs)
+
+    @classmethod
+    def _restore_params(cls, obj):
+        params = super()._restore_params(obj)
+        # fix history_kwargs and shared_params key (from str to int)
+        for param_name in ['history_kwargs', 'shared_params']:
+            param = params.get(param_name, {}).copy()
+            new_param = defaultdict(dict)
+            for k, v in param.items():
+                try:
+                    k = int(k)
+                except ValueError:
+                    # pk is not int (ex. uid)
+                    pass
+                new_param[k] = v
+            params[param_name] = new_param
+        return params
 
 
 class TransitionJobAction(TimeStampMixin):

--- a/src/ralph/lib/transitions/templates/transitions/current_transitions.html
+++ b/src/ralph/lib/transitions/templates/transitions/current_transitions.html
@@ -10,7 +10,7 @@
 
 {% block view_content %}
     <h1>{% trans "Current transitions" %}</h1>
-    {% include "transitions/_transition_jobs_table.html" with jobs=job_in_progress %}
+    {% include "transitions/_transition_jobs_table.html" with jobs=jobs_in_progress %}
 
     <h1>{% trans "Finished transitions" %}</h1>
     {# TODO: add pagination etc #}

--- a/src/ralph/lib/transitions/tests/test_models.py
+++ b/src/ralph/lib/transitions/tests/test_models.py
@@ -11,8 +11,6 @@ from ralph.lib.transitions.exceptions import (
 from ralph.lib.transitions.models import (
     _check_and_get_transition,
     _create_graph_from_actions,
-    _sort_graph_topologically,
-    CycleError,
     run_field_transition,
     Transition
 )
@@ -217,25 +215,3 @@ class TransitionsTest(TransitionTestCase):
         self.assertEqual(graph, {
             'go_to_post_office': [],
         })
-
-    def test_topological_sort(self):
-        graph = {
-            1: [],
-            2: [1, 4],
-            3: [],
-            4: [1]
-        }
-        order = [a for a in _sort_graph_topologically(graph)]
-        # order of 2 and 3 doesn't matter
-        self.assertEqual(set(order[:2]), set([2, 3]))
-        self.assertEqual(order[2:], [4, 1])
-
-    def test_topological_sort_cycle(self):
-        graph = {
-            1: [2],
-            2: [1, 4],
-            3: [],
-            4: [1]
-        }
-        with self.assertRaises(CycleError):
-            [a for a in _sort_graph_topologically(graph)]

--- a/src/ralph/lib/transitions/tests/test_utils.py
+++ b/src/ralph/lib/transitions/tests/test_utils.py
@@ -1,0 +1,27 @@
+from django.test import TestCase
+
+from ralph.lib.transitions.utils import _sort_graph_topologically, CycleError
+
+
+class TopologicalSortTest(TestCase):
+    def test_topological_sort(self):
+        graph = {
+            1: [],
+            2: [1, 4],
+            3: [],
+            4: [1]
+        }
+        order = [a for a in _sort_graph_topologically(graph)]
+        # order of 2 and 3 doesn't matter
+        self.assertEqual(set(order[:2]), set([2, 3]))
+        self.assertEqual(order[2:], [4, 1])
+
+    def test_topological_sort_cycle(self):
+        graph = {
+            1: [2],
+            2: [1, 4],
+            3: [],
+            4: [1]
+        }
+        with self.assertRaises(CycleError):
+            [a for a in _sort_graph_topologically(graph)]

--- a/src/ralph/lib/transitions/utils.py
+++ b/src/ralph/lib/transitions/utils.py
@@ -1,0 +1,47 @@
+
+
+class CycleError(Exception):
+    pass
+
+
+def _sort_graph_topologically(graph):
+    """
+    Sort directed graph topologicaly.
+
+    Args:
+        graph: dict of lists (key is node name, value if list of neighbours)
+
+    Returns:
+        generator of nodes in topoligical order
+    """
+    # calculate input degree (number of nodes pointing to particular node)
+    indeg = {k: 0 for k in graph}
+    for node, edges in graph.items():
+        for edge in edges:
+            indeg[edge] += 1
+    # sort graph topologically
+    # return nodes which input degree is 0
+    no_requirements = set([a for a in indeg if indeg.get(a, 0) == 0])
+    while no_requirements:
+        next_node = no_requirements.pop()
+        # for each node to which this one is pointing - decrease input degree
+        for dependency in graph[next_node]:
+            indeg[dependency] -= 1
+            # add to set of nodes ready to be returned (without nodes pointing
+            # to it)
+            if indeg[dependency] == 0:
+                no_requirements.add(dependency)
+        yield next_node
+    if any(indeg.values()):
+        raise CycleError("Cycle detected during topological sort")
+
+
+def _compare_instances_types(instances):
+    """Function check type of instances.
+    Conditions:
+        - transition can run only objects with the same type.
+    """
+    if not all(
+        map(lambda x: isinstance(instances[0], x.__class__), instances)
+    ):
+        raise TypeError()

--- a/src/ralph/lib/transitions/views.py
+++ b/src/ralph/lib/transitions/views.py
@@ -212,7 +212,7 @@ class TransitionViewMixin(object):
     def get_async_transitions_awaiter_url(self, job_ids):
         return '{}?{}'.format(
             reverse('async_bulk_transitions_awaiter'),
-            urlencode(MultiValueDict({'jobid': job_ids}))
+            urlencode(MultiValueDict([('jobid', job_id) for job_id in job_ids]))
         )
 
     def get_success_url(self):

--- a/src/ralph/tests/models.py
+++ b/src/ralph/tests/models.py
@@ -149,6 +149,8 @@ class AsyncOrder(
         instance = instances[0]  # only one instance in asyc action
         instance.counter += 1
         instance.save()
+        kwargs['shared_params'][instance.pk]['counter'] = instance.counter
+        kwargs['history_kwargs'][instance.pk]['hist_counter'] = instance.counter
         if instance.counter < 5:
             raise RescheduleAsyncTransitionActionLater()
         instance.foo = kwargs['foo']
@@ -171,6 +173,7 @@ class AsyncOrder(
         is_async=True,
     )
     def failing_action(cls, instances, **kwargs):
+        kwargs['shared_params'][instances[0].pk]['test'] = 'failing'
         raise ValueError()
 
 


### PR DESCRIPTION
Transition actions could share params using `shared_params` dict.

Other fixes and improvements:
- async transition properly restore history and shared params when action was rescheduled
- start of refactorization of `ralph.lib.transitions.models`

TODO:
- [x] tests (both sync and async)
- [x] docs
- [x] cleanup
