### PR TITLE
Fixed DCAsset venture cross validator

### DIFF
--- a/src/ralph/cross_validator/mappers.py
+++ b/src/ralph/cross_validator/mappers.py
@@ -132,7 +132,10 @@ mappers = {
             'service_env': service_env_diff,
             'position': ('device_info__position', 'position'),
             'rack': foreign_key_diff('device_info__rack', 'rack'),
-            'venture': foreign_key_diff('venture_role', 'configuration_path'),
+            'venture': foreign_key_diff(
+                'device_info__ralph_device__venture_role',
+                'configuration_path'
+            ),
             'custom_fields': custom_fields_diff,
         },
         'blacklist': ['id', 'parent_id'],


### PR DESCRIPTION
venture_role -> device_info__ralph_device__venture_role (get it from device, not directly from asset)
