### PR TITLE
DCAsset's configuration_path Ralph2 sync fix

### DIFF
--- a/src/ralph/ralph2_sync/subscribers.py
+++ b/src/ralph/ralph2_sync/subscribers.py
@@ -180,10 +180,9 @@ def sync_device_to_ralph3(data):
     if 'service' in data and 'environment' in data:
         dca.service_env = _get_service_env(data)
     if 'venture_role' in data:
-        if data['venture_role']:
-            dca.configuration_path = _get_configuration_path_from_venture_role(
-                venture_role_id=data['venture_role']
-            )
+        dca.configuration_path = _get_configuration_path_from_venture_role(
+            venture_role_id=data['venture_role']
+        )
     dca.save()
     if 'custom_fields' in data:
         for field, value in data['custom_fields'].items():

--- a/src/ralph/ralph2_sync/tests/test_subscribers.py
+++ b/src/ralph/ralph2_sync/tests/test_subscribers.py
@@ -113,6 +113,19 @@ class Ralph2DataCenterAssetTestCase(TestCase):
         ip.ethernet.refresh_from_db()
         self.assertEqual(ip.ethernet.base_object.pk, dca.pk)
 
+    def test_sync_device_empty_venture_role(self):
+        old_id = 1
+        conf_class = ConfigurationClassFactory()
+        dca = DataCenterAssetFactory(configuration_path=conf_class)
+        ImportedObjects.create(obj=dca, old_pk=old_id)
+        data = {
+            'id': old_id,
+            'venture_role': None,
+        }
+        sync_device_to_ralph3(data)
+        dca.refresh_from_db()
+        self.assertIsNone(dca.configuration_path)
+
 
 class Ralph2CustomFieldsTestCase(TestCase):
     def test_sync_custom_fields_to_ralph3_with_choices(self):


### PR DESCRIPTION
Set configuration_path to None when venture_role in data is None
