### PR TITLE
Add `use as configuration variable` property to custom fields

### DIFF
--- a/docs/user/custom_fields.md
+++ b/docs/user/custom_fields.md
@@ -22,6 +22,7 @@ Possible options:
     * `choice list`
 * `choices` - fill it if you've chosen `choices` type. This is list of possible choices for your custom field. Separate choices by `|`, ex. `abc|def|ghi`.
 * `default value` - if you fill it, this value will be used as a default for your custom field,
+* `use as configuration variable` - when set, this variable will be exposed in API in "configuration_variables" field. You could use this later in configuration management tool like Puppet or Ansible.
 
 Example:
 
@@ -59,7 +60,10 @@ Example:
     ...
     "custom_fields": {
         "monitoring": "zabbix",
-        "docker_version": "1.11"
+        "docker_version": "1.11"  # this field doesn't have `use_as_configuration_variable` checked, so it won't be visible in `configuration_variables` field
+    },
+    "configuration_variables": {
+        "monitoring": "zabbix"
     },
     ...
 }

--- a/docs/user/dcim.md
+++ b/docs/user/dcim.md
@@ -22,3 +22,5 @@ Then you could add configuration classes (`http://<YOUR_RALPH_URL>/assets/config
 > For Ansible, this could be mapped to [Playbook](http://docs.ansible.com/ansible/playbooks.html).
 
 Finally, you could attach configuration to your host (`Data Center Asset`, `Virtual Server` etc.) using `configuration path` field. This could be used for administrators information only, but you could use this to automate you configuration management tool as well! Simply fetch `configuration_path` for host from Ralph's API and apply it in your tool.
+
+You could use custom fields to set some variables passed to your configuration management tool. To show custom field under `configuration_variables` field in REST API, select `use as configuration variable` in its settings. See [Custom fields](/user/custom_fields) section for more infromation.

--- a/docs/user/quickstart.md
+++ b/docs/user/quickstart.md
@@ -234,4 +234,4 @@ As always, you can add as many attachments(for example pdf scans of support cont
 So, this is it! Congratulations, you've finished our Quickstart!
 
 
-You might want to learn Workflow(Transitions) tutorial and customization, PDF templates, permissions customization and many more - just follow [advanced user guide](/user/guide.md)
+You might want to learn Workflow(Transitions) tutorial and customization, PDF templates, permissions customization and many more - just follow [advanced user guide](/user/guide)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -9,6 +9,7 @@ pages:
   - User guide:
       - Quickstart: user/quickstart.md
       - Advanced guide: user/guide.md
+      - DCIM: user/dcim.md
       - Domains management: user/domains.md
       - Custom fields: user/custom_fields.md
       - Dashboards: user/dashboards.md

--- a/src/ralph/lib/custom_fields/admin.py
+++ b/src/ralph/lib/custom_fields/admin.py
@@ -13,10 +13,16 @@ from ralph.lib.custom_fields.views import CustomFieldFormfieldView
 
 @register(CustomField)
 class CustomFieldAdmin(RalphAdmin):
-    list_display = ['name', 'attribute_name', 'type', 'default_value']
+    list_display = [
+        'name', 'attribute_name', 'type', 'default_value',
+        'use_as_configuration_variable'
+    ]
     search_fields = ['name', 'attribute_name']
     list_filter = ['type']
-    fields = ['name', 'attribute_name', 'type', 'choices', 'default_value']
+    fields = [
+        'name', 'attribute_name', 'type', 'choices', 'default_value',
+        'use_as_configuration_variable'
+    ]
     readonly_fields = ['attribute_name']
 
     def get_urls(self):

--- a/src/ralph/lib/custom_fields/api/serializers.py
+++ b/src/ralph/lib/custom_fields/api/serializers.py
@@ -97,9 +97,21 @@ class WithCustomFieldsSerializerMixin(serializers.Serializer):
     attribute_name of custom_field and value is value of custom field.
     """
     custom_fields = serializers.SerializerMethodField()
+    configuration_variables = serializers.SerializerMethodField()
 
     def get_custom_fields(self, obj):
+        # use base manager to not execute separated query when
+        # custom fields are included in prefetch_related
         return {
             cfv.custom_field.attribute_name: cfv.value
             for cfv in obj.custom_fields.all()
+        }
+
+    def get_configuration_variables(self, obj):
+        # use base manager to not execute separated query when
+        # custom fields are included in prefetch_related
+        return {
+            cfv.custom_field.attribute_name: cfv.value
+            for cfv in obj.custom_fields.all()
+            if cfv.custom_field.use_as_configuration_variable
         }

--- a/src/ralph/lib/custom_fields/migrations/0002_customfield_use_as_configuration_variable.py
+++ b/src/ralph/lib/custom_fields/migrations/0002_customfield_use_as_configuration_variable.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('custom_fields', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='customfield',
+            name='use_as_configuration_variable',
+            field=models.BooleanField(default=False, help_text='When set, this variable will be exposed in API in "configuration_variables" section. You could use this later in configuration management tool like Puppet or Ansible.'),
+        ),
+    ]

--- a/src/ralph/lib/custom_fields/models.py
+++ b/src/ralph/lib/custom_fields/models.py
@@ -7,7 +7,6 @@ from django.contrib.contenttypes.fields import GenericRelation
 from django.contrib.contenttypes.models import ContentType
 from django.core.exceptions import ValidationError
 from django.db import models
-from django.utils.functional import cached_property
 from django.utils.text import capfirst, slugify
 from django.utils.translation import ugettext_lazy as _
 

--- a/src/ralph/lib/custom_fields/tests/test_api.py
+++ b/src/ralph/lib/custom_fields/tests/test_api.py
@@ -20,7 +20,8 @@ class CustomFieldsAPITests(APITestCase):
         )
         cls.custom_field_choices = CustomField.objects.create(
             name='test choice', type=CustomFieldTypes.CHOICE,
-            choices='qwerty|asdfgh|zxcvbn', default_value='zxcvbn'
+            choices='qwerty|asdfgh|zxcvbn', default_value='zxcvbn',
+            use_as_configuration_variable=True,
         )
 
         cls.user = get_user_model().objects.create_superuser(
@@ -52,6 +53,23 @@ class CustomFieldsAPITests(APITestCase):
             custom_field=self.custom_field_str,
             value='sample_value2',
         )
+
+    def test_get_customfields_in_object_resource(self):
+        url = reverse('somemodel-detail', args=(self.sm2.id,))
+        response = self.client.get(url, format='json')
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data['custom_fields'], {
+            'test_str': 'sample_value2',
+            'test_choice': 'qwerty',
+        })
+
+    def test_get_configuration_variables_in_object_resource(self):
+        url = reverse('somemodel-detail', args=(self.sm2.id,))
+        response = self.client.get(url, format='json')
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data['configuration_variables'], {
+            'test_choice': 'qwerty',
+        })
 
     def test_get_customfields_for_single_object(self):
         url = reverse(self.list_view_name, args=(self.sm1.id,))


### PR DESCRIPTION
- this field allow to specify variables which should be exposed to (for example) configuration management tools
- new API field: `configuration_variables`, which contains subset of `custom_fields` field - only the ones with `use_as_configuration_variable` checked
