### PR TITLE
Add gateway field to network

### DIFF
--- a/src/ralph/dhcp/views.py
+++ b/src/ralph/dhcp/views.py
@@ -200,7 +200,7 @@ class DHCPNetworksView(
         networks = self.networks.filter(
             network_environment__domain__isnull=False,
             dhcp_broadcast=True,
-            ips__is_gateway=True,
+            gateway__isnull=False,
         ).exclude(
             network_environment=False
         ).prefetch_related('dns_servers')

--- a/src/ralph/networks/admin.py
+++ b/src/ralph/networks/admin.py
@@ -56,8 +56,10 @@ class DiscoveryQueueAdmin(RalphAdmin):
 
 
 class NetworkForm(RalphAdminFormMixin, ModelForm):
-    top_margin = forms.IntegerField(initial=settings.DEFAULT_NETWORK_MARGIN)
-    bottom_margin = forms.IntegerField(initial=settings.DEFAULT_NETWORK_MARGIN)
+    top_margin = forms.IntegerField(initial=settings.DEFAULT_NETWORK_TOP_MARGIN)
+    bottom_margin = forms.IntegerField(
+        initial=settings.DEFAULT_NETWORK_BOTTOM_MARGIN
+    )
 
     class Meta:
         model = Network
@@ -125,7 +127,7 @@ class NetworkAdmin(RalphMPTTAdmin):
         ('min_ip', NetworkRangeFilter)
     ]
     list_select_related = ['kind', 'network_environment']
-    raw_id_fields = ['racks', 'terminators', 'service_env']
+    raw_id_fields = ['racks', 'gateway', 'terminators', 'service_env']
     resource_class = resources.NetworkResource
     readonly_fields = [
         'show_subnetworks', 'show_addresses', 'show_parent_networks'
@@ -139,9 +141,9 @@ class NetworkAdmin(RalphMPTTAdmin):
     fieldsets = (
         (_('Basic info'), {
             'fields': [
-                'name', 'address', 'remarks', 'terminators', 'vlan', 'racks',
-                'network_environment', 'dns_servers', 'kind', 'service_env',
-                'dhcp_broadcast', 'top_margin', 'bottom_margin'
+                'name', 'address', 'gateway', 'remarks', 'terminators', 'vlan',
+                'racks', 'network_environment', 'dns_servers', 'kind',
+                'service_env', 'dhcp_broadcast', 'bottom_margin', 'top_margin',
             ]
         }),
         (_('Relations'), {

--- a/src/ralph/networks/migrations/0005_network_gateway.py
+++ b/src/ralph/networks/migrations/0005_network_gateway.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('networks', '0004_auto_20160606_1512'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='network',
+            name='gateway',
+            field=models.ForeignKey(to='networks.IPAddress', null=True, verbose_name='Gateway address', blank=True, related_name='gateway_network'),
+        ),
+    ]

--- a/src/ralph/networks/tests/test_models.py
+++ b/src/ralph/networks/tests/test_models.py
@@ -138,19 +138,6 @@ class NetworkTest(RalphTestCase):
         result = ip.get_network()
         self.assertEqual(None, result)
 
-    def test_network_should_return_gateway(self):
-        net = Network.objects.create(
-            name='ip_address_should_return_gateway',
-            address='10.1.1.0/24',
-        )
-        net.save()
-        ip = IPAddress.objects.create(
-            address='10.1.1.2',
-            is_gateway=True,
-            network=net
-        )
-        self.assertEqual(net.gateway, ip.ip)
-
     def test_reserve_margin_addresses_should_reserve_free_addresses(self):
         net = Network.objects.create(
             name='ip_address_should_return_network',

--- a/src/ralph/ralph2_sync/subscribers.py
+++ b/src/ralph/ralph2_sync/subscribers.py
@@ -394,22 +394,14 @@ def sync_network_to_ralph3(data):
             )
     if 'gateway' in data:
         if data['gateway']:
-            IPAddress.objects.filter(
-                network=net,
-                is_gateway=True
-            ).delete()
-            IPAddress.objects.update_or_create(
+            net.gateway = IPAddress.objects.update_or_create(
                 address=data['gateway'],
                 defaults=dict(
-                    network=net,
                     is_gateway=True
                 )
-            )
+            )[0]
         else:
-            IPAddress.objects.filter(
-                network=net,
-                is_gateway=True
-            ).delete()
+            net.gateway = None
     net.network_environment = _get_obj(
         NetworkEnvironment, data['environment_id']
     )[0]

--- a/src/ralph/settings/base.py
+++ b/src/ralph/settings/base.py
@@ -326,9 +326,10 @@ OPENSTACK_INSTANCES = json.loads(os.environ.get('OPENSTACK_INSTANCES', '[]'))
 ISSUE_TRACKER_URL = os.environ.get('ISSUE_TRACKER_URL', '')
 
 # Networks
-DEFAULT_NETWORK_MARGIN = int(os.environ.get('DEFAULT_NETWORK_MARGIN', 10))  # deprecated, to remove in the future
-DEFAULT_NETWORK_TOP_MARGIN = int(os.environ.get('DEFAULT_NETWORK_TOP_MARGIN', 10))
-DEFAULT_NETWORK_BOTTOM_MARGIN = int(os.environ.get('DEFAULT_NETWORK_BOTTOM_MARGIN', 0))
+DEFAULT_NETWORK_TOP_MARGIN = int(os.environ.get('DEFAULT_NETWORK_TOP_MARGIN', 10))  # noqa
+DEFAULT_NETWORK_BOTTOM_MARGIN = int(os.environ.get('DEFAULT_NETWORK_BOTTOM_MARGIN', 0))  # noqa
+# deprecated, to remove in the future
+DEFAULT_NETWORK_MARGIN = int(os.environ.get('DEFAULT_NETWORK_MARGIN', 10))
 # when set to True, network records (IP/Ethernet) can't be modified until
 # 'expose in DHCP' is selected
 DHCP_ENTRY_FORBID_CHANGE = os_env_true('DHCP_ENTRY_FORBID_CHANGE', 'True')

--- a/src/ralph/settings/base.py
+++ b/src/ralph/settings/base.py
@@ -326,7 +326,9 @@ OPENSTACK_INSTANCES = json.loads(os.environ.get('OPENSTACK_INSTANCES', '[]'))
 ISSUE_TRACKER_URL = os.environ.get('ISSUE_TRACKER_URL', '')
 
 # Networks
-DEFAULT_NETWORK_MARGIN = int(os.environ.get('DEFAULT_NETWORK_MARGIN', 10))
+DEFAULT_NETWORK_MARGIN = int(os.environ.get('DEFAULT_NETWORK_MARGIN', 10))  # deprecated, to remove in the future
+DEFAULT_NETWORK_TOP_MARGIN = int(os.environ.get('DEFAULT_NETWORK_TOP_MARGIN', 10))
+DEFAULT_NETWORK_BOTTOM_MARGIN = int(os.environ.get('DEFAULT_NETWORK_BOTTOM_MARGIN', 0))
 # when set to True, network records (IP/Ethernet) can't be modified until
 # 'expose in DHCP' is selected
 DHCP_ENTRY_FORBID_CHANGE = os_env_true('DHCP_ENTRY_FORBID_CHANGE', 'True')


### PR DESCRIPTION
Multiple networks (especially when they are not real networks, but artificial ones created to separate ip ranges in Ralph) could share the same gateway address, which wasn't possible before (one IP could be assigned to only one network).
