### PR TITLE
Fix generic foreign key prefetch related in polymorphic api

### DIFF
--- a/src/ralph/assets/api/views.py
+++ b/src/ralph/assets/api/views.py
@@ -76,21 +76,27 @@ class BaseObjectFilterSet(NetworkableObjectFilters):
         model = models.BaseObject
 
 
+base_object_descendant_prefetch_related = [
+    Prefetch('licences', queryset=BaseObjectLicence.objects.select_related(
+        *BaseObjectLicenceViewSet.select_related
+    )),
+    Prefetch(
+        'custom_fields',
+        queryset=CustomFieldValue.objects.select_related('custom_field')
+    ),
+    'service_env__service__business_owners',
+    'service_env__service__technical_owners',
+]
+
+
+class BaseObjectDescendantViewSetMixin(RalphAPIViewSet):
+    prefetch_related = base_object_descendant_prefetch_related
+
+
 class BaseObjectViewSet(PolymorphicViewSetMixin, RalphAPIViewSet):
     queryset = models.BaseObject.polymorphic_objects.all()
     serializer_class = serializers.BaseObjectPolymorphicSerializer
     http_method_names = ['get', 'options', 'head']
-    prefetch_related = [
-        Prefetch('licences', queryset=BaseObjectLicence.objects.select_related(
-            *BaseObjectLicenceViewSet.select_related
-        )),
-        Prefetch(
-            'custom_fields',
-            queryset=CustomFieldValue.objects.select_related('custom_field')
-        ),
-        'service_env__service__business_owners',
-        'service_env__service__technical_owners',
-    ]
     filter_fields = [
         'id', 'service_env', 'service_env', 'service_env__service__uid',
         'content_type'
@@ -193,7 +199,7 @@ class DCHostViewSet(BaseObjectViewSetMixin, RalphAPIViewSet):
         'service_env', 'service_env__service', 'service_env__environment',
         'configuration_path', 'configuration_path__module'
     ]
