### PR TITLE
Ralph3 sync mgmt cmd improvements

### DIFF
--- a/src/ralph/export_to_ng/publishers.py
+++ b/src/ralph/export_to_ng/publishers.py
@@ -104,7 +104,7 @@ def sync_device_to_ralph3(sender, instance=None, **kwargs):
     """
     Send device data when device was saved.
     """
-    return get_device_data(instance)
+    return get_device_data(instance, fields=kwargs.get('_sync_fields'))
 
 
 @ralph3_sync(RolePropertyValue, topic='sync_device_to_ralph3')

--- a/src/ralph/settings.py
+++ b/src/ralph/settings.py
@@ -389,6 +389,7 @@ HERMES = {
 }
 RALPH3_HERMES_SYNC_ENABLED = False
 RALPH3_HERMES_SYNC_FUNCTIONS = []
+RALPH2_HERMES_ROLE_PROPERTY_WHITELIST = []
 NG_SYNC_DEFAULT_WAREHOUSE = 1
 
 # </template>
@@ -809,5 +810,3 @@ NG_EXPORTER = {
     # non-conflicting. this is achieved by adding below constant
     'discovery_datacenter_constant': 1000,
 }
-
-RALPH2_HERMES_ROLE_PROPERTY_WHITELIST = []


### PR DESCRIPTION
- call post_save signal directly instead of calling .save()
- new `sleep` option for sleeping between succesive triggers
- sync ventures assigned to hosts (DC Asset) and custom fields assigned to hosts
