### PR TITLE
Nullable hostname

### DIFF
--- a/src/ralph/assets/migrations/0011_auto_20160603_0742.py
+++ b/src/ralph/assets/migrations/0011_auto_20160603_0742.py
@@ -1,0 +1,39 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+import ralph.lib.mixins.fields
+
+
+def migrate_hostname(apps, schema_editor):
+    Asset = apps.get_model('assets', 'Asset')
+    # update all assets where hostname is empty string to null hostname
+    Asset.objects.filter(hostname='').update(hostname=None)
+
+
+def rev_migrate_hostname(apps, schema_editor):
+    Asset = apps.get_model('assets', 'Asset')
+    Asset.objects.filter(hostname__isnull=True).update(hostname='')
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('assets', '0010_auto_20160405_1531'),
+    ]
+
+    operations = [
+        migrations.RunPython(
+            migrate_hostname,
+            # this reverse has te be executed after altering field back to
+            # CharField in reverse migration to use `CharField.to_python`
+            # (to get '') instead of `NullableCharField.to_python`
+            # (which returns None)
+            rev_migrate_hostname
+        ),
+        migrations.AlterField(
+            model_name='asset',
+            name='hostname',
+            field=ralph.lib.mixins.fields.NullableCharField(default=None, max_length=255, blank=True, null=True, verbose_name='hostname'),
+        ),
+    ]

--- a/src/ralph/assets/models/assets.py
+++ b/src/ralph/assets/models/assets.py
@@ -281,7 +281,7 @@ class BudgetInfo(NamedMixin, TimeStampMixin, models.Model):
 
 class Asset(AdminAbsoluteUrlMixin, BaseObject):
     model = models.ForeignKey(AssetModel, related_name='assets')
-    hostname = models.CharField(
+    hostname = NullableCharField(
         blank=True,
         default=None,
         max_length=255,

--- a/src/ralph/back_office/tests/test_models.py
+++ b/src/ralph/back_office/tests/test_models.py
@@ -45,7 +45,7 @@ class HostnameGeneratorTests(RalphTestCase):
     def _check_hostname_not_generated(self, asset):
         asset._try_assign_hostname(True)
         changed_asset = BackOfficeAsset.objects.get(pk=asset.id)
-        self.assertEqual(changed_asset.hostname, '')
+        self.assertIsNone(changed_asset.hostname)
 
     def _check_hostname_is_generated(self, asset):
         asset._try_assign_hostname(True)

--- a/src/ralph/lib/mixins/fields.py
+++ b/src/ralph/lib/mixins/fields.py
@@ -40,9 +40,6 @@ class NullableCharFieldMixin(object):
     """
     _formfield_class = NullableCharFormField
 
-    def to_python(self, value):
-        return super().to_python(value) or ''
-
     def get_prep_value(self, value):
         return super().get_prep_value(value) or None
 

--- a/src/ralph/reports/tests.py
+++ b/src/ralph/reports/tests.py
@@ -181,7 +181,7 @@ class TestReportAssetAndLicence(RalphTestCase):
                 'hostname', 'tags'
             ],
             [
-                str(self.dc_1.id), '', self.dc_1.barcode, self.dc_1.sn,
+                str(self.dc_1.id), 'None', self.dc_1.barcode, self.dc_1.sn,
                 'Keyboard', 'M1', '1', 'None', str(self.dc_1.invoice_date),
                 str(self.dc_1.invoice_no), self.dc_1.hostname, 'tag1,tag2'
             ]
@@ -230,7 +230,7 @@ class TestReportAssetAndLicence(RalphTestCase):
                 'N/A', 'Project Info', '1', '0.00',
                 str(self.licence.invoice_date), str(self.licence.invoice_no),
                 str(self.dc_1.id), self.dc_1.asset.barcode,
-                '', 'None', 'None', 'None', 'None', 'None', 'None', 'None',
+                'None', 'None', 'None', 'None', 'None', 'None', 'None', 'None',
                 '', '', '', ''
             ]
         ]


### PR DESCRIPTION
Change `hostname` of `Asset` (`DataCenterAsset` and `BackOfficeAsset`) to `NullableCharField`. This will result in saving empty `hostname` as `null` instead of empty string (`''`) to the database, which might help in the future using `hostname` column as a "clickable" column in admin or to mark `hostname` as unique (`null != null`, but `'' == ''`).

There is also minor change in `NullableCharField` as well - `to_python` now returns `None` instead of `''` in case of empty value - this affects only read-only views (like admin listing) - form fields would work as usual.
