### PR TITLE
Fix syncing existing mgmt IP

### DIFF
--- a/src/ralph/ralph2_sync/subscribers.py
+++ b/src/ralph/ralph2_sync/subscribers.py
@@ -21,6 +21,7 @@ from ralph.data_importer.models import (
     ImportedObjects
 )
 from ralph.lib.custom_fields.models import CustomField, CustomFieldTypes
+from ralph.networks.models import IPAddress
 from ralph.ralph2_sync.helpers import WithSignalDisabled
 from ralph.ralph2_sync.publishers import sync_dc_asset_to_ralph2
 
@@ -116,7 +117,15 @@ def sync_device_to_ralph3(data):
     if 'management_ip' in data:
         management_ip = data['management_ip']
         if management_ip:
-            dca.management_ip = management_ip
+            try:
+                ip = IPAddress.objects.get(address=management_ip)
+            except IPAddress.DoesNotExist:
+                dca.management_ip = management_ip
+            else:
+                ip.ethernet.base_object = dca
+                ip.ethernet.save()
+                ip.is_management = True
+                ip.save()
             dca.management_hostname = data.get('management_hostname')
         else:
             del dca.management_ip


### PR DESCRIPTION
Re-assign mgmt IP during sync if it already exist. Otherwise create new IP.