-    prefetch_related = BaseObjectViewSet.prefetch_related + [
+    prefetch_related = base_object_descendant_prefetch_related + [
         'tags',
         'memory_set',
         Prefetch(

--- a/src/ralph/back_office/api.py
+++ b/src/ralph/back_office/api.py
@@ -2,7 +2,7 @@
 from ralph.accounts.api_simple import SimpleRalphUserSerializer
 from ralph.api import RalphAPISerializer, RalphAPIViewSet, router
 from ralph.assets.api.serializers import AssetSerializer
-from ralph.assets.api.views import BaseObjectViewSet
+from ralph.assets.api.views import base_object_descendant_prefetch_related
 from ralph.back_office.admin import BackOfficeAssetAdmin
 from ralph.back_office.models import (
     BackOfficeAsset,
@@ -53,7 +53,7 @@ class BackOfficeAssetViewSet(RalphAPIViewSet):
         'user', 'owner', 'property_of', 'office_infrastructure',
         'budget_info'
     ]
-    prefetch_related = BaseObjectViewSet.prefetch_related + [
+    prefetch_related = base_object_descendant_prefetch_related + [
         'user__groups', 'user__user_permissions',
         'service_env__service__environments',
         'service_env__service__business_owners',

--- a/src/ralph/data_center/api/serializers.py
+++ b/src/ralph/data_center/api/serializers.py
@@ -36,6 +36,12 @@ class ClusterSimpleSerializer(BaseObjectSerializer):
         depth = 1
 
 
+class BaseObjectClusterSimpleSerializer(RalphAPISerializer):
+    class Meta:
+        model = BaseObjectCluster
+        fields = ('id', 'url', 'base_object', 'is_master')
+
+
 class BaseObjectClusterSerializer(RalphAPISerializer):
     class Meta:
         model = BaseObjectCluster
@@ -45,7 +51,7 @@ class BaseObjectClusterSerializer(RalphAPISerializer):
 class ClusterSerializer(
     OwnersFromServiceEnvSerializerMixin, ClusterSimpleSerializer
 ):
-    base_objects = BaseObjectClusterSerializer(
+    base_objects = BaseObjectClusterSimpleSerializer(
         many=True, read_only=True, source='baseobjectcluster_set'
     )
     masters = serializers.HyperlinkedRelatedField(

--- a/src/ralph/data_center/api/views.py
+++ b/src/ralph/data_center/api/views.py
@@ -3,7 +3,10 @@ from django.db.models import Prefetch
 
 from ralph.api import RalphAPIViewSet
 from ralph.assets.api.filters import NetworkableObjectFilters
-from ralph.assets.api.views import BaseObjectViewSet, BaseObjectViewSetMixin
+from ralph.assets.api.views import (
+    base_object_descendant_prefetch_related,
+    BaseObjectViewSetMixin
+)
 from ralph.assets.models import Ethernet
 from ralph.data_center.admin import DataCenterAssetAdmin
 from ralph.data_center.api.serializers import (
@@ -47,7 +50,7 @@ class DataCenterAssetViewSet(BaseObjectViewSetMixin, RalphAPIViewSet):
         'rack', 'rack__server_room', 'rack__server_room__data_center',
         'property_of', 'budget_info', 'content_type'
     ]
-    prefetch_related = BaseObjectViewSet.prefetch_related + [
+    prefetch_related = base_object_descendant_prefetch_related + [
         'connections',
         'tags',
         'memory_set',
@@ -118,6 +121,6 @@ class ClusterViewSet(BaseObjectViewSetMixin, RalphAPIViewSet):
         'type', 'parent', 'service_env', 'service_env__service',
         'service_env__environment', 'configuration_path', 'content_type'
     ]
-    prefetch_related = BaseObjectViewSet.prefetch_related + [
-        'tags', 'baseobjectcluster_set',
+    prefetch_related = base_object_descendant_prefetch_related + [
+        'tags', 'baseobjectcluster_set'
     ]

--- a/src/ralph/data_center/models/virtual.py
+++ b/src/ralph/data_center/models/virtual.py
@@ -72,11 +72,9 @@ class Cluster(BaseObject, models.Model):
 
     @cached_property
     def masters(self):
-        return BaseObject.polymorphic_objects.filter(
-            pk__in=self.baseobjectcluster_set.filter(
-                is_master=True
-            ).values_list('base_object_id', flat=True)
-        )
+        for obj in self.baseobjectcluster_set.all():
+            if obj.is_master:
+                yield obj
 
     def _validate_name_hostname(self):
         if not self.name and not self.hostname:

--- a/src/ralph/data_center/tests/test_api.py
+++ b/src/ralph/data_center/tests/test_api.py
@@ -449,7 +449,8 @@ class ClusterAPITests(RalphAPITestCase):
 
     def test_list_cluster(self):
         url = reverse('cluster-list')
-        response = self.client.get(url, format='json')
+        with self.assertNumQueries(12):
+            response = self.client.get(url, format='json')
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(len(response.data['results']), 2)
         for item in response.data['results']:
@@ -458,7 +459,8 @@ class ClusterAPITests(RalphAPITestCase):
 
     def test_get_cluster_details(self):
         url = reverse('cluster-detail', args=(self.cluster_1.id,))
-        response = self.client.get(url, format='json')
+        with self.assertNumQueries(10):
+            response = self.client.get(url, format='json')
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data['name'], self.cluster_1.name)
         self.assertEqual(response.data['hostname'], self.cluster_1.hostname)
@@ -481,7 +483,6 @@ class ClusterAPITests(RalphAPITestCase):
                     )
                 ),
                 'is_master': self.boc_1.is_master,
-                'cluster': self.get_full_url(url),
             },
             {
                 'id': self.boc_2.id,
@@ -492,6 +493,5 @@ class ClusterAPITests(RalphAPITestCase):
                     'baseobject-detail', args=(self.boc_2.base_object.id,)
                 )),
                 'is_master': self.boc_2.is_master,
-                'cluster': self.get_full_url(url),
             }
         ])

--- a/src/ralph/virtual/api.py
+++ b/src/ralph/virtual/api.py
@@ -12,7 +12,10 @@ from ralph.assets.api.serializers import (
     NetworkComponentSerializerMixin,
     ServiceEnvironmentSimpleSerializer
 )
-from ralph.assets.api.views import BaseObjectViewSet, BaseObjectViewSetMixin
+from ralph.assets.api.views import (
+    base_object_descendant_prefetch_related,
+    BaseObjectViewSetMixin
+)
 from ralph.assets.models import Ethernet
 from ralph.data_center.api.serializers import DataCenterAssetSimpleSerializer
 from ralph.data_center.models import DataCenterAsset
@@ -170,7 +173,7 @@ class CloudHostViewSet(BaseObjectViewSetMixin, RalphAPIViewSet):
         'parent', 'parent__cloudproject', 'cloudprovider', 'hypervisor',
         'service_env__service', 'service_env__environment', 'content_type'
     ]
-    prefetch_related = BaseObjectViewSet.prefetch_related + [
+    prefetch_related = base_object_descendant_prefetch_related + [
         'tags', 'cloudflavor__virtualcomponent_set__model', 'licences',
         Prefetch(
             'ethernet_set',
@@ -205,7 +208,7 @@ class VirtualServerViewSet(BaseObjectViewSetMixin, RalphAPIViewSet):
         'parent', 'service_env__service', 'service_env__environment',
         'configuration_path', 'content_type'
     ]
-    prefetch_related = BaseObjectViewSet.prefetch_related + [
+    prefetch_related = base_object_descendant_prefetch_related + [
         'tags',
         'memory_set',
         Prefetch(


### PR DESCRIPTION
Bug: When there is more than one type on `BaseObject` API endpoint (`/api/base-objects/`), custom fields are returned only for objects of the first type

`CustomFieldValue` is model based on `ContentType`s, so it has `GenericForeignKey` to all other models. According to Django documentation for prefetch_related (https://docs.djangoproject.com/en/1.8/ref/models/querysets/#prefetch-related):
"It also supports prefetching of GenericRelation and GenericForeignKey, however, it must be restricted to a homogeneous set of results. For example, prefetching objects referenced by a GenericForeignKey is only supported if the query is restricted to one ContentType."

In case of `BaseObject`, there could be more than one type of object, so prefetch related was working only for the first of them (implicitly adding filter by content type to `CustomFieldValue` prefetch query), resulting in returning empty list of custom fields for objects of different type.

Since `ralph.api.utils.PolymorphicViewSetMixin` is injecting fields to be prefetched for every polymorphic descendant (in this case of BaseObject, ex. DataCenterAsset, BackOfficeAsset etc), the solution was to prefetch custom fields (and potentially any other field) in final viewset for the type (ex. `DataCenterAssetViewSet`), which is later injected to polymorphic (sub)query for objects of this type (instead of calling it once for all).
