### PR TITLE
Ralph2 sync: handle networks terminators

### DIFF
--- a/src/ralph/ralph2_sync/subscribers.py
+++ b/src/ralph/ralph2_sync/subscribers.py
@@ -429,6 +429,25 @@ def sync_network_to_ralph3(data):
         except DNSServer.DoesNotExist:
             logger.error('DNS Server with ip {} not found'.format(dns_ip))
     net.dns_servers = dns_servers
+
+    if 'terminators' in data:
+        terminators = []
+        for obj_type, obj_id in data['terminators']:
+            terminator_model = None
+            if obj_type == 'StackedSwitch':
+                terminator_model = Cluster
+            elif obj_type == 'DataCenterAsset':
+                terminator_model = DataCenterAsset
+            else:
+                logger.error(
+                    'Unknown terminator type: {}'.format(terminator_model)
+                )
+            if terminator_model:
+                terminator = _get_obj(terminator_model, obj_id)[0]
+                if terminator:
+                    terminators.append(terminator)
+        net.terminators = terminators
+
     if created:
         ImportedObjects.create(net, data['id'])
 

--- a/src/ralph/ralph2_sync/tests/test_subscribers.py
+++ b/src/ralph/ralph2_sync/tests/test_subscribers.py
@@ -433,6 +433,7 @@ class Ralph2NetworkTestCase(TestCase):
             'kind_id': 1,
             'racks_ids': [],
             'dns_servers': [],
+            'terminators': [],
         }
 
     def _get_network(self):
@@ -499,6 +500,21 @@ class Ralph2NetworkTestCase(TestCase):
         sync_network_to_ralph3(self.data)
         net.refresh_from_db()
         self.assertCountEqual(net.dns_servers.all(), dnss[1:])
+
+    def test_sync_should_update_terminators(self):
+        self.data['terminators'] = [
+            ('DataCenterAsset', 1111),
+            ('StackedSwitch', 2222)
+        ]
+        dca = _create_imported_object(
+            factory=DataCenterAssetFactory, old_id=1111,
+        )
+        cluster = _create_imported_object(
+            factory=ClusterFactory, old_id=2222,
+        )
+        sync_network_to_ralph3(self.data)
+        net = ImportedObjects.get_object_from_old_pk(Network, self.data['id'])
+        self.assertCountEqual(net.terminators.all(), [dca, cluster])
 
 
 class Ralph2NetworkKindTestCase(TestCase):


### PR DESCRIPTION
Related to #2591 - handle network terminators (DataCenterAsset or Cluster
