### PR TITLE
Add owners and support team to service tooltip

### DIFF
--- a/src/ralph/admin/autocomplete.py
+++ b/src/ralph/admin/autocomplete.py
@@ -51,7 +51,7 @@ class AutocompleteTooltipMixin(object):
                 model_field = get_field_by_relation_path(self, field)
             except FieldDoesNotExist:
                 logger.warning(
-                    'Autocomplete tooltip dield {} not found for {}'.format(
+                    'Autocomplete tooltip field {} not found for {}'.format(
                         field, self._meta.model_name,
                     )
                 )

--- a/src/ralph/admin/autocomplete.py
+++ b/src/ralph/admin/autocomplete.py
@@ -6,7 +6,7 @@ from functools import reduce
 from dj.choices import Choices
 from django.conf.urls import url
 from django.core.exceptions import FieldDoesNotExist
-from django.db.models import Q, Manager
+from django.db.models import Manager, Q
 from django.db.models.loading import get_model
 from django.http import Http404, HttpResponseBadRequest, JsonResponse
 from django.views.generic import View

--- a/src/ralph/assets/models/assets.py
+++ b/src/ralph/assets/models/assets.py
@@ -12,6 +12,7 @@ from django.utils.translation import ugettext_lazy as _
 from mptt.models import MPTTModel, TreeForeignKey
 
 from ralph.accounts.models import Team
+from ralph.admin.autocomplete import AutocompleteTooltipMixin
 from ralph.assets.models.base import BaseObject
 from ralph.assets.models.choices import (
     ModelVisualizationLayout,
@@ -85,9 +86,15 @@ class Service(
         return cls._default_manager.filter(active=True)
 
 
-class ServiceEnvironment(BaseObject):
+class ServiceEnvironment(AutocompleteTooltipMixin, BaseObject):
     service = models.ForeignKey(Service)
     environment = models.ForeignKey(Environment)
+
+    autocomplete_tooltip_fields = [
+        'service__business_owners',
+        'service__technical_owners',
+        'service__support_team',
+    ]
 
     def __str__(self):
         return '{} - {}'.format(self.service.name, self.environment.name)


### PR DESCRIPTION
- New tooltip for service autocomplete field, containing business owners, technical owners and support team
- Change the way of field lookup in tooltip - now it could be nested field (from related model) and it handles M2M relationship.
