### PR TITLE
Show base object service owners in API

### DIFF
--- a/src/ralph/assets/api/serializers.py
+++ b/src/ralph/assets/api/serializers.py
@@ -156,16 +156,11 @@ class ServiceEnvironmentSimpleSerializer(RalphAPISerializer):
         source='environment_name', read_only=True
     )
     service_uid = serializers.CharField(read_only=True)
-    # business_owners = SimpleRalphUserSerializer(
-    #     many=True, source='service.business_owners')
-    # technical_owners = SimpleRalphUserSerializer(
-    #     many=True, source='service.technical_owners')
 
     class Meta:
         model = ServiceEnvironment
         fields = (
             'id', 'service', 'environment', 'url', 'service_uid',
-            # 'business_owners', 'technical_owners'
         )
         _skip_tags_field = True
 
@@ -184,9 +179,7 @@ class ServiceEnvironmentSerializer(
     class Meta:
         model = ServiceEnvironment
         depth = 1
-        exclude = (
-            'content_type', 'parent', 'service_env',
-        )
+        exclude = ('content_type', 'parent', 'service_env')
 
 
 class ManufacturerSerializer(RalphAPISerializer):

--- a/src/ralph/assets/api/serializers.py
+++ b/src/ralph/assets/api/serializers.py
@@ -149,10 +149,17 @@ class ServiceEnvironmentSimpleSerializer(RalphAPISerializer):
         source='environment_name', read_only=True
     )
     service_uid = serializers.CharField(read_only=True)
+    business_owners = SimpleRalphUserSerializer(
+        many=True, source='service.business_owners')
+    technical_owners = SimpleRalphUserSerializer(
+        many=True, source='service.technical_owners')
 
     class Meta:
         model = ServiceEnvironment
-        fields = ('id', 'service', 'environment', 'url', 'service_uid')
+        fields = (
+            'id', 'service', 'environment', 'url', 'service_uid',
+            'business_owners', 'technical_owners'
+        )
         _skip_tags_field = True
 
 
@@ -160,11 +167,19 @@ class ServiceEnvironmentSerializer(
     TypeFromContentTypeSerializerMixin, RalphAPISerializer
 ):
     __str__ = StrField(show_type=True)
+    business_owners = SimpleRalphUserSerializer(
+        many=True, source='service.business_owners'
+    )
+    technical_owners = SimpleRalphUserSerializer(
+        many=True, source='service.technical_owners'
+    )
 
     class Meta:
         model = ServiceEnvironment
         depth = 1
-        exclude = ('content_type', 'parent', 'service_env')
+        exclude = (
+            'content_type', 'parent', 'service_env',
+        )
 
 
 class ManufacturerSerializer(RalphAPISerializer):
@@ -308,9 +323,8 @@ class FibreChannelCardSerializer(FibreChannelCardSimpleSerializer):
 
 
 # used by DataCenterAsset and VirtualServer serializers
-class ComponentSerializerMixin(serializers.Serializer):
+class NetworkComponentSerializerMixin(serializers.Serializer):
     ethernet = EthernetSimpleSerializer(many=True, source='ethernet_set')
-    memory = MemorySimpleSerializer(many=True, source='memory_set')
     ipaddresses = fields.SerializerMethodField()
 
     def get_ipaddresses(self, instance):
@@ -329,6 +343,11 @@ class ComponentSerializerMixin(serializers.Serializer):
             except AttributeError:
                 pass
         return ipaddresses
+
+
+# used by DataCenterAsset and VirtualServer serializers
+class ComponentSerializerMixin(NetworkComponentSerializerMixin):
+    memory = MemorySimpleSerializer(many=True, source='memory_set')
 
 
 class DCHostSerializer(ComponentSerializerMixin, BaseObjectSerializer):

--- a/src/ralph/assets/api/serializers.py
+++ b/src/ralph/assets/api/serializers.py
@@ -40,6 +40,13 @@ class TypeFromContentTypeSerializerMixin(RalphAPISerializer):
         return instance.content_type.model
 
 
+class OwnersFromServiceEnvSerializerMixin(RalphAPISerializer):
+    business_owners = SimpleRalphUserSerializer(
+        many=True, source='service_env.service.business_owners')
+    technical_owners = SimpleRalphUserSerializer(
+        many=True, source='service_env.service.technical_owners')
+
+
 class BusinessSegmentSerializer(RalphAPISerializer):
     class Meta:
         model = BusinessSegment
