### PR TITLE
Revert "Add sputnik to travis.yml"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -51,7 +51,6 @@ install:
     - gulp
     - make install-test
     - pip install coveralls
-    - pip install pylint
     - pip install django==$DJANGO_VERSION
 
 script:
@@ -60,7 +59,6 @@ script:
 
 after_success:
     - if [[ $TEST_DB_ENGINE == mysql ]]; then coveralls; fi
-    - python <(curl -s https://raw.githubusercontent.com/TouK/sputnik-ci/master/sputnik-ci.py)
 
 before_deploy:
     - sudo add-apt-repository -y ppa:spotify-jyrki/dh-virtualenv


### PR DESCRIPTION
Reverts allegro/ralph#2451. Sputnik (pylint) is working terribly in django (Ralph) project. See #2469 or #2463 for examples. Maybe it'll work better after tweaking pylint but we don't have time for it now.
