### PR TITLE
Ralph3 sync custom fields fix when value is None

### DIFF
--- a/src/ralph/export_to_ng/publishers.py
+++ b/src/ralph/export_to_ng/publishers.py
@@ -76,6 +76,14 @@ def publish_sync_ack_to_ralph3(obj, ralph3_id):
     }
 
 
+def _get_custom_fields(device):
+    result = {}
+    for key, value in device.get_property_set().items():
+        if key in settings.RALPH2_HERMES_ROLE_PROPERTY_WHITELIST:
+            result[key] = value if value is not None else ''
+    return result
+
+
 def get_device_data(device, fields=None):
     """
     Returns dictonary with device data.
@@ -92,10 +100,7 @@ def get_device_data(device, fields=None):
         'service': device.service.uid if device.service else None,
         'environment': device.device_environment_id,
         'venture_role': device.venture_role_id,
-        'custom_fields': {
-            k: v for k, v in device.get_property_set().items()
-            if k in settings.RALPH2_HERMES_ROLE_PROPERTY_WHITELIST
-        },
+        'custom_fields': _get_custom_fields(device),
     }
     return {k: v for k, v in data.items() if k in fields} if fields else data
 
@@ -187,8 +192,5 @@ def sync_virtual_server_to_ralph3(sender, instance=None, created=False, **kwargs
         'environment': instance.device_environment_id,
         'venture_role': instance.venture_role_id,
         'parent_id': asset.id if asset else None,
-        'custom_fields': {
-            k: v for k, v in instance.get_property_set().items()
-            if k in settings.RALPH2_HERMES_ROLE_PROPERTY_WHITELIST
-        },
+        'custom_fields': _get_custom_fields(instance),
     }

--- a/src/ralph/export_to_ng/tests/test_publishers.py
+++ b/src/ralph/export_to_ng/tests/test_publishers.py
@@ -6,6 +6,7 @@ from ralph.business.models import (
     RoleProperty,
     RolePropertyType,
     RolePropertyTypeValue,
+    RolePropertyValue,
     Venture,
     VentureRole,
 )
@@ -26,7 +27,7 @@ from ralph_assets.tests.utils.assets import DCAssetFactory
 @override_settings(
     RALPH3_HERMES_SYNC_ENABLED=True,
     RALPH3_HERMES_SYNC_FUNCTIONS=['sync_device_to_ralph3'],
-    RALPH2_HERMES_ROLE_PROPERTY_WHITELIST=['test_symbol'])
+    RALPH2_HERMES_ROLE_PROPERTY_WHITELIST=['test_symbol', 'test_symbol2'])
 class DevicePublisherTestCase(TestCase):
     def setUp(self):
         self.asset = DCAssetFactory()
@@ -104,8 +105,15 @@ class DevicePublisherTestCase(TestCase):
     def test_devices_properties(self):
         property_symbol = 'test_symbol'
         property_value = 'test_value'
+        property_symbol2 = 'test_symbol2'
         self.device.venture_role.roleproperty_set.create(symbol=property_symbol)  # noqa
+        prop2 = self.device.venture_role.roleproperty_set.create(
+            symbol=property_symbol2
+        )
         self.device.set_property(property_symbol, property_value, None)
+        RolePropertyValue.objects.get_or_create(
+            property=prop2, device=self.device, value=None
+        )
         result = sync_device_to_ralph3(Device, self.device)
         self.assertEqual(result, {
             'id': self.asset.id,
@@ -116,7 +124,8 @@ class DevicePublisherTestCase(TestCase):
             'management_hostname': 'mgmt-1.mydc.net',
             'venture_role': 11111,
             'custom_fields': {
-                property_symbol: property_value
+                property_symbol: property_value,
+                property_symbol2: '',
             },
         })
 


### PR DESCRIPTION
When CF value is None, send is as empty string.