@@ -149,16 +156,16 @@ class ServiceEnvironmentSimpleSerializer(RalphAPISerializer):
         source='environment_name', read_only=True
     )
     service_uid = serializers.CharField(read_only=True)
-    business_owners = SimpleRalphUserSerializer(
-        many=True, source='service.business_owners')
-    technical_owners = SimpleRalphUserSerializer(
-        many=True, source='service.technical_owners')
+    # business_owners = SimpleRalphUserSerializer(
+    #     many=True, source='service.business_owners')
+    # technical_owners = SimpleRalphUserSerializer(
+    #     many=True, source='service.technical_owners')
 
     class Meta:
         model = ServiceEnvironment
         fields = (
             'id', 'service', 'environment', 'url', 'service_uid',
-            'business_owners', 'technical_owners'
+            # 'business_owners', 'technical_owners'
         )
         _skip_tags_field = True
 
@@ -323,7 +330,7 @@ class FibreChannelCardSerializer(FibreChannelCardSimpleSerializer):
 
 
 # used by DataCenterAsset and VirtualServer serializers
-class NetworkComponentSerializerMixin(serializers.Serializer):
+class NetworkComponentSerializerMixin(OwnersFromServiceEnvSerializerMixin):
     ethernet = EthernetSimpleSerializer(many=True, source='ethernet_set')
     ipaddresses = fields.SerializerMethodField()
 

--- a/src/ralph/assets/api/views.py
+++ b/src/ralph/assets/api/views.py
@@ -44,7 +44,7 @@ class ServiceViewSet(RalphAPIViewSet):
 class ServiceEnvironmentViewSet(RalphAPIViewSet):
     queryset = models.ServiceEnvironment.objects.all()
     serializer_class = serializers.ServiceEnvironmentSerializer
-    select_related = ['service', 'environment']
+    select_related = ['service', 'environment', 'service__support_team']
     # allow to only add environments through service resource
     http_method_names = ['get', 'delete']
     prefetch_related = ['tags'] + [
@@ -87,7 +87,9 @@ class BaseObjectViewSet(PolymorphicViewSetMixin, RalphAPIViewSet):
         Prefetch(
             'custom_fields',
             queryset=CustomFieldValue.objects.select_related('custom_field')
-        )
+        ),
+        'service_env__service__business_owners',
+        'service_env__service__technical_owners',
     ]
     filter_fields = [
         'id', 'service_env', 'service_env', 'service_env__service__uid',

--- a/src/ralph/assets/tests/test_api.py
+++ b/src/ralph/assets/tests/test_api.py
@@ -698,7 +698,7 @@ class DCHostAPITests(RalphAPITestCase):
 
     def test_get_dc_hosts_list(self):
         url = reverse('dchost-list')
-        with self.assertNumQueries(13):
+        with self.assertNumQueries(15):
             response = self.client.get(url, format='json')
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data['count'], 3)

