### PR TITLE
network components in API improvements & performance improvements for DataCenterAsset and Virtual Server

### DIFF
--- a/src/ralph/assets/api/serializers.py
+++ b/src/ralph/assets/api/serializers.py
@@ -30,6 +30,7 @@ from ralph.assets.models import (
 from ralph.assets.models.components import Ethernet
 from ralph.lib.custom_fields.api import WithCustomFieldsSerializerMixin
 from ralph.licences.api_simple import SimpleBaseObjectLicenceSerializer
+from ralph.networks.api_simple import IPAddressSimpleSerializer
 
 
 class BusinessSegmentSerializer(RalphAPISerializer):
@@ -255,7 +256,16 @@ class AssetSerializer(BaseObjectSerializer):
         model = Asset
 
 
-class EthernetSerializer(RalphAPISerializer):
+class EthernetSimpleSerializer(RalphAPISerializer):
+    ipaddress = IPAddressSimpleSerializer()
+
+    class Meta:
+        model = Ethernet
+        fields = ('id', 'mac', 'ipaddress', 'url')
+
+
+class EthernetSerializer(EthernetSimpleSerializer):
+
     class Meta:
         model = Ethernet
         depth = 1

--- a/src/ralph/assets/api/views.py
+++ b/src/ralph/assets/api/views.py
@@ -6,6 +6,7 @@ from ralph.api import RalphAPIViewSet
 from ralph.api.utils import PolymorphicViewSetMixin
 from ralph.assets import models
 from ralph.assets.api import serializers
+from ralph.lib.custom_fields.models import CustomFieldValue
 from ralph.licences.api import BaseObjectLicenceViewSet
 from ralph.licences.models import BaseObjectLicence
 from ralph.networks.models import IPAddress
@@ -77,6 +78,10 @@ class BaseObjectViewSet(PolymorphicViewSetMixin, RalphAPIViewSet):
         Prefetch('licences', queryset=BaseObjectLicence.objects.select_related(
             *BaseObjectLicenceViewSet.select_related
         )),
+        Prefetch(
+            'custom_fields',
+            queryset=CustomFieldValue.objects.select_related('custom_field')
+        )
     ]
     filter_fields = [
         'id', 'service_env', 'service_env', 'service_env__service__uid',

--- a/src/ralph/assets/api/views.py
+++ b/src/ralph/assets/api/views.py
@@ -100,7 +100,7 @@ class AssetHolderViewSet(RalphAPIViewSet):
 class EthernetViewSet(RalphAPIViewSet):
     queryset = models.Ethernet.objects.all()
     serializer_class = serializers.EthernetSerializer
-    filter_fields = ['base_object']
+    filter_fields = ['base_object', 'ipaddress__address']
     prefetch_related = ['model', 'base_object', 'base_object__tags']
 
     def destroy(self, request, *args, **kwargs):

--- a/src/ralph/assets/tests/factories.py
+++ b/src/ralph/assets/tests/factories.py
@@ -15,7 +15,7 @@ from ralph.assets.models.assets import (
     ServiceEnvironment
 )
 from ralph.assets.models.base import BaseObject
-from ralph.assets.models.choices import ComponentType, ObjectModelType
+from ralph.assets.models.choices import ObjectModelType
 from ralph.assets.models.components import Ethernet
 from ralph.assets.models.configuration import (
     ConfigurationClass,
@@ -183,6 +183,13 @@ class EthernetFactory(DjangoModelFactory):
     class Meta:
         model = Ethernet
         django_get_or_create = ['label']
+
+
+class EthernetWithIPAddressFactory(EthernetFactory):
+    ipaddress = factory.RelatedFactory(
+        'ralph.networks.tests.factories.IPAddressWithNetworkFactory',
+        'ethernet'
+    )
 
 
 class ConfigurationModuleFactory(DjangoModelFactory):

--- a/src/ralph/data_center/admin.py
+++ b/src/ralph/data_center/admin.py
@@ -258,7 +258,8 @@ class DataCenterAssetAdmin(
     list_select_related = [
         'model', 'model__manufacturer', 'model__category', 'rack',
         'rack__server_room', 'rack__server_room__data_center', 'service_env',
-        'service_env__service', 'service_env__environment', 'configuration_path'
+        'service_env__service', 'service_env__environment',
+        'configuration_path__module',
     ]
     raw_id_fields = [
         'model', 'rack', 'service_env', 'parent', 'budget_info',

--- a/src/ralph/data_center/api/serializers.py
+++ b/src/ralph/data_center/api/serializers.py
@@ -98,11 +98,13 @@ class ComponentSerializerMixin(serializers.Serializer):
         """
         # don't use `ipaddresses` property here to make use of
         # `ethernet__ipaddresses` in prefetch related
-        return [
-            eth.ipaddress.address
-            for eth in instance.ethernet.all()
-            if eth.ipaddress
-        ]
+        ipaddresses = []
+        for eth in instance.ethernet.all():
+            try:
+                ipaddresses.append(eth.ipaddress.address)
+            except AttributeError:
+                pass
+        return ipaddresses
 
 
 class RackSerializer(RalphAPISerializer):

--- a/src/ralph/data_center/api/serializers.py
+++ b/src/ralph/data_center/api/serializers.py
@@ -2,8 +2,11 @@
 from rest_framework import fields, serializers
 
 from ralph.api import RalphAPISerializer
-from ralph.assets.api.serializers import AssetSerializer, BaseObjectSerializer
-from ralph.assets.api.serializers import EthernetSimpleSerializer
+from ralph.assets.api.serializers import (
+    AssetSerializer,
+    BaseObjectSerializer,
+    EthernetSimpleSerializer
+)
 from ralph.data_center.models import (
     Accessory,
     BaseObjectCluster,

--- a/src/ralph/data_center/api/serializers.py
+++ b/src/ralph/data_center/api/serializers.py
@@ -87,7 +87,19 @@ class ComponentSerializerMixin(serializers.Serializer):
     ipaddresses = fields.SerializerMethodField()
 
     def get_ipaddresses(self, instance):
-        return instance.ipaddresses.values_list('address', flat=True)
+        """
+        Return list of ip addresses for passed instance.
+
+        Returns:
+            list of ip addresses (as strings)
+        """
+        # don't use `ipaddresses` property here to make use of
+        # `ethernet__ipaddresses` in prefetch related
+        return [
+            eth.ipaddress.address
+            for eth in instance.ethernet.all()
+            if eth.ipaddress
+        ]
 
 
 class RackSerializer(RalphAPISerializer):

--- a/src/ralph/data_center/api/serializers.py
+++ b/src/ralph/data_center/api/serializers.py
@@ -1,9 +1,9 @@
 # -*- coding: utf-8 -*-
-from rest_framework import serializers
+from rest_framework import fields, serializers
 
 from ralph.api import RalphAPISerializer
 from ralph.assets.api.serializers import AssetSerializer, BaseObjectSerializer
-from ralph.assets.models.components import Ethernet
+from ralph.assets.api.serializers import EthernetSimpleSerializer
 from ralph.data_center.models import (
     Accessory,
     BaseObjectCluster,
@@ -81,21 +81,13 @@ class SimpleRackSerializer(RalphAPISerializer):
         exclude = ('accessories',)
 
 
-class EthernetSerializer(RalphAPISerializer):
-    class Meta:
-        model = Ethernet
-        depth = 1
-
-
+# used by DataCenterAsset and VirtualServer serializers
 class ComponentSerializerMixin(serializers.Serializer):
-    # ethernets = EthernetSerializer()
-    # disk_shares = ..
-    # ipaddresses = SimpleIPAddressesSerializer()
-    # mac_addresses = SimpleRackSerializer()
-    service = serializers.SerializerMethodField('get_service_env')
+    ethernet = EthernetSimpleSerializer(many=True)
+    ipaddresses = fields.SerializerMethodField()
 
-    def get_service_env(self, obj):
-        return ''
+    def get_ipaddresses(self, instance):
+        return instance.ipaddresses.values_list('address', flat=True)
 
 
 class RackSerializer(RalphAPISerializer):

--- a/src/ralph/data_center/api/views.py
+++ b/src/ralph/data_center/api/views.py
@@ -1,9 +1,10 @@
 # -*- coding: utf-8 -*-
-
+from django.db.models import Prefetch
 
 from ralph.api import RalphAPIViewSet
 from ralph.assets.api.filters import NetworkableObjectFilters
 from ralph.assets.api.views import BaseObjectViewSet, BaseObjectViewSetMixin
+from ralph.assets.models import Ethernet
 from ralph.data_center.admin import DataCenterAssetAdmin
 from ralph.data_center.api.serializers import (
     AccessorySerializer,
@@ -47,11 +48,12 @@ class DataCenterAssetViewSet(BaseObjectViewSetMixin, RalphAPIViewSet):
         'property_of', 'budget_info'
     ]
     prefetch_related = BaseObjectViewSet.prefetch_related + [
-        'service_env__service__environments',
-        'service_env__service__business_owners',
-        'service_env__service__technical_owners',
         'connections',
         'tags',
+        Prefetch(
+            'ethernet',
+            queryset=Ethernet.objects.select_related('ipaddress')
+        ),
     ]
     filter_fields = [
         'service_env__service__uid',

--- a/src/ralph/data_center/tests/factories.py
+++ b/src/ralph/data_center/tests/factories.py
@@ -10,6 +10,7 @@ from ralph.assets.tests.factories import (
     BudgetInfoFactory,
     ConfigurationClassFactory,
     DataCenterAssetModelFactory,
+    EthernetWithIPAddressFactory,
     ServiceEnvironmentFactory
 )
 from ralph.data_center.models.physical import (
@@ -113,6 +114,49 @@ class DataCenterAssetFactory(DjangoModelFactory):
 
     class Meta:
         model = DataCenterAsset
+
+
+class DataCenterAssetFullFactory(DataCenterAssetFactory):
+    """
+    Factory for DataCenterAsset and m2m relations
+    """
+    rack = factory.SubFactory(RackFactory)
+    # TODO: parent, licences, supports, networks (as terminators), operations,
+    # security scans, clusters, tags
+
+    eth1 = factory.RelatedFactory(
+        EthernetWithIPAddressFactory,
+        'base_object',
+        ipaddress__is_management=True,
+    )
+    eth2 = factory.RelatedFactory(
+        EthernetWithIPAddressFactory,
+        'base_object',
+
+    )
+    eth3 = factory.RelatedFactory(
+        EthernetWithIPAddressFactory,
+        'base_object',
+        ipaddress__dhcp_expose=True,
+    )
+
+    licence1 = factory.RelatedFactory(
+        'ralph.licences.tests.factories.BaseObjectLicenceFactory', 'base_object'
+    )
+    licence2 = factory.RelatedFactory(
+        'ralph.licences.tests.factories.BaseObjectLicenceFactory',
+        'base_object',
+        quantity=3
+    )
+
+    # support1 = factory.RelatedFactory(
+    #     'ralph.supports.tests.factories.BaseObjectsSupportFactory',
+    #     'baseobject'
+    # )
+    # support2 = factory.RelatedFactory(
+    #     'ralph.supports.tests.factories.BaseObjectsSupportFactory',
+    #     'baseobject'
+    # )
 
 
 class DatabaseFactory(DjangoModelFactory):

--- a/src/ralph/data_center/tests/factories.py
+++ b/src/ralph/data_center/tests/factories.py
@@ -10,6 +10,7 @@ from ralph.assets.tests.factories import (
     BudgetInfoFactory,
     ConfigurationClassFactory,
     DataCenterAssetModelFactory,
+    EthernetFactory,
     EthernetWithIPAddressFactory,
     ServiceEnvironmentFactory
 )
@@ -121,18 +122,16 @@ class DataCenterAssetFullFactory(DataCenterAssetFactory):
     Factory for DataCenterAsset and m2m relations
     """
     rack = factory.SubFactory(RackFactory)
-    # TODO: parent, licences, supports, networks (as terminators), operations,
-    # security scans, clusters, tags
 
+    # m2m relations
+    # TODO: parent, networks (as terminators), operations, security scans,
+    # clusters, tags
     eth1 = factory.RelatedFactory(
         EthernetWithIPAddressFactory,
         'base_object',
         ipaddress__is_management=True,
     )
-    eth2 = factory.RelatedFactory(
-        EthernetWithIPAddressFactory,
-        'base_object',
-    )
+    eth2 = factory.RelatedFactory(EthernetFactory, 'base_object')
     eth3 = factory.RelatedFactory(
         EthernetWithIPAddressFactory,
         'base_object',

--- a/src/ralph/data_center/tests/factories.py
+++ b/src/ralph/data_center/tests/factories.py
@@ -132,14 +132,12 @@ class DataCenterAssetFullFactory(DataCenterAssetFactory):
     eth2 = factory.RelatedFactory(
         EthernetWithIPAddressFactory,
         'base_object',
-
     )
     eth3 = factory.RelatedFactory(
         EthernetWithIPAddressFactory,
         'base_object',
         ipaddress__dhcp_expose=True,
     )
-
     licence1 = factory.RelatedFactory(
         'ralph.licences.tests.factories.BaseObjectLicenceFactory', 'base_object'
     )
@@ -148,15 +146,14 @@ class DataCenterAssetFullFactory(DataCenterAssetFactory):
         'base_object',
         quantity=3
     )
-
-    # support1 = factory.RelatedFactory(
-    #     'ralph.supports.tests.factories.BaseObjectsSupportFactory',
-    #     'baseobject'
-    # )
-    # support2 = factory.RelatedFactory(
-    #     'ralph.supports.tests.factories.BaseObjectsSupportFactory',
-    #     'baseobject'
-    # )
+    support1 = factory.RelatedFactory(
+        'ralph.supports.tests.factories.BaseObjectsSupportFactory',
+        'baseobject'
+    )
+    support2 = factory.RelatedFactory(
+        'ralph.supports.tests.factories.BaseObjectsSupportFactory',
+        'baseobject'
+    )
 
 
 class DatabaseFactory(DjangoModelFactory):

--- a/src/ralph/data_center/tests/test_api.py
+++ b/src/ralph/data_center/tests/test_api.py
@@ -22,6 +22,7 @@ from ralph.data_center.tests.factories import (
     ClusterFactory,
     ClusterTypeFactory,
     DataCenterAssetFactory,
+    DataCenterAssetFullFactory,
     RackAccessoryFactory,
     RackFactory,
     ServerRoomFactory
@@ -35,7 +36,7 @@ class DataCenterAssetAPITests(RalphAPITestCase):
         self.service_env = ServiceEnvironmentFactory()
         self.model = DataCenterAssetModelFactory()
         self.rack = RackFactory()
-        self.dc_asset = DataCenterAssetFactory(
+        self.dc_asset = DataCenterAssetFullFactory(
             rack=self.rack,
             position=10,
             model=self.model,
@@ -48,7 +49,8 @@ class DataCenterAssetAPITests(RalphAPITestCase):
 
     def test_get_data_center_assets_list(self):
         url = reverse('datacenterasset-list')
-        response = self.client.get(url, format='json')
+        with self.assertNumQueries(9):
+            response = self.client.get(url, format='json')
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(
             response.data['count'], DataCenterAsset.objects.count()

--- a/src/ralph/data_center/tests/test_api.py
+++ b/src/ralph/data_center/tests/test_api.py
@@ -69,7 +69,7 @@ class DataCenterAssetAPITests(RalphAPITestCase):
         )
         self.assertEqual(len(response.data['ethernet']), 4)
         self.assertIn(self.ip.address, [
-            eth['ipaddress']['address'] for eth in response.data['ethernets']
+            eth['ipaddress']['address'] for eth in response.data['ethernet']
             if eth['ipaddress']
         ])
 

--- a/src/ralph/data_center/tests/test_api.py
+++ b/src/ralph/data_center/tests/test_api.py
@@ -67,7 +67,7 @@ class DataCenterAssetAPITests(RalphAPITestCase):
         self.assertEqual(
             response.data['model']['id'], self.dc_asset.model.id
         )
-        self.assertEqual(len(response.data['ethernet']), 3)
+        self.assertEqual(len(response.data['ethernet']), 4)
         self.assertIn(self.ip.address, [
             eth['ipaddress']['address'] for eth in response.data['ethernets']
             if eth['ipaddress']

--- a/src/ralph/data_center/tests/test_api.py
+++ b/src/ralph/data_center/tests/test_api.py
@@ -45,7 +45,7 @@ class DataCenterAssetAPITests(RalphAPITestCase):
             ethernet=EthernetFactory(base_object=self.dc_asset)
         )
         self.dc_asset.tags.add('db', 'test')
-        self.dc_asset_2 = DataCenterAssetFactory()
+        self.dc_asset_2 = DataCenterAssetFullFactory()
 
     def test_get_data_center_assets_list(self):
         url = reverse('datacenterasset-list')
@@ -67,6 +67,11 @@ class DataCenterAssetAPITests(RalphAPITestCase):
         self.assertEqual(
             response.data['model']['id'], self.dc_asset.model.id
         )
+        self.assertEqual(len(response.data['ethernet']), 3)
+        self.assertIn(self.ip.address, [
+            eth['ipaddress']['address'] for eth in response.data['ethernets']
+            if eth['ipaddress']
+        ])
 
     def test_create_data_center_asset(self):
         url = reverse('datacenterasset-list')

--- a/src/ralph/data_center/tests/test_models.py
+++ b/src/ralph/data_center/tests/test_models.py
@@ -225,17 +225,6 @@ class DataCenterAssetTest(RalphTestCase):
         self._prepare_rack(self.dc_asset, '192.168.1.0/24')
         self.assertEqual(self.dc_asset.network_environment, self.net_env)
 
-    def test_network_environment_many_options(self):
-        self._prepare_rack(self.dc_asset, '192.168.1.0/24')
-        proper_net_env = self.net_env
-        self._prepare_rack(self.dc_asset, '192.168.2.0/24', rack=self.rack)
-        self.assertGreater(
-            NetworkEnvironment.objects.filter(network__racks=self.rack).count(),
-            1
-        )
-        self.assertEqual(self.dc_asset.network_environment, proper_net_env)
-        self.assertNotEqual(self.dc_asset.network_environment, self.net_env)
-
     # =========================================================================
     # next free hostname
     # =========================================================================

--- a/src/ralph/licences/api.py
+++ b/src/ralph/licences/api.py
@@ -68,7 +68,9 @@ class BaseObjectLicenceViewSet(RalphAPIViewSet):
     serializer_class = BaseObjectLicenceSerializer
     select_related = [
         'licence', 'licence__region', 'licence__manufacturer',
-        'licence__licence_type', 'licence__software', 'base_object'
+        'licence__licence_type', 'licence__software', 'base_object',
+        'licence__budget_info', 'licence__office_infrastructure',
+        'licence__property_of',
     ]
     save_serializer_class = BaseObjectLicenceSerializer
 

--- a/src/ralph/licences/api_simple.py
+++ b/src/ralph/licences/api_simple.py
@@ -10,7 +10,10 @@ class SimpleLicenceSerializer(RalphAPISerializer):
     class Meta:
         model = Licence
         depth = 1
-        exclude = ('base_objects', 'users', 'content_type', 'service_env')
+        exclude = (
+            'base_objects', 'users', 'content_type', 'service_env', 'parent',
+            'configuration_path', 'tags'
+        )
 
 
 class SimpleLicenceUserSerializer(RalphAPISerializer):

--- a/src/ralph/licences/models.py
+++ b/src/ralph/licences/models.py
@@ -231,6 +231,15 @@ class Licence(Regionalizable, AdminAbsoluteUrlMixin, BaseObject):
     objects_used_free_with_related = LicencesUsedFreeRelatedObjectsManager()
 
     def __str__(self):
+        return "{} x {} - {} ({})".format(
+            self.number_bought,
+            self.software.name,
+            self.invoice_date,
+            self.niw,
+        )
+
+    @cached_property
+    def autocomplete_str(self):
         return "{} ({} free) x {} - {} ({})".format(
             self.number_bought,
             self.free,

--- a/src/ralph/networks/api.py
+++ b/src/ralph/networks/api.py
@@ -4,7 +4,7 @@ from rest_framework.exceptions import ValidationError
 
 from ralph.api import RalphAPISerializer, RalphAPIViewSet, router
 from ralph.api.serializers import RalphAPISaveSerializer
-# from ralph.assets.api.serializers import EthernetSerializer
+from ralph.assets.api.serializers import EthernetSerializer
 from ralph.networks.models import (
     IPAddress,
     Network,
@@ -42,6 +42,7 @@ class NetworkSerializer(RalphAPISerializer):
 
 class IPAddressSerializer(RalphAPISerializer):
     network = NetworkSimpleSerializer()
+    ethernet = EthernetSerializer()
 
     class Meta:
         model = IPAddress

--- a/src/ralph/networks/api.py
+++ b/src/ralph/networks/api.py
@@ -4,7 +4,7 @@ from rest_framework.exceptions import ValidationError
 
 from ralph.api import RalphAPISerializer, RalphAPIViewSet, router
 from ralph.api.serializers import RalphAPISaveSerializer
-from ralph.assets.api.serializers import EthernetSerializer
+# from ralph.assets.api.serializers import EthernetSerializer
 from ralph.networks.models import (
     IPAddress,
     Network,
@@ -41,7 +41,6 @@ class NetworkSerializer(RalphAPISerializer):
 
 
 class IPAddressSerializer(RalphAPISerializer):
-    ethernet = EthernetSerializer()
     network = NetworkSimpleSerializer()
 
     class Meta:
@@ -80,7 +79,7 @@ class IPAddressViewSet(RalphAPIViewSet):
     ]
     filter_fields = [
         'hostname', 'ethernet__base_object', 'network', 'network__address',
-        'status', 'is_public', 'is_management', 'dhcp_expose'
+        'status', 'is_public', 'is_management', 'dhcp_expose', 'ethernet__mac',
     ]
 
     def destroy(self, request, *args, **kwargs):

--- a/src/ralph/networks/api_simple.py
+++ b/src/ralph/networks/api_simple.py
@@ -1,0 +1,10 @@
+from ralph.api import RalphAPISerializer
+from ralph.networks.models import IPAddress
+
+
+class IPAddressSimpleSerializer(RalphAPISerializer):
+    class Meta:
+        model = IPAddress
+        fields = (
+            'id', 'address', 'hostname', 'dhcp_expose', 'is_management', 'url'
+        )

--- a/src/ralph/networks/tests/test_api.py
+++ b/src/ralph/networks/tests/test_api.py
@@ -39,6 +39,21 @@ class IPAddressAPITests(RalphAPITestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data['count'], 1)
 
+    def test_get_ip_details(self):
+        url = reverse('ipaddress-detail', args=(self.ip1.id,))
+        response = self.client.get(url, format='json')
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(
+            response.data['ethernet']['mac'], self.ip1.ethernet.mac
+        )
+        self.assertEqual(
+            response.data['ethernet']['ipaddress']['address'], self.ip1.address
+        )
+        self.assertEqual(
+            response.data['ethernet']['base_object']['id'],
+            self.ip1.ethernet.base_object.id
+        )
+
     def test_change_network_should_not_pass(self):
         net = NetworkFactory(address='192.168.1.0/24')
         data = {'network': net.id}

--- a/src/ralph/networks/tests/test_api.py
+++ b/src/ralph/networks/tests/test_api.py
@@ -31,6 +31,14 @@ class IPAddressAPITests(RalphAPITestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data['count'], 1)
 
+    def test_get_ip_list_filter_by_mac(self):
+        url = '{}?ethernet__mac={}'.format(
+            reverse('ipaddress-list'), self.ip1.ethernet.mac
+        )
+        response = self.client.get(url, format='json')
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data['count'], 1)
+
     def test_change_network_should_not_pass(self):
         net = NetworkFactory(address='192.168.1.0/24')
         data = {'network': net.id}

--- a/src/ralph/virtual/admin.py
+++ b/src/ralph/virtual/admin.py
@@ -4,7 +4,11 @@ from django.db.models import Count
 from django.utils.translation import ugettext_lazy as _
 
 from ralph.admin import RalphAdmin, RalphAdminForm, RalphTabularInline, register
-from ralph.admin.filters import IPFilter, TagsListFilter
+from ralph.admin.filters import (
+    IPFilter,
+    TagsListFilter,
+    TreeRelatedAutocompleteFilterWithDescendants
+)
 from ralph.assets.models.components import Ethernet
 from ralph.data_center.models.virtual import BaseObjectCluster
 from ralph.lib.transitions.admin import TransitionAdminMixin
@@ -41,8 +45,9 @@ class VirtualServerAdmin(TransitionAdminMixin, RalphAdmin):
     form = VirtualServerForm
     search_fields = ['hostname', 'sn']
     list_filter = [
-        'sn', 'hostname', 'service_env', 'configuration_path', IPFilter,
-        'parent', ('tags', TagsListFilter)
+        'sn', 'hostname', 'service_env', IPFilter,
+        'parent', ('tags', TagsListFilter),
+        ('configuration_path__module', TreeRelatedAutocompleteFilterWithDescendants)  # noqa
     ]
     list_display = [
         'hostname', 'type', 'sn', 'service_env', 'configuration_path'
@@ -54,7 +59,7 @@ class VirtualServerAdmin(TransitionAdminMixin, RalphAdmin):
     ]
     list_select_related = [
         'service_env__service', 'service_env__environment', 'type',
-        'configuration_path'
+        'configuration_path__module'
     ]
 
     change_views = [VirtualServerNetworkView]

--- a/src/ralph/virtual/api.py
+++ b/src/ralph/virtual/api.py
@@ -10,6 +10,7 @@ from ralph.assets.api.serializers import (
 )
 from ralph.data_center.api.serializers import (
     ClusterSimpleSerializer,
+    ComponentSerializerMixin,
     DataCenterAssetSimpleSerializer
 )
 from ralph.data_center.models import DataCenterAsset
@@ -123,7 +124,8 @@ class VirtualServerTypeSerializer(RalphAPISerializer):
         model = VirtualServerType
 
 
-class VirtualServerSerializer(BaseObjectSerializer):
+# TODO: select related
+class VirtualServerSerializer(ComponentSerializerMixin, BaseObjectSerializer):
     type = VirtualServerTypeSerializer()
     # TODO: cast BaseObject to DataCenterAsset for hypervisor field
     hypervisor = DataCenterAssetSimpleSerializer(source='parent')

--- a/src/ralph/virtual/models.py
+++ b/src/ralph/virtual/models.py
@@ -252,6 +252,7 @@ class VirtualServer(AdminAbsoluteUrlMixin, NetworkableBaseObject, BaseObject):
         verbose_name=_('SN'),
         unique=True,
     )
+    # TODO: remove this field
     cluster = models.ForeignKey(Cluster, blank=True, null=True)
 
     @cached_property

--- a/src/ralph/virtual/tests/factories.py
+++ b/src/ralph/virtual/tests/factories.py
@@ -1,7 +1,11 @@
 import factory
 from factory.django import DjangoModelFactory
 
-from ralph.assets.tests.factories import ServiceEnvironmentFactory
+from ralph.assets.tests.factories import (
+    ConfigurationClassFactory,
+    EthernetWithIPAddressFactory,
+    ServiceEnvironmentFactory
+)
 from ralph.data_center.tests.factories import DataCenterAssetFactory
 from ralph.virtual.models import (
     CloudFlavor,
@@ -81,6 +85,27 @@ class VirtualServerFactory(DjangoModelFactory):
     type = factory.SubFactory(VirtualServerTypeFactory)
     sn = factory.Faker('ssn')
     parent = factory.SubFactory(DataCenterAssetFactory)
+    configuration_path = factory.SubFactory(ConfigurationClassFactory)
 
     class Meta:
         model = VirtualServer
+
+
+class VirtualServerFullFactory(VirtualServerFactory):
+    eth1 = factory.RelatedFactory(
+        EthernetWithIPAddressFactory,
+        'base_object',
+    )
+    eth2 = factory.RelatedFactory(
+        EthernetWithIPAddressFactory,
+        'base_object',
+        ipaddress__dhcp_expose=True,
+    )
+    licence1 = factory.RelatedFactory(
+        'ralph.licences.tests.factories.BaseObjectLicenceFactory', 'base_object'
+    )
+    licence2 = factory.RelatedFactory(
+        'ralph.licences.tests.factories.BaseObjectLicenceFactory',
+        'base_object',
+        quantity=3
+    )

--- a/src/ralph/virtual/tests/factories.py
+++ b/src/ralph/virtual/tests/factories.py
@@ -3,6 +3,7 @@ from factory.django import DjangoModelFactory
 
 from ralph.assets.tests.factories import (
     ConfigurationClassFactory,
+    EthernetFactory,
     EthernetWithIPAddressFactory,
     ServiceEnvironmentFactory
 )
@@ -92,10 +93,7 @@ class VirtualServerFactory(DjangoModelFactory):
 
 
 class VirtualServerFullFactory(VirtualServerFactory):
-    eth1 = factory.RelatedFactory(
-        EthernetWithIPAddressFactory,
-        'base_object',
-    )
+    eth1 = factory.RelatedFactory(EthernetFactory, 'base_object')
     eth2 = factory.RelatedFactory(
         EthernetWithIPAddressFactory,
         'base_object',

--- a/src/ralph/virtual/tests/test_api.py
+++ b/src/ralph/virtual/tests/test_api.py
@@ -30,9 +30,7 @@ from ralph.virtual.tests.factories import (
     CloudHostFactory,
     CloudProjectFactory,
     CloudProviderFactory,
-    VirtualServerFactory,
-    VirtualServerFullFactory,
-    VirtualServerTypeFactory
+    VirtualServerFullFactory
 )
 
 
@@ -323,7 +321,11 @@ class VirtualServerAPITestCase(RalphAPITestCase):
         )
         self.assertEqual(len(response.data['ethernet']), 2)
         self.assertCountEqual(
-            [eth['ipaddress']['address'] for eth in response.data['ethernet']],
+            [
+                eth['ipaddress']['address']
+                for eth in response.data['ethernet']
+                if eth['ipaddress']
+            ],
             self.virtual_server.ipaddresses.values_list('address', flat=True)
         )
 


### PR DESCRIPTION
- filter ethernet by ipaddress
- attach IP info in ethernet
- filter IP by mac address
- attach ethernet (and simple IP) info for DataCenterAsset and VirtualServer
- various filters and performance (sql queries count) optimizations
