### PR TITLE
Use default table for BaseObjectsSupport

### DIFF
--- a/src/ralph/supports/migrations/0006_auto_20160615_0805.py
+++ b/src/ralph/supports/migrations/0006_auto_20160615_0805.py
@@ -1,0 +1,40 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+import ralph.lib.mixins.fields
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('supports', '0005_auto_20160105_1222'),
+    ]
+
+    operations = [
+        migrations.AlterModelOptions(
+            name='baseobjectssupport',
+            options={},
+        ),
+        migrations.AlterModelTable(
+            name='baseobjectssupport',
+            table=None,
+        ),
+        migrations.SeparateDatabaseAndState(
+            state_operations=[
+                migrations.AddField(
+                    model_name='baseobjectssupport',
+                    name='baseobject',
+                    field=ralph.lib.mixins.fields.BaseObjectForeignKey(default=0, verbose_name='Asset', to='assets.BaseObject', related_name='supports'),
+                    preserve_default=False,
+                ),
+                migrations.AddField(
+                    model_name='baseobjectssupport',
+                    name='support',
+                    field=models.ForeignKey(default=0, to='supports.Support'),
+                    preserve_default=False,
+                ),
+            ],
+            database_operations=[]
+        ),
+    ]

--- a/src/ralph/supports/models.py
+++ b/src/ralph/supports/models.py
@@ -164,6 +164,4 @@ class BaseObjectsSupport(models.Model):
     )
 
     class Meta:
-        managed = False
         unique_together = ('support', 'baseobject')
-        db_table = 'supports_support_base_objects'


### PR DESCRIPTION
Migration 0003 in supports created through model for BaseObjectSupport, keeping old DB table name, which breaks tests with SKIP_MIGRATION=1. This commit rename this table (to use default name for this model) and make this model managable.
