### PR TITLE
Add ethernet and ips to cluster API

### DIFF
--- a/src/ralph/data_center/admin.py
+++ b/src/ralph/data_center/admin.py
@@ -43,7 +43,7 @@ from ralph.lib.custom_fields.admin import CustomFieldValueAdminMixin
 from ralph.lib.table import Table
 from ralph.lib.transitions.admin import TransitionAdminMixin
 from ralph.licences.models import BaseObjectLicence
-from ralph.networks.forms import SimpleNetworkForm
+from ralph.networks.forms import SimpleNetworkWithManagementIPForm
 from ralph.networks.models.networks import Network
 from ralph.networks.views import NetworkWithTerminatorsView
 from ralph.operations.views import OperationViewReadOnlyForExisiting
@@ -60,7 +60,7 @@ class AccessoryAdmin(RalphAdmin):
 
 
 class ClusterNetworkInline(RalphTabularInline):
-    form = SimpleNetworkForm
+    form = SimpleNetworkWithManagementIPForm
     model = Ethernet
     exclude = ['model']
 

--- a/src/ralph/data_center/api/serializers.py
+++ b/src/ralph/data_center/api/serializers.py
@@ -6,6 +6,7 @@ from ralph.assets.api.serializers import (
     AssetSerializer,
     BaseObjectSerializer,
     ComponentSerializerMixin,
+    NetworkComponentSerializerMixin,
     OwnersFromServiceEnvSerializerMixin
 )
 from ralph.data_center.models import (
@@ -49,7 +50,9 @@ class BaseObjectClusterSerializer(RalphAPISerializer):
 
 
 class ClusterSerializer(
-    OwnersFromServiceEnvSerializerMixin, ClusterSimpleSerializer
+    NetworkComponentSerializerMixin,
+    OwnersFromServiceEnvSerializerMixin,
+    ClusterSimpleSerializer
 ):
     base_objects = BaseObjectClusterSimpleSerializer(
         many=True, read_only=True, source='baseobjectcluster_set'

--- a/src/ralph/data_center/api/views.py
+++ b/src/ralph/data_center/api/views.py
@@ -118,6 +118,11 @@ class BaseObjectClusterViewSet(RalphAPIViewSet):
     serializer_class = BaseObjectClusterSerializer
 
 
+class ClusterFilterSet(NetworkableObjectFilters):
+    class Meta(NetworkableObjectFilters.Meta):
+        model = Cluster
+
+
 class ClusterViewSet(BaseObjectViewSetMixin, RalphAPIViewSet):
     queryset = Cluster.objects.all()
     serializer_class = ClusterSerializer
@@ -126,5 +131,10 @@ class ClusterViewSet(BaseObjectViewSetMixin, RalphAPIViewSet):
         'service_env__environment', 'configuration_path', 'content_type'
     ]
     prefetch_related = base_object_descendant_prefetch_related + [
-        'tags', 'baseobjectcluster_set'
+        'tags', 'baseobjectcluster_set',
+        Prefetch(
+            'ethernet_set',
+            queryset=Ethernet.objects.select_related('ipaddress')
+        ),
     ]
+    additional_filter_class = ClusterFilterSet

--- a/src/ralph/data_center/models/virtual.py
+++ b/src/ralph/data_center/models/virtual.py
@@ -73,9 +73,11 @@ class Cluster(WithManagementIPMixin, BaseObject, models.Model):
 
     @cached_property
     def masters(self):
+        result = []
         for obj in self.baseobjectcluster_set.all():
             if obj.is_master:
-                yield obj
+                result.append(obj)
+        return result
 
     def _validate_name_hostname(self):
         if not self.name and not self.hostname:

--- a/src/ralph/data_center/tests/test_api.py
+++ b/src/ralph/data_center/tests/test_api.py
@@ -409,6 +409,7 @@ class ClusterAPITests(RalphAPITestCase):
         self.cluster_1.service_env.service.business_owners = [self.user1]
         self.cluster_1.service_env.service.technical_owners = [self.user2]
         self.cluster_1.service_env.save()
+        self.cluster_1.management_ip = '10.20.30.40'
 
     def test_create_cluster(self):
         url = reverse('cluster-list')
@@ -449,7 +450,7 @@ class ClusterAPITests(RalphAPITestCase):
 
     def test_list_cluster(self):
         url = reverse('cluster-list')
-        with self.assertNumQueries(12):
+        with self.assertNumQueries(13):
             response = self.client.get(url, format='json')
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(len(response.data['results']), 2)
@@ -459,7 +460,7 @@ class ClusterAPITests(RalphAPITestCase):
 
     def test_get_cluster_details(self):
         url = reverse('cluster-detail', args=(self.cluster_1.id,))
-        with self.assertNumQueries(10):
+        with self.assertNumQueries(11):
             response = self.client.get(url, format='json')
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data['name'], self.cluster_1.name)
@@ -495,3 +496,12 @@ class ClusterAPITests(RalphAPITestCase):
                 'is_master': self.boc_2.is_master,
             }
         ])
+        self.assertEqual(
+            response.data['ethernet'][0]['ipaddress']['address'], '10.20.30.40'
+        )
+        self.assertTrue(
+            response.data['ethernet'][0]['ipaddress']['is_management']
+        )
+        self.assertEqual(
+            response.data['ipaddresses'], ['10.20.30.40']
+        )

--- a/src/ralph/networks/forms.py
+++ b/src/ralph/networks/forms.py
@@ -201,8 +201,13 @@ class SimpleNetworkForm(forms.ModelForm):
         return obj
 
 
-class NetworkForm(SimpleNetworkForm):
+class SimpleNetworkWithManagementIPForm(SimpleNetworkForm):
     is_management = forms.BooleanField(label='Is managment', required=False)
+
+    ip_fields = ['hostname', 'address', 'is_management']
+
+
+class NetworkForm(SimpleNetworkWithManagementIPForm):
     dhcp_expose = forms.BooleanField(label=_('Expose in DHCP'), required=False)
 
     ip_fields = ['hostname', 'address', 'is_management', 'dhcp_expose']


### PR DESCRIPTION
- New Cluster API fields: ethernet and ipaddresses
- Add `is_management` field to cluster ethernet form