--- a/src/ralph/data_center/api/serializers.py
+++ b/src/ralph/data_center/api/serializers.py
@@ -5,7 +5,8 @@ from ralph.api import RalphAPISerializer
 from ralph.assets.api.serializers import (
     AssetSerializer,
     BaseObjectSerializer,
-    ComponentSerializerMixin
+    ComponentSerializerMixin,
+    OwnersFromServiceEnvSerializerMixin
 )
 from ralph.data_center.models import (
     Accessory,
@@ -41,7 +42,9 @@ class BaseObjectClusterSerializer(RalphAPISerializer):
         fields = ('id', 'url', 'base_object', 'is_master', 'cluster')
 
 
-class ClusterSerializer(ClusterSimpleSerializer):
+class ClusterSerializer(
+    OwnersFromServiceEnvSerializerMixin, ClusterSimpleSerializer
+):
     base_objects = BaseObjectClusterSerializer(
         many=True, read_only=True, source='baseobjectcluster_set'
     )

--- a/src/ralph/data_center/api/views.py
+++ b/src/ralph/data_center/api/views.py
@@ -111,11 +111,13 @@ class BaseObjectClusterViewSet(RalphAPIViewSet):
     serializer_class = BaseObjectClusterSerializer
 
 
-class ClusterViewSet(RalphAPIViewSet):
+class ClusterViewSet(BaseObjectViewSetMixin, RalphAPIViewSet):
     queryset = Cluster.objects.all()
     serializer_class = ClusterSerializer
     select_related = [
         'type', 'parent', 'service_env', 'service_env__service',
-        'service_env__environment',
+        'service_env__environment', 'configuration_path', 'content_type'
     ]
-    prefetch_related = ['tags', 'baseobjectcluster_set']
+    prefetch_related = BaseObjectViewSet.prefetch_related + [
+        'tags', 'baseobjectcluster_set',
+    ]

--- a/src/ralph/data_center/tests/test_api.py
+++ b/src/ralph/data_center/tests/test_api.py
@@ -49,7 +49,7 @@ class DataCenterAssetAPITests(RalphAPITestCase):
 
     def test_get_data_center_assets_list(self):
         url = reverse('datacenterasset-list')
-        with self.assertNumQueries(11):
+        with self.assertNumQueries(12):
             response = self.client.get(url, format='json')
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(

--- a/src/ralph/data_center/tests/test_api.py
+++ b/src/ralph/data_center/tests/test_api.py
@@ -49,7 +49,7 @@ class DataCenterAssetAPITests(RalphAPITestCase):
 
     def test_get_data_center_assets_list(self):
         url = reverse('datacenterasset-list')
-        with self.assertNumQueries(12):
+        with self.assertNumQueries(13):
             response = self.client.get(url, format='json')
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(

--- a/src/ralph/data_center/tests/test_api.py
+++ b/src/ralph/data_center/tests/test_api.py
@@ -41,6 +41,9 @@ class DataCenterAssetAPITests(RalphAPITestCase):
             position=10,
             model=self.model,
         )
+        self.dc_asset.service_env.service.business_owners = [self.user1]
+        self.dc_asset.service_env.service.technical_owners = [self.user2]
+        self.dc_asset.service_env.save()
         self.ip = IPAddressFactory(
             ethernet=EthernetFactory(base_object=self.dc_asset)
         )
@@ -75,6 +78,12 @@ class DataCenterAssetAPITests(RalphAPITestCase):
         self.assertEqual(len(response.data['memory']), 2)
         self.assertEqual(response.data['memory'][0]['speed'], 1600)
         self.assertEqual(response.data['memory'][0]['size'], 8192)
+        self.assertEqual(
+            response.data['business_owners'][0]['username'], 'user1'
+        )
+        self.assertEqual(
+            response.data['technical_owners'][0]['username'], 'user2'
+        )
 
     def test_create_data_center_asset(self):
         url = reverse('datacenterasset-list')
@@ -397,6 +406,9 @@ class ClusterAPITests(RalphAPITestCase):
             is_master=True
         )
         self.cluster_2 = ClusterFactory()
+        self.cluster_1.service_env.service.business_owners = [self.user1]
+        self.cluster_1.service_env.service.technical_owners = [self.user2]
+        self.cluster_1.service_env.save()
 
     def test_create_cluster(self):
         url = reverse('cluster-list')
@@ -422,19 +434,18 @@ class ClusterAPITests(RalphAPITestCase):
         cluster = Cluster.objects.get(pk=response.data['id'])
         self.assertEqual(cluster.hostname, data['hostname'])
 
-    # TODO: waiting for #2423
-    # def test_create_cluster_without_hostname_or_name(self):
-    #     url = reverse('cluster-list')
-    #     data = {
-    #         'type': self.cluster_type.id,
-    #         'service_env': self.service_env.id,
-    #     }
-    #     response = self.client.post(url, data, format='json')
-    #     self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
-    #     self.assertEqual(response.data, {
-    #         'name': ['At least one of name or hostname is required'],
-    #         'hostname': ['At least one of name or hostname is required'],
-    #     })
+    def test_create_cluster_without_hostname_or_name(self):
+        url = reverse('cluster-list')
+        data = {
+            'type': self.cluster_type.id,
+            'service_env': self.service_env.id,
+        }
+        response = self.client.post(url, data, format='json')
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(response.data, {
+            'name': ['At least one of name or hostname is required'],
+            'hostname': ['At least one of name or hostname is required'],
+        })
 
     def test_list_cluster(self):
         url = reverse('cluster-list')
@@ -451,6 +462,12 @@ class ClusterAPITests(RalphAPITestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data['name'], self.cluster_1.name)
         self.assertEqual(response.data['hostname'], self.cluster_1.hostname)
+        self.assertEqual(
+            response.data['business_owners'][0]['username'], 'user1'
+        )
+        self.assertEqual(
+            response.data['technical_owners'][0]['username'], 'user2'
+        )
         self.assertEqual(len(response.data['base_objects']), 2)
         self.assertCountEqual(response.data['base_objects'], [
             {

--- a/src/ralph/supports/api.py
+++ b/src/ralph/supports/api.py
@@ -40,7 +40,7 @@ class SupportSerializer(TypeFromContentTypeSerializerMixin, RalphAPISerializer):
     class Meta:
         model = Support
         depth = 1
-        exclude = ('content_type', 'service_env')
+        exclude = ('content_type', 'service_env', 'configuration_path')
 
 
 class SupportViewSet(RalphAPIViewSet):

--- a/src/ralph/virtual/tests/test_api.py
+++ b/src/ralph/virtual/tests/test_api.py
@@ -306,7 +306,7 @@ class VirtualServerAPITestCase(RalphAPITestCase):
 
     def test_get_virtual_server_list(self):
         url = reverse('virtualserver-list')
-        with self.assertNumQueries(9):
+        with self.assertNumQueries(11):
             response = self.client.get(url, format='json')
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data['count'], 2)

--- a/src/ralph/virtual/tests/test_api.py
+++ b/src/ralph/virtual/tests/test_api.py
@@ -45,7 +45,9 @@ class OpenstackModelsTestCase(RalphAPITestCase):
             self.service_env.append(ServiceEnvironment.objects.create(
                 service=self.services[i], environment=self.envs[i]
             ))
-
+        self.service_env[0].service.business_owners = [self.user1]
+        self.service_env[0].service.technical_owners = [self.user2]
+        self.service_env[0].save()
         self.cloud_provider = CloudProviderFactory(name='openstack')
         self.cloud_flavor = CloudFlavorFactory()
         self.cloud_project = CloudProjectFactory(
@@ -122,6 +124,12 @@ class OpenstackModelsTestCase(RalphAPITestCase):
                          self.cloud_flavor.disk)
         self.assertEqual(response.data['cloudflavor']['name'],
                          self.cloud_flavor.name)
+        self.assertEqual(
+            response.data['business_owners'][0]['username'], 'user1'
+        )
+        self.assertEqual(
+            response.data['technical_owners'][0]['username'], 'user2'
+        )
 
     def test_get_cloudproject_detail(self):
         url = reverse('cloudproject-detail', args=(self.cloud_project.id,))
@@ -299,6 +307,9 @@ class VirtualServerAPITestCase(RalphAPITestCase):
         self.cluster = ClusterFactory()
         self.type = VirtualServerType.objects.create(name='XEN')
         self.virtual_server = VirtualServerFullFactory()
+        self.virtual_server.service_env.service.business_owners = [self.user1]
+        self.virtual_server.service_env.service.technical_owners = [self.user2]
+        self.virtual_server.service_env.save()
         self.virtual_server2 = VirtualServerFullFactory()
         self.ip = IPAddressFactory(
             ethernet=EthernetFactory(base_object=self.virtual_server2)
@@ -331,6 +342,12 @@ class VirtualServerAPITestCase(RalphAPITestCase):
         self.assertEqual(len(response.data['memory']), 2)
         self.assertEqual(response.data['memory'][0]['speed'], 1600)
         self.assertEqual(response.data['memory'][0]['size'], 8192)
+        self.assertEqual(
+            response.data['business_owners'][0]['username'], 'user1'
+        )
+        self.assertEqual(
+            response.data['technical_owners'][0]['username'], 'user2'
+        )
 
     def test_create_virtual_server(self):
         virtual_server_count = VirtualServer.objects.count()


### PR DESCRIPTION
New fields `business_owners` and `technical_owners` added to `DataCenterAsset`, `VirtualServer`, `CloudHost`, `Cluster` and `ServiceEnvironment` serializers. It's list of short user info (username, first and last name).
