### PR TITLE
Revert filter DataCenterAsset by service id and name

### DIFF
--- a/src/ralph/data_center/api/views.py
+++ b/src/ralph/data_center/api/views.py
@@ -53,7 +53,11 @@ class DataCenterAssetViewSet(BaseObjectViewSetMixin, RalphAPIViewSet):
         'connections',
         'tags',
     ]
-    filter_fields = ['service_env__service__uid']
+    filter_fields = [
+        'service_env__service__uid',
+        'service_env__service__name',
+        'service_env__service__id',
+    ]
     additional_filter_class = DataCenterAssetFilterSet
 
 

--- a/src/ralph/data_center/tests/test_api.py
+++ b/src/ralph/data_center/tests/test_api.py
@@ -177,8 +177,24 @@ class DataCenterAssetAPITests(RalphAPITestCase):
         )
 
     def test_filter_by_service_uid2(self):
-        url = reverse('datacenterasset-list') + '?service_env__service__uid={}'.format(  # noqa
-            self.dc_asset.service_env.service.uid,
+        url = (
+            reverse('datacenterasset-list') +
+            '?service_env__service__uid={}'.format(
+                self.dc_asset.service_env.service.uid,
+            )
+        )
+        response = self.client.get(url, format='json')
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(
+            response.data['count'], 1
+        )
+
+    def test_filter_by_service_id(self):
+        url = (
+            reverse('datacenterasset-list') +
+            '?service_env__service__id={}'.format(
+                self.dc_asset.service_env.service.id,
+            )
         )
         response = self.client.get(url, format='json')
         self.assertEqual(response.status_code, status.HTTP_200_OK)
@@ -189,6 +205,19 @@ class DataCenterAssetAPITests(RalphAPITestCase):
     def test_filter_by_service_name(self):
         url = reverse('datacenterasset-list') + '?service={}'.format(
             self.dc_asset.service_env.service.name,
+        )
+        response = self.client.get(url, format='json')
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(
+            response.data['count'], 1
+        )
+
+    def test_filter_by_service_name2(self):
+        url = (
+            reverse('datacenterasset-list') +
+            '?service_env__service__name={}'.format(
+                self.dc_asset.service_env.service.name,
+            )
         )
         response = self.client.get(url, format='json')
         self.assertEqual(response.status_code, status.HTTP_200_OK)


### PR DESCRIPTION
It was accidentally removed in feature/deployment
