### PR TITLE
Ignore F405 in flake8

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,6 +38,7 @@ test: clean
 
 flake: isort
 	flake8 src/ralph
+	flake8 src/ralph/settings --ignore=F405 --exclude=local.py
 	@cat scripts/flake.txt
 
 clean:

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,4 @@
 [flake8]
-exclude = migrations,tests,docs,settings*.py,*local.py
+exclude = migrations,tests,docs,settings*,*local.py
 max-complexity = 15
 max-line-length = 80
-ignore = F405

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,3 +2,4 @@
 exclude = migrations,tests,docs,settings*.py,*local.py
 max-complexity = 15
 max-line-length = 80
+ignore = F405


### PR DESCRIPTION
Version 2.6.0 of flake8 introduced new check for variables coming from star import (ex. `from ralph.settings.base import *`). Since we import in settings from star on purpose, this check is not required for us.
