### PR TITLE
menu resync fix & tests

### DIFF
--- a/src/ralph/admin/sitetrees.py
+++ b/src/ralph/admin/sitetrees.py
@@ -301,8 +301,7 @@ sitetrees = [
                 section(_('Transitions'), 'transitions', 'TransitionModel'),
                 section(_('Report template'), 'reports', 'Report'),
                 section(_('Custom fields'), 'custom_fields', 'CustomField'),
-                *cross_validation_items
-            ]
+            ] + cross_validation_items
         )
     ])
 ]

--- a/src/ralph/admin/tests/test_menu.py
+++ b/src/ralph/admin/tests/test_menu.py
@@ -1,0 +1,8 @@
+# -*- coding: utf-8 -*-
+from django.core.management import call_command
+from django.test import TestCase
+
+
+class RalphMenuTest(TestCase):
+    def test_menu_resync(self):
+        call_command('sitetree_resync_apps')


### PR DESCRIPTION
Fix menu resyncing (unpacking list to another list work only in python 3.5: http://stackoverflow.com/questions/3870778/why-does-this-cause-a-syntax-error)
