### PR TITLE
Change `%(class)s` to `%(class)s_set` as related model in component

### DIFF
--- a/src/ralph/assets/api/filters.py
+++ b/src/ralph/assets/api/filters.py
@@ -8,7 +8,7 @@ class NetworkableObjectFilters(django_filters.FilterSet):
     configuration_path = django_filters.CharFilter(
         name='configuration_path__path'
     )
-    ip = django_filters.CharFilter(name='ethernet__ipaddress__address')
+    ip = django_filters.CharFilter(name='ethernet_set__ipaddress__address')
 
     class Meta:
         fields = [

--- a/src/ralph/assets/api/views.py
+++ b/src/ralph/assets/api/views.py
@@ -92,7 +92,7 @@ class BaseObjectViewSet(PolymorphicViewSetMixin, RalphAPIViewSet):
         'sn': ['asset__sn'],
         'barcode': ['asset__barcode'],
         'price': ['asset__price'],
-        'ip': ['ethernet__ipaddress__address'],
+        'ip': ['ethernet_set__ipaddress__address'],
         'service': ['service_env__service__uid', 'service_env__service__name'],
     }
 

--- a/src/ralph/assets/migrations/0013_auto_20160615_2140.py
+++ b/src/ralph/assets/migrations/0013_auto_20160615_2140.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('assets', '0012_auto_20160606_1409'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='ethernet',
+            name='base_object',
+            field=models.ForeignKey(related_name='ethernet_set', to='assets.BaseObject'),
+        ),
+        migrations.AlterField(
+            model_name='genericcomponent',
+            name='base_object',
+            field=models.ForeignKey(related_name='genericcomponent_set', to='assets.BaseObject'),
+        ),
+    ]

--- a/src/ralph/assets/models/components.py
+++ b/src/ralph/assets/models/components.py
@@ -59,7 +59,7 @@ class ComponentModel(AutocompleteTooltipMixin, NamedMixin, models.Model):
 
 
 class Component(TimeStampMixin, models.Model):
-    base_object = models.ForeignKey(BaseObject, related_name='%(class)s')
+    base_object = models.ForeignKey(BaseObject, related_name='%(class)s_set')
     model = models.ForeignKey(
         ComponentModel,
         verbose_name=_('model'),

--- a/src/ralph/data_center/api/serializers.py
+++ b/src/ralph/data_center/api/serializers.py
@@ -86,7 +86,7 @@ class SimpleRackSerializer(RalphAPISerializer):
 
 # used by DataCenterAsset and VirtualServer serializers
 class ComponentSerializerMixin(serializers.Serializer):
-    ethernet = EthernetSimpleSerializer(many=True)
+    ethernet = EthernetSimpleSerializer(many=True, source='ethernet_set')
     ipaddresses = fields.SerializerMethodField()
 
     def get_ipaddresses(self, instance):
@@ -99,7 +99,7 @@ class ComponentSerializerMixin(serializers.Serializer):
         # don't use `ipaddresses` property here to make use of
         # `ethernet__ipaddresses` in prefetch related
         ipaddresses = []
-        for eth in instance.ethernet.all():
+        for eth in instance.ethernet_set.all():
             try:
                 ipaddresses.append(eth.ipaddress.address)
             except AttributeError:

--- a/src/ralph/data_center/api/views.py
+++ b/src/ralph/data_center/api/views.py
@@ -51,7 +51,7 @@ class DataCenterAssetViewSet(BaseObjectViewSetMixin, RalphAPIViewSet):
         'connections',
         'tags',
         Prefetch(
-            'ethernet',
+            'ethernet_set',
             queryset=Ethernet.objects.select_related('ipaddress')
         ),
     ]

--- a/src/ralph/data_center/migrations/0015_auto_20160615_2140.py
+++ b/src/ralph/data_center/migrations/0015_auto_20160615_2140.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('data_center', '0014_custom_move_managment_to_networks'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='diskshare',
+            name='base_object',
+            field=models.ForeignKey(related_name='diskshare_set', to='assets.BaseObject'),
+        ),
+    ]

--- a/src/ralph/data_center/models/physical.py
+++ b/src/ralph/data_center/models/physical.py
@@ -423,7 +423,7 @@ class DataCenterAsset(NetworkableBaseObject, AutocompleteTooltipMixin, Asset):
         return asset_cores_count
 
     def _get_management_ip(self):
