### PR TITLE
Better way of disabling publishers during handlind subscribers in Ralph2 sync

### DIFF
--- a/src/ralph/ralph2_sync/helpers.py
+++ b/src/ralph/ralph2_sync/helpers.py
@@ -1,0 +1,32 @@
+import logging
+
+from django.utils.decorators import ContextDecorator
+
+logger = logging.getLogger(__name__)
+
+
+class WithSignalDisabled(ContextDecorator):
+    """
+    Context manager for disabling particular signal in it's scope.
+    """
+    def __init__(self, signal, receiver, sender, dispatch_uid=None):
+        self.signal = signal
+        self.receiver = receiver
+        self.sender = sender
+        self.dispatch_uid = dispatch_uid
+
+    def __enter__(self):
+        logger.warning('Disabling signal {}'.format(self.dispatch_uid))
+        self.signal.disconnect(
+            receiver=self.receiver,
+            sender=self.sender,
+            dispatch_uid=self.dispatch_uid,
+        )
+
+    def __exit__(self, type, value, traceback):
+        logger.warning('Enabling signal {}'.format(self.dispatch_uid))
+        self.signal.connect(
+            receiver=self.receiver,
+            sender=self.sender,
+            dispatch_uid=self.dispatch_uid,
+        )

--- a/src/ralph/ralph2_sync/publishers.py
+++ b/src/ralph/ralph2_sync/publishers.py
@@ -49,6 +49,10 @@ def ralph2_sync(model):
                     logger.exception('Error during Ralph2 sync')
                 else:
                     return result
+        # store additional info about signal
+        wrapped_func._signal_model = model
+        wrapped_func._signal_dispatch_uid = func.__name__
+        wrapped_func._signal_type = post_save
         return wrapped_func
     return wrap
 

--- a/src/ralph/ralph2_sync/subscribers.py
+++ b/src/ralph/ralph2_sync/subscribers.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 import logging
+from contextlib import ExitStack
 from functools import wraps
 
 import pyhermes
@@ -9,6 +10,8 @@ from django.db import transaction
 from ralph.assets.models import AssetModel, Environment, ServiceEnvironment
 from ralph.data_center.models import DataCenterAsset
 from ralph.data_importer.models import ImportedObjects
+from ralph.ralph2_sync.helpers import WithSignalDisabled
+from ralph.ralph2_sync.publishers import sync_dc_asset_to_ralph2
 
 logger = logging.getLogger(__name__)
 
@@ -18,18 +21,40 @@ model_mapping = {
 }
 
 
+def _get_publisher_signal_info(func):
+    """
+    Return signal info for publisher in format accepted by `WithSignalDisabled`.
+    """
+    return {
+        'dispatch_uid': func._signal_dispatch_uid,
+        'sender': func._signal_model,
+        'signal': func._signal_type,
+        'receiver': func,
+    }
+
+
 class sync_subscriber(pyhermes.subscriber):
     """
     Log additional exception when sync has failed.
     """
+    def __init__(self, topic, disable_publishers=None):
+        self.disable_publishers = disable_publishers or []
+        super().__init__(topic)
+
     def _get_wrapper(self, func):
         @wraps(func)
         @transaction.atomic
         def exception_wrapper(*args, **kwargs):
-            try:
-                return func(*args, **kwargs)
-            except:
-                logger.exception('Exception during syncing')
+            # disable selected publisher signals during handling subcriber
+            with ExitStack() as stack:
+                for publisher in self.disable_publishers:
+                    stack.enter_context(WithSignalDisabled(
+                        **_get_publisher_signal_info(publisher)
+                    ))
+                try:
+                    return func(*args, **kwargs)
+                except:
+                    logger.exception('Exception during syncing')
         return exception_wrapper
 
 
@@ -60,7 +85,10 @@ def ralph2_sync_ack(data):
         )
 
 
-@sync_subscriber(topic='sync_device_to_ralph3')
+@sync_subscriber(
+    topic='sync_device_to_ralph3',
+    disable_publishers=[sync_dc_asset_to_ralph2],
+)
 def sync_device_to_ralph3(data):
     """
     Receive data about device from Ralph2
@@ -81,6 +109,4 @@ def sync_device_to_ralph3(data):
                 Environment, data['environment']
             )
         )
-    # don't trigger another publishing event
-    dca._handle_post_save = False
     dca.save()


### PR DESCRIPTION
Previously `_handle_post_save` attribute was assigned to the obj, which should prevent firing post_save publisher on it. Unfortunately it wasn't working perfectly - obj could be saved somewhere underneath and thus it wouldn't have this attr assigned, which caused signal (and publisher) to be fired, which may cause pub-sub cycle between Ralph2 and Ralph3.

This PR solves it by temporarly disabling post_save publisher signal during handling subscriber request.

Since signals (connectors) are not thread-safe, you may want to run runserver with `--nothreading` option (this would work with gunicorn out of the box, since it's using processes instead of threads).
