### PR TITLE
Use VentureRole.get_properties instead of Device.get_property_set for Ralph2 validator

### DIFF
--- a/src/ralph/cross_validator/mappers.py
+++ b/src/ralph/cross_validator/mappers.py
@@ -67,9 +67,8 @@ def custom_fields_diff(old, new):
         dev = old.linked_device
     else:
         dev = old
-    if dev:
-        # TODO: respect whitelist of custom fields to sync
-        old_custom_fields = dev.get_property_set()
+    if dev and dev.venture_role:
+        old_custom_fields = dev.venture_role.get_properties(dev)
     else:
         old_custom_fields = {}
     new_custom_fields = new.custom_fields_as_dict

--- a/src/ralph/cross_validator/ralph2/device.py
+++ b/src/ralph/cross_validator/ralph2/device.py
@@ -65,30 +65,6 @@ class Device(SoftDeletable, models.Model):
             if ip.is_management:
                 return ip.address
 
-    def get_property_set(self):
-        props = {}
-        if self.venture:
-            props.update(dict(
-                [
-                    (p.symbol, p.default)
-                    for p in self.venture.roleproperty_set.all()
-                ]
-            ))
-        if self.venture_role:
-            props.update(dict(
-                [
-                    (p.symbol, p.default)
-                    for p in self.venture_role.roleproperty_set.all()
-                ]
-            ))
-        props.update(dict(
-            [
-                (p.property.symbol, p.value) for p in
-                self.rolepropertyvalue_set.all()
-            ]
-        ))
-        return props
-
 
 class Rack(models.Model):
     name = models.CharField(max_length=255)


### PR DESCRIPTION
See #2545 for details (TL;DR: Device.get_property_set returns invalid data in context of current VentureRole)