-        eth = self.ethernet.select_related('ipaddress').filter(
+        eth = self.ethernet_set.select_related('ipaddress').filter(
             ipaddress__is_management=True
         ).first()
         if eth:
@@ -433,7 +433,7 @@ class DataCenterAsset(NetworkableBaseObject, AutocompleteTooltipMixin, Asset):
     def _get_or_create_management_ip(self):
         ip = self._get_management_ip()
         if not ip:
-            eth = self.ethernet.create()
+            eth = self.ethernet_set.create()
             ip = IPAddress(ethernet=eth, is_management=True)
         return ip
 

--- a/src/ralph/deployment/deployment.py
+++ b/src/ralph/deployment/deployment.py
@@ -165,7 +165,7 @@ def mac_choices_for_objects(actions, objects):
         list of tuples with MAC addresses
     """
     if len(objects) == 1:
-        return [(eth.id, eth.mac) for eth in objects[0].ethernet.filter(
+        return [(eth.id, eth.mac) for eth in objects[0].ethernet_set.filter(
             Q(ipaddress__is_management=False) | Q(ipaddress__isnull=True),
             mac__isnull=False,
         )]
@@ -181,7 +181,7 @@ def _get_non_mgmt_ethernets(instance):
     Args:
         instance: BaseObject instance
     """
-    return instance.ethernet.filter(
+    return instance.ethernet_set.filter(
         mac__isnull=False
     ).exclude(
         ipaddress__is_management=True

--- a/src/ralph/networks/tests/test_forms.py
+++ b/src/ralph/networks/tests/test_forms.py
@@ -10,7 +10,7 @@ from ralph.tests.models import PolymorphicTestModel
 
 class NetworkInlineTestCase(RalphTestCase):
     def setUp(self):
-        self.inline_prefix = 'ethernet-'
+        self.inline_prefix = 'ethernet_set-'
         self.obj1 = PolymorphicTestModel.objects.create(hostname='abc')
         self.obj2 = PolymorphicTestModel.objects.create(hostname='xyz')
         self.ip1 = IPAddressFactory(
@@ -302,7 +302,7 @@ class NetworkInlineTestCase(RalphTestCase):
 
 class NetworkInlineWithDHCPExposeTestCase(RalphTestCase):
     def setUp(self):
-        self.inline_prefix = 'ethernet-'
+        self.inline_prefix = 'ethernet_set-'
         self.obj1 = PolymorphicTestModel.objects.create(hostname='abc')
         self.ip1 = IPAddressFactory(
             ethernet__base_object=self.obj1,

--- a/src/ralph/virtual/admin.py
+++ b/src/ralph/virtual/admin.py
@@ -277,7 +277,7 @@ class CloudFlavorAdmin(RalphAdmin):
 
     def get_queryset(self, request):
         return super().get_queryset(request).prefetch_related(
-            'virtualcomponent__model', 'tags'
+            'virtualcomponent_set__model', 'tags'
         ).annotate(instances_count=Count('cloudhost'))
 
     def get_tags(self, obj):

--- a/src/ralph/virtual/api.py
+++ b/src/ralph/virtual/api.py
@@ -154,7 +154,7 @@ class CloudFlavorViewSet(RalphAPIViewSet):
     queryset = CloudFlavor.objects.all()
     serializer_class = CloudFlavorSerializer
     save_serializer_class = SaveCloudFlavorSerializer
-    prefetch_related = ['tags', 'virtualcomponent__model']
+    prefetch_related = ['tags', 'virtualcomponent_set__model']
 
 
 class CloudProviderViewSet(RalphAPIViewSet):
@@ -171,7 +171,7 @@ class CloudHostViewSet(RalphAPIViewSet):
         'service_env__service', 'service_env__environment',
     ]
     prefetch_related = [
-        'tags', 'cloudflavor__virtualcomponent__model', 'licences'
+        'tags', 'cloudflavor__virtualcomponent_set__model', 'licences'
     ]
 
 
@@ -204,7 +204,7 @@ class VirtualServerViewSet(BaseObjectViewSetMixin, RalphAPIViewSet):
     prefetch_related = BaseObjectViewSet.prefetch_related + [
         'tags',
         Prefetch(
-            'ethernet',
+            'ethernet_set',
             queryset=Ethernet.objects.select_related('ipaddress')
         ),
         # TODO: clusters

--- a/src/ralph/virtual/management/commands/openstack_sync.py
+++ b/src/ralph/virtual/management/commands/openstack_sync.py
@@ -255,7 +255,7 @@ class Command(BaseCommand):
         ).select_related(
             'hypervisor', 'parent', 'parent__cloudproject',
         ).prefetch_related('tags'):
-            ips = server.ethernet.select_related('ipaddress').values_list(
+            ips = server.ethernet_set.select_related('ipaddress').values_list(
                 'ipaddress__address', flat=True
             )
             new_server = {

--- a/src/ralph/virtual/migrations/0005_auto_20160615_2140.py
+++ b/src/ralph/virtual/migrations/0005_auto_20160615_2140.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('virtual', '0004_virtualserver_status'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='virtualcomponent',
+            name='base_object',
+            field=models.ForeignKey(related_name='virtualcomponent_set', to='assets.BaseObject'),
+        ),
+    ]

--- a/src/ralph/virtual/models.py
+++ b/src/ralph/virtual/models.py
@@ -57,7 +57,7 @@ class CloudFlavor(BaseObject):
         try:
             VirtualComponent.objects.get(base_object=self, model=model)
         except ObjectDoesNotExist:
-            for component in self.virtualcomponent.filter(
+            for component in self.virtualcomponent_set.filter(
                 model__type=model_args['type']
             ):
                 component.delete()
@@ -70,7 +70,7 @@ class CloudFlavor(BaseObject):
         try:
             components = self._prefetched_objects_cache['virtualcomponent']
         except (KeyError, AttributeError):
-            return self.virtualcomponent.filter(
+            return self.virtualcomponent_set.filter(
                 model__type=model_type
             ).values_list(field_path, flat=True).first()
         else:
@@ -170,7 +170,7 @@ class CloudHost(AdminAbsoluteUrlMixin, BaseObject):
 
     @property
     def ip_addresses(self):
-        return self.ethernet.select_related('ipaddress').values_list(
+        return self.ethernet_set.select_related('ipaddress').values_list(
             'ipaddress__address', flat=True
         )
 


### PR DESCRIPTION
Example change: ethernet -> ethernet_set

Singular name (ex. ethernet) could suggest, that there is only one related component. In fact there could be more or each type. Thic change should make it now more clear.
