### PR TITLE
Components: add support for processors.

### DIFF
--- a/src/ralph/assets/api/routers.py
+++ b/src/ralph/assets/api/routers.py
@@ -12,9 +12,9 @@ from ralph.assets.api.views import (
     EnvironmentViewSet,
     EthernetViewSet,
     FibreChannelCardViewSet,
-    ProcessorViewSet,
     ManufacturerViewSet,
     MemoryViewSet,
+    ProcessorViewSet,
     ProfitCenterViewSet,
     ServiceEnvironmentViewSet,
     ServiceViewSet

--- a/src/ralph/assets/api/routers.py
+++ b/src/ralph/assets/api/routers.py
@@ -12,6 +12,7 @@ from ralph.assets.api.views import (
     EnvironmentViewSet,
     EthernetViewSet,
     FibreChannelCardViewSet,
+    ProcessorViewSet,
     ManufacturerViewSet,
     MemoryViewSet,
     ProfitCenterViewSet,
@@ -32,6 +33,7 @@ router.register(r'fibre-channel-cards', FibreChannelCardViewSet)
 router.register(r'ethernets', EthernetViewSet)
 router.register(r'memory', MemoryViewSet)
 router.register(r'manufacturers', ManufacturerViewSet)
+router.register(r'processors', ProcessorViewSet)
 router.register(r'profit-centers', ProfitCenterViewSet)
 router.register(r'services-environments', ServiceEnvironmentViewSet)
 router.register(r'services', ServiceViewSet)

--- a/src/ralph/assets/api/serializers.py
+++ b/src/ralph/assets/api/serializers.py
@@ -343,6 +343,8 @@ class ProcessorSerializer(ProcessorSimpleSerializer):
 # used by DataCenterAsset and VirtualServer serializers
 class NetworkComponentSerializerMixin(OwnersFromServiceEnvSerializerMixin):
     ethernet = EthernetSimpleSerializer(many=True, source='ethernet_set')
+    memory = MemorySimpleSerializer(many=True, source='memory_set')
+    processor = ProcessorSimpleSerializer(many=True, source='processor_set')
     ipaddresses = fields.SerializerMethodField()
 
     def get_ipaddresses(self, instance):

--- a/src/ralph/assets/api/serializers.py
+++ b/src/ralph/assets/api/serializers.py
@@ -322,6 +322,19 @@ class FibreChannelCardSerializer(FibreChannelCardSimpleSerializer):
         exclude = ('model',)
 
 
+class ProcessorSimpleSerializer(RalphAPISerializer):
+    class Meta:
+        model = Processor
+        fields = ('id', 'url', 'speed', 'cores')
+
+
+class ProcessorSerializer(ProcessorSimpleSerializer):
+    class Meta:
+        depth = 1
+        model = Processor
+        exclude = ('model',)
+
+
 # used by DataCenterAsset and VirtualServer serializers
 class NetworkComponentSerializerMixin(OwnersFromServiceEnvSerializerMixin):
     ethernet = EthernetSimpleSerializer(many=True, source='ethernet_set')

--- a/src/ralph/assets/api/serializers.py
+++ b/src/ralph/assets/api/serializers.py
@@ -27,7 +27,12 @@ from ralph.assets.models import (
     Service,
     ServiceEnvironment
 )
-from ralph.assets.models.components import Ethernet, FibreChannelCard, Memory
+from ralph.assets.models.components import (
+    Ethernet,
+    FibreChannelCard,
+    Memory,
+    Processor
+)
 from ralph.lib.custom_fields.api import WithCustomFieldsSerializerMixin
 from ralph.licences.api_simple import SimpleBaseObjectLicenceSerializer
 from ralph.networks.api_simple import IPAddressSimpleSerializer

--- a/src/ralph/assets/api/serializers.py
+++ b/src/ralph/assets/api/serializers.py
@@ -342,9 +342,8 @@ class ProcessorSerializer(ProcessorSimpleSerializer):
 
 # used by DataCenterAsset and VirtualServer serializers
 class NetworkComponentSerializerMixin(OwnersFromServiceEnvSerializerMixin):
+    # TODO(xor-xor): ethernet -> ethernets
     ethernet = EthernetSimpleSerializer(many=True, source='ethernet_set')
-    memory = MemorySimpleSerializer(many=True, source='memory_set')
-    processor = ProcessorSimpleSerializer(many=True, source='processor_set')
     ipaddresses = fields.SerializerMethodField()
 
     def get_ipaddresses(self, instance):
@@ -368,6 +367,7 @@ class NetworkComponentSerializerMixin(OwnersFromServiceEnvSerializerMixin):
 # used by DataCenterAsset and VirtualServer serializers
 class ComponentSerializerMixin(NetworkComponentSerializerMixin):
     memory = MemorySimpleSerializer(many=True, source='memory_set')
+    processors = ProcessorSimpleSerializer(many=True, source='processor_set')
 
 
 class DCHostSerializer(ComponentSerializerMixin, BaseObjectSerializer):

--- a/src/ralph/assets/api/views.py
+++ b/src/ralph/assets/api/views.py
@@ -157,7 +157,7 @@ class FibreChannelCardViewSet(RalphAPIViewSet):
 class ProcessorViewSet(RalphAPIViewSet):
     queryset = models.Processor.objects.all()
     serializer_class = serializers.ProcessorSerializer
-    filter_fields = ['base_object']  # XXX what else we may need here..?
+    filter_fields = ['base_object', 'cores']
     prefetch_related = ['base_object', 'base_object__tags']
 
 

--- a/src/ralph/assets/api/views.py
+++ b/src/ralph/assets/api/views.py
@@ -154,6 +154,13 @@ class FibreChannelCardViewSet(RalphAPIViewSet):
     prefetch_related = ['base_object', 'base_object__tags']
 
 
+class ProcessorViewSet(RalphAPIViewSet):
+    queryset = models.Processor.objects.all()
+    serializer_class = serializers.ProcessorSerializer
+    filter_fields = ['base_object']  # XXX what else we may need here..?
+    prefetch_related = ['base_object', 'base_object__tags']
+
+
 class ConfigurationModuleViewSet(RalphAPIViewSet):
     queryset = models.ConfigurationModule.objects.all()
     serializer_class = serializers.ConfigurationModuleSerializer

--- a/src/ralph/assets/migrations/0017_processor.py
+++ b/src/ralph/assets/migrations/0017_processor.py
@@ -1,0 +1,32 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+import django.db.models.deletion
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('assets', '0016_fibrechannelcard'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='Processor',
+            fields=[
+                ('id', models.AutoField(verbose_name='ID', auto_created=True, primary_key=True, serialize=False)),
+                ('created', models.DateTimeField(verbose_name='date created', auto_now_add=True)),
+                ('modified', models.DateTimeField(verbose_name='last modified', auto_now=True)),
+                ('model_name', models.CharField(null=True, verbose_name='model name', blank=True, max_length=255)),
+                ('speed', models.PositiveIntegerField(null=True, verbose_name='speed (MHz)', blank=True)),
+                ('cores', models.PositiveIntegerField(null=True, blank=True)),
+                ('base_object', models.ForeignKey(related_name='processor_set', to='assets.BaseObject')),
+                ('model', models.ForeignKey(on_delete=django.db.models.deletion.SET_NULL, blank=True, null=True, verbose_name='model', to='assets.ComponentModel', default=None)),
+            ],
+            options={
+                'verbose_name': 'processor',
+                'verbose_name_plural': 'processors',
+            },
+        ),
+    ]

--- a/src/ralph/assets/models/__init__.py
+++ b/src/ralph/assets/models/__init__.py
@@ -27,6 +27,7 @@ from ralph.assets.models.components import (
     Ethernet,
     Memory,
     FibreChannelCard,
+    Processor
 )
 from ralph.assets.models.configuration import (
     ConfigurationClass,
@@ -57,6 +58,7 @@ __all__ = [
     'ModelVisualizationLayout',
     'ObjectModelType',
     'ProfitCenter',
+    'Processor',
     'Service',
     'ServiceEnvironment',
     'Ethernet',

--- a/src/ralph/assets/models/components.py
+++ b/src/ralph/assets/models/components.py
@@ -206,3 +206,17 @@ class FibreChannelCard(Component):
 
     def __str__(self):
         return 'model: "{}", WWN: "{}"'.format(self.model_name, self.wwn)
+
+
+class Processor(Component):
+    speed = models.PositiveIntegerField(
+        verbose_name=_("speed (MHz)"), null=True, blank=True,
+    )
+    cores = models.PositiveIntegerField(null=True, blank=True)
+
+    class Meta:
+        verbose_name = _('processor')
+        verbose_name_plural = _('processors')
+
+    def __str__(self):
+        return self.model_name

--- a/src/ralph/assets/tests/factories.py
+++ b/src/ralph/assets/tests/factories.py
@@ -252,3 +252,13 @@ class FibreChannelCardFactory(DjangoModelFactory):
 
     class Meta:
         model = FibreChannelCard
+
+
+class ProcessorFactory(DjangoModelFactory):
+    base_object = factory.SubFactory(BaseObjectFactory)
+    speed = factory.Iterator([2500, 2600, 3000, 3200])
+    cores = factory.Iterator([4, 8, 16])
+    model_name = "Intel(R) Xeon(R) CPU"
+
+    class Meta:
+        model = Processor

--- a/src/ralph/assets/tests/factories.py
+++ b/src/ralph/assets/tests/factories.py
@@ -16,7 +16,12 @@ from ralph.assets.models.assets import (
 )
 from ralph.assets.models.base import BaseObject
 from ralph.assets.models.choices import ObjectModelType
-from ralph.assets.models.components import Ethernet, FibreChannelCard, Memory
+from ralph.assets.models.components import (
+    Ethernet,
+    FibreChannelCard,
+    Memory,
+    Processor
+)
 from ralph.assets.models.configuration import (
     ConfigurationClass,
     ConfigurationModule

--- a/src/ralph/assets/views.py
+++ b/src/ralph/assets/views.py
@@ -5,7 +5,8 @@ from ralph.admin.views.extra import RalphDetailViewAdmin
 from ralph.assets.models.components import (
     FibreChannelCard,
     GenericComponent,
-    Memory
+    Memory,
+    Processor
 )
 
 

--- a/src/ralph/assets/views.py
+++ b/src/ralph/assets/views.py
@@ -35,4 +35,18 @@ class ComponentsAdminView(RalphDetailViewAdmin):
         )
         extra = 1
 
-    inlines = [GenericComponentInline, MemoryInline, FibreChannelCardInline]
+    class ProcessorInline(RalphTabularInline):
+        model = Processor
+        fields = (
+            'model_name',
+            'speed',
+            'cores',
+        )
+        extra = 1
+
+    inlines = [
+        GenericComponentInline,
+        MemoryInline,
+        FibreChannelCardInline,
+        ProcessorInline,
+    ]

--- a/src/ralph/data_center/api/views.py
+++ b/src/ralph/data_center/api/views.py
@@ -56,6 +56,7 @@ class DataCenterAssetViewSet(BaseObjectViewSetMixin, RalphAPIViewSet):
             queryset=Ethernet.objects.select_related('ipaddress')
         ),
         'fibrechannelcard_set',
+        'processor_set',
     ]
     filter_fields = [
         'service_env__service__uid',

--- a/src/ralph/data_center/tests/factories.py
+++ b/src/ralph/data_center/tests/factories.py
@@ -166,6 +166,8 @@ class DataCenterAssetFullFactory(DataCenterAssetFactory):
     mem2 = factory.RelatedFactory(MemoryFactory, 'base_object')
     fc_card1 = factory.RelatedFactory(FibreChannelCardFactory, 'base_object')
     fc_card2 = factory.RelatedFactory(FibreChannelCardFactory, 'base_object')
+    proc1 = factory.RelatedFactory(ProcessorFactory, 'base_object')
+    proc2 = factory.RelatedFactory(ProcessorFactory, 'base_object')
 
     @factory.post_generation
     def post_tags(self, create, extracted, **kwargs):

--- a/src/ralph/data_center/tests/factories.py
+++ b/src/ralph/data_center/tests/factories.py
@@ -14,6 +14,7 @@ from ralph.assets.tests.factories import (
     EthernetWithIPAddressFactory,
     FibreChannelCardFactory,
     MemoryFactory,
+    ProcessorFactory,
     ServiceEnvironmentFactory
 )
 from ralph.data_center.models.physical import (

--- a/src/ralph/data_center/tests/test_api.py
+++ b/src/ralph/data_center/tests/test_api.py
@@ -52,7 +52,7 @@ class DataCenterAssetAPITests(RalphAPITestCase):
 
     def test_get_data_center_assets_list(self):
         url = reverse('datacenterasset-list')
-        with self.assertNumQueries(13):
+        with self.assertNumQueries(14):
             response = self.client.get(url, format='json')
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(

--- a/src/ralph/virtual/tests/test_api.py
+++ b/src/ralph/virtual/tests/test_api.py
@@ -317,7 +317,7 @@ class VirtualServerAPITestCase(RalphAPITestCase):
 
     def test_get_virtual_server_list(self):
         url = reverse('virtualserver-list')
-        with self.assertNumQueries(11):
+        with self.assertNumQueries(13):
             response = self.client.get(url, format='json')
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data['count'], 2)


### PR DESCRIPTION
Ready for review.

@mkurek - do we want to add this component to `ralph.virtual.api`..? I guess we want, because [memory is already there](https://github.com/allegro/ralph/pull/2487/files).

And also, see my remark at `ProcessorViewSet` (`filter_fields`).
