### PR TITLE
Use VentureRole.get_properties instead of Device.get_property_set for Ralph3 sync

### DIFF
--- a/src/ralph/discovery/models_device.py
+++ b/src/ralph/discovery/models_device.py
@@ -992,6 +992,8 @@ class Device(
         return [(obj, fields)] if obj else []
 
     def get_property_set(self):
+        # don't rely on this method - use venture_role.get_properties(device)
+        # instead!
         props = {}
         if self.venture:
             props.update(dict(

--- a/src/ralph/export_to_ng/publishers.py
+++ b/src/ralph/export_to_ng/publishers.py
@@ -78,9 +78,10 @@ def publish_sync_ack_to_ralph3(obj, ralph3_id):
 
 def _get_custom_fields(device):
     result = {}
-    for key, value in device.get_property_set().items():
-        if key in settings.RALPH2_HERMES_ROLE_PROPERTY_WHITELIST:
-            result[key] = value if value is not None else ''
+    if device.venture_role:
+        for key, value in device.venture_role.get_properties(device).items():
+            if key in settings.RALPH2_HERMES_ROLE_PROPERTY_WHITELIST:
+                result[key] = value if value is not None else ''
     return result
 
 


### PR DESCRIPTION
`Device.get_property_set` all `RolePropertyValue`s attached to `Device`, which might comes from some previous role of this device, but it's still attached to this device in DB - but it's NOT visible in GUI or through `puppet-classifier` endpoint, so we should not sync it as well. `puppet-classifier` use `VentureRole.get_properties` method, which returns only properties in scope of current `VentureRole`, so it should be used in Ralph3 sync too.
