### PR TITLE
Fix network env subscriber

### DIFF
--- a/src/ralph/ralph2_sync/subscribers.py
+++ b/src/ralph/ralph2_sync/subscribers.py
@@ -21,6 +21,7 @@ from ralph.data_center.models import (
     Cluster,
     ClusterStatus,
     ClusterType,
+    DataCenter,
     DataCenterAsset,
     Rack
 )
@@ -430,7 +431,7 @@ def sync_network_environment_to_ralph3(data):
     env, created = _get_obj(NetworkEnvironment, data['id'], creating=True)
     env.name = data['name']
     if 'data_center_id' in data:
-        env.data_center_id = data['data_center_id']
+        env.data_center = _get_obj(DataCenter, data['data_center_id'])[0]
     env.domain = data['domain']
     env.remarks = data['remarks']
     if created:

--- a/src/ralph/ralph2_sync/tests/test_subscribers.py
+++ b/src/ralph/ralph2_sync/tests/test_subscribers.py
@@ -432,7 +432,7 @@ class Ralph2NetworkTestCase(TestCase):
             'dns_servers': [],
         }
 
-    def _create_imported_network(self):
+    def _create_imported_network(self, old_id=None):
         return _create_imported_object(
             factory=NetworkFactory,
             old_id=old_id if old_id else self.data['id']
@@ -513,11 +513,13 @@ class Ralph2NetworkKindTestCase(TestCase):
 
 class Ralph2NetworkEnvironmentTestCase(TestCase):
     def setUp(self):
-        self.dc = DataCenterFactory()
+        self.dc = _create_imported_object(
+            factory=DataCenterFactory, old_id=10
+        )
         self.data = {
             'id': 1,
             'name': 'net-env',
-            'data_center_id': self.dc.id,
+            'data_center_id': 10,
             'domain': 'foo.net',
             'remarks': '',
             'hostname_template_prefix': 's1',


### PR DESCRIPTION
Get DataCenter from ImportedObject instead of assigning (Ralph2!) id directly.
