### PR TITLE
Skip hostname checking for reserved IPs during syncing

### DIFF
--- a/src/ralph/ralph2_sync/subscribers.py
+++ b/src/ralph/ralph2_sync/subscribers.py
@@ -400,11 +400,12 @@ def sync_network_to_ralph3(data):
     net.vlan = data['vlan']
     net.dhcp_broadcast = data['dhcp_broadcast']
     if data['reserved_ips']:
-        for ip in data['reserved_ips']:
-            IPAddress.objects.update_or_create(
-                address=ip,
-                defaults=dict(status=IPAddressStatus.reserved, network=net)
-            )
+        for address in data['reserved_ips']:
+            ip = IPAddress.objects.get_or_create(
+                address=address,
+                defaults=dict(status=IPAddressStatus.reserved)
+            )[0]
+            ip.save()  # trigger save to reassign to proper network
     if 'gateway' in data:
         if data['gateway']:
             net.gateway = IPAddress.objects.update_or_create(

--- a/src/ralph/settings/base.py
+++ b/src/ralph/settings/base.py
@@ -167,7 +167,7 @@ MESSAGE_TAGS = {
 }
 
 DEFAULT_DEPRECIATION_RATE = int(os.environ.get('DEFAULT_DEPRECIATION_RATE', 25))  # noqa
-CHECK_IP_HOSTNAME_ON_SAVE = True
+CHECK_IP_HOSTNAME_ON_SAVE = os_env_true('CHECK_IP_HOSTNAME_ON_SAVE')
 ASSET_HOSTNAME_TEMPLATE = {
     'prefix': '{{ country_code|upper }}{{ code|upper }}',
     'postfix': '',


### PR DESCRIPTION
- allow to skip hostname checking during saving reserved IP in network sync
- don't overwrite IP status to reserved when it's already exist
