### PR TITLE
Fix CHECK_IP_HOSTNAME_ON_SAVE default

### DIFF
--- a/src/ralph/settings/base.py
+++ b/src/ralph/settings/base.py
@@ -167,7 +167,7 @@ MESSAGE_TAGS = {
 }
 
 DEFAULT_DEPRECIATION_RATE = int(os.environ.get('DEFAULT_DEPRECIATION_RATE', 25))  # noqa
-CHECK_IP_HOSTNAME_ON_SAVE = os_env_true('CHECK_IP_HOSTNAME_ON_SAVE')
+CHECK_IP_HOSTNAME_ON_SAVE = os_env_true('CHECK_IP_HOSTNAME_ON_SAVE', '1')
 ASSET_HOSTNAME_TEMPLATE = {
     'prefix': '{{ country_code|upper }}{{ code|upper }}',
     'postfix': '',


### PR DESCRIPTION
53b9b140a43e100e0707708b6912ef9df27be901 allows to read `CHECK_IP_HOSTNAME_ON_SAVE` from env variable, but has changed default value from True to False.
