### PR TITLE
Venture role publisher - full name instead of name

### DIFF
--- a/src/ralph/export_to_ng/publishers.py
+++ b/src/ralph/export_to_ng/publishers.py
@@ -143,7 +143,8 @@ def sync_venture_role_to_ralph3(sender, instance=None, created=False, **kwargs):
     venture_role = instance
     data = {
         'id': venture_role.id,
-        'name': venture_role.name,
+        # publish full name instead of single name (based on puppet classifier)
+        'name': venture_role.full_name.replace(' / ', '__'),
         'venture': venture_role.venture_id,
     }
     return data

--- a/src/ralph/export_to_ng/tests/test_publishers.py
+++ b/src/ralph/export_to_ng/tests/test_publishers.py
@@ -166,12 +166,25 @@ class VentureRolePublisherTestCase(TestCase):
             name='abcd',
             venture=self.venture1
         )
+        self.venture_role2 = VentureRole.objects.create(
+            name='qwerty',
+            venture=self.venture1,
+            parent=self.venture_role
+        )
 
     def test_publish_venture_role(self):
         result = sync_venture_role_to_ralph3(VentureRole, self.venture_role)
         self.assertEqual(result, {
             'id': self.venture_role.id,
             'name': 'abcd',
+            'venture': self.venture1.id,
+        })
+
+    def test_publish_venture_role_with_parent(self):
+        result = sync_venture_role_to_ralph3(VentureRole, self.venture_role2)
+        self.assertEqual(result, {
+            'id': self.venture_role2.id,
+            'name': 'abcd__qwerty',
             'venture': self.venture1.id,
         })
 


### PR DESCRIPTION
Publish full name of venture role (includes parent names) instead of single name
