### PR TITLE
Fix sitetree for Data Center.

### DIFF
--- a/src/ralph/admin/sitetrees.py
+++ b/src/ralph/admin/sitetrees.py
@@ -103,7 +103,6 @@ sitetrees = [
                 section(_('Server Rooms'), 'data_center', 'ServerRoom'),
                 section(_('VIPs'), 'data_center', 'VIP'),
                 section(_('Virtual Servers'), 'virtual', 'VirtualServer'),
-                section(_('IP Addresses'), 'data_center', 'ipaddress'),
                 section(_('Clusters'), 'data_center', 'cluster'),
             ],
         ),


### PR DESCRIPTION
Before this fix, I get this error when `make site tree`:

```
File "/home/vagrant/src/ralph/src/ralph/admin/sitetrees.py", line 106, in <module>
  section(_('IP Addresses'), 'data_center', 'ipaddress'),
File "/home/vagrant/src/ralph/src/ralph/admin/sitetrees.py", line 55, in section
  model_class = apps.get_model(app, model)
File "/home/vagrant/lib/python3.4/site-packages/django/apps/registry.py", line 202, in get_model
  return self.get_app_config(app_label).get_model(model_name.lower())
File "/home/vagrant/lib/python3.4/site-packages/django/apps/config.py", line 162, in get_model
  "App '%s' doesn't have a '%s' model." % (self.label, model_name))
LookupError: App 'data_center' doesn't have a 'ipaddress' model.
```
