### PR TITLE
Fix top and bottom margin of network default values

### DIFF
--- a/src/ralph/settings/base.py
+++ b/src/ralph/settings/base.py
@@ -326,8 +326,8 @@ OPENSTACK_INSTANCES = json.loads(os.environ.get('OPENSTACK_INSTANCES', '[]'))
 ISSUE_TRACKER_URL = os.environ.get('ISSUE_TRACKER_URL', '')
 
 # Networks
-DEFAULT_NETWORK_TOP_MARGIN = int(os.environ.get('DEFAULT_NETWORK_TOP_MARGIN', 10))  # noqa
-DEFAULT_NETWORK_BOTTOM_MARGIN = int(os.environ.get('DEFAULT_NETWORK_BOTTOM_MARGIN', 0))  # noqa
+DEFAULT_NETWORK_BOTTOM_MARGIN = int(os.environ.get('DEFAULT_NETWORK_BOTTOM_MARGIN', 10))  # noqa
+DEFAULT_NETWORK_TOP_MARGIN = int(os.environ.get('DEFAULT_NETWORK_TOP_MARGIN', 0))  # noqa
 # deprecated, to remove in the future
 DEFAULT_NETWORK_MARGIN = int(os.environ.get('DEFAULT_NETWORK_MARGIN', 10))
 # when set to True, network records (IP/Ethernet) can't be modified until


### PR DESCRIPTION
Set bottom margin (counting from the beginning of the network) to 10 and top margin to 0.
Naming of these variables will be fixed in another PR.
