### PR TITLE
Better way of disabling publishers during handlind subscribers in Ralph3 sync

### DIFF
--- a/src/ralph/export_to_ng/helpers.py
+++ b/src/ralph/export_to_ng/helpers.py
@@ -1,0 +1,30 @@
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+class WithSignalDisabled(object):
+    """
+    Context manager for disabling particular signal in it's scope.
+    """
+    def __init__(self, signal, receiver, sender, dispatch_uid=None):
+        self.signal = signal
+        self.receiver = receiver
+        self.sender = sender
+        self.dispatch_uid = dispatch_uid
+
+    def __enter__(self):
+        logger.warning('Disabling signal {}'.format(self.dispatch_uid))
+        self.signal.disconnect(
+            receiver=self.receiver,
+            sender=self.sender,
+            dispatch_uid=self.dispatch_uid,
+        )
+
+    def __exit__(self, type, value, traceback):
+        logger.warning('Enabling signal {}'.format(self.dispatch_uid))
+        self.signal.connect(
+            receiver=self.receiver,
+            sender=self.sender,
+            dispatch_uid=self.dispatch_uid,
+        )

--- a/src/ralph/export_to_ng/publishers.py
+++ b/src/ralph/export_to_ng/publishers.py
@@ -44,6 +44,11 @@ def ralph3_sync(model):
                     logger.exception('Error during Ralph2 sync')
                 else:
                     return result
+
+        # store additional info about signal
+        wrapped_func._signal_model = model
+        wrapped_func._signal_dispatch_uid = func.__name__
+        wrapped_func._signal_type = post_save
         return wrapped_func
     return wrap
 

--- a/src/ralph/util/details.py
+++ b/src/ralph/util/details.py
@@ -275,4 +275,6 @@ def _update_batch(device_ids, rack, dc):
         else:
             d.rack = None
         d.dc = dc.name.upper() if dc else None
+        # don't run ralph3 sync
+        d._handle_post_save = False
         d.save()


### PR DESCRIPTION
Previously _handle_post_save attribute was assigned to the obj, which should prevent firing post_save publisher on it. Unfortunately it wasn't working perfectly - obj could be saved somewhere underneath and thus it wouldn't have this attr assigned, which caused signal (and publisher) to be fired, which may cause pub-sub cycle between Ralph2 and Ralph3.

This PR solves it by temporarly disabling post_save publisher signal during handling subscriber request.

Since signals (connectors) are not thread-safe, you may want to run runserver with --nothreading option (this would work with gunicorn out of the box, since it's using processes instead of threads).
