### PR TITLE
Management IP assignment fix

### DIFF
--- a/src/ralph/data_center/models/mixins.py
+++ b/src/ralph/data_center/models/mixins.py
@@ -1,7 +1,24 @@
-from ralph.networks.models import IPAddress
+from django.core.exceptions import ValidationError
+
+from ralph.networks.models import IPAddress, IPAddressStatus
 
 
 class WithManagementIPMixin(object):
+    """
+    This mixin helps to handle management_ip and hostname (ex. for
+    DataCenterAsset and Cluster).
+
+    What happen when management ip is assigned:
+    * first, existing management ip for this host is fetched
+    * if there is change in address value, existing management ip (IPAddress)
+      is removed (unless it's reserved IP - then it's detached from current
+      host) - it's done to not accidentally duplicate existing IPAddress
+    * then, there is check is IPAddres with new mgmt value already exist
+      * if yes, there is validation if it's not assigned to any other host -
+        if yes, then ValidationError is raised
+      * if no, it's attached to current object and marked as management ip
+
+    """
     def _get_management_ip(self):
         eth = self.ethernet_set.select_related('ipaddress').filter(
             ipaddress__is_management=True
@@ -10,11 +27,35 @@ class WithManagementIPMixin(object):
             return eth.ipaddress
         return None
 
-    def _get_or_create_management_ip(self):
+    def _get_or_create_management_ip(self, address=None):
         ip = self._get_management_ip()
         if not ip:
-            eth = self.ethernet_set.create()
-            ip = IPAddress(ethernet=eth, is_management=True)
+            if address:
+                # check if IP is already created
+                try:
+                    ip = IPAddress.objects.get(address=address)
+                except IPAddress.DoesNotExist:
+                    pass
+                else:
+                    # check if it's not assigned to any object
+                    if (
+                        ip.ethernet and
+                        ip.ethernet.base_object_id != self.pk
+                    ):
+                        raise ValidationError(
+                            'IP is already assigned to another object'
+                        )
+                    # check if object has ethernet attached - if not, create new
+                    # one
+                    if ip.ethernet:
+                        ip.ethernet.base_object = self
+                        ip.ethernet.save()
+                    else:
+                        ip.ethernet = self.ethernet_set.create()
+                    ip.is_management = True
+            if not ip:
+                eth = self.ethernet_set.create()
+                ip = IPAddress(ethernet=eth, is_management=True)
         return ip
 
     @property
@@ -26,7 +67,12 @@ class WithManagementIPMixin(object):
 
     @management_ip.setter
     def management_ip(self, value):
-        ip = self._get_or_create_management_ip()
+        current_mgmt = self.management_ip
+        # if new management ip value is different than previous, remove previous
+        # IP entry to not try to change it's value
+        if current_mgmt and current_mgmt != value:
+            del self.management_ip
+        ip = self._get_or_create_management_ip(value)
         ip.address = value
         ip.save()
 
@@ -34,8 +80,15 @@ class WithManagementIPMixin(object):
     def management_ip(self):
         ip = self._get_management_ip()
         if ip:
-            ip.delete()
-            ip.ethernet.delete()
+            eth = ip.ethernet
+            # remove IP only if it's status is different than reserved
+            if ip.status != IPAddressStatus.reserved:
+                ip.delete()
+            else:
+                ip.is_management = False
+                ip.ethernet = None
+                ip.save()
+            eth.delete()
 
     @property
     def management_hostname(self):

--- a/src/ralph/data_center/models/mixins.py
+++ b/src/ralph/data_center/models/mixins.py
@@ -43,7 +43,9 @@ class WithManagementIPMixin(object):
                         ip.ethernet.base_object_id != self.pk
                     ):
                         raise ValidationError(
-                            'IP is already assigned to another object'
+                            'IP is already assigned to {}'.format(
+                                ip.ethernet.base_object.last_descendant
+                            )
                         )
                     # check if object has ethernet attached - if not, create new
                     # one

--- a/src/ralph/data_center/models/mixins.py
+++ b/src/ralph/data_center/models/mixins.py
@@ -29,13 +29,19 @@ class WithManagementIPMixin(object):
 
     def _get_or_create_management_ip(self, address=None):
         ip = self._get_management_ip()
+
+        def _create_new_ip():
+            eth = self.ethernet_set.create()
+            ip = IPAddress(ethernet=eth, is_management=True)
+            return ip
+
         if not ip:
             if address:
                 # check if IP is already created
                 try:
                     ip = IPAddress.objects.get(address=address)
                 except IPAddress.DoesNotExist:
-                    pass
+                    ip = _create_new_ip()
                 else:
                     # check if it's not assigned to any object
                     if (
@@ -55,9 +61,8 @@ class WithManagementIPMixin(object):
                     else:
                         ip.ethernet = self.ethernet_set.create()
                     ip.is_management = True
-            if not ip:
-                eth = self.ethernet_set.create()
-                ip = IPAddress(ethernet=eth, is_management=True)
+            else:
+                ip = _create_new_ip()
         return ip
 
     @property

--- a/src/ralph/data_center/tests/test_forms.py
+++ b/src/ralph/data_center/tests/test_forms.py
@@ -8,7 +8,7 @@ from ralph.assets.models import Ethernet
 from ralph.data_center.models import DataCenterAsset
 from ralph.data_center.tests.factories import DataCenterAssetFactory
 from ralph.networks.forms import validate_is_management
-from ralph.networks.models import IPAddress
+from ralph.networks.models import IPAddress, IPAddressStatus
 from ralph.networks.tests.factories import IPAddressFactory
 from ralph.tests import RalphTestCase
 
@@ -82,6 +82,22 @@ class TestDataCenterAssetForm(RalphTestCase):
         self.assertEqual(response.status_code, 302)
         self.dca.refresh_from_db()
         self.assertEqual(self.dca.management_ip, '10.20.30.40')
+        self.assertEqual(self.dca.management_hostname, 'qwerty.mydc.net')
+
+    def test_enter_reserved_mgmt_ip_should_pass(self):
+        IPAddressFactory(
+            is_management=False, address='10.20.30.41',
+            ethernet=None, status=IPAddressStatus.reserved,
+        )
+        data = self._get_initial_data()
+        data.update({
+            'management_ip': '10.20.30.41',
+            'management_hostname': 'qwerty.mydc.net',
+        })
+        response = self.client.post(self.dca.get_absolute_url(), data)
+        self.assertEqual(response.status_code, 302)
+        self.dca.refresh_from_db()
+        self.assertEqual(self.dca.management_ip, '10.20.30.41')
         self.assertEqual(self.dca.management_hostname, 'qwerty.mydc.net')
 
     def test_enter_duplicated_mgmt_ip_should_not_pass(self):


### PR DESCRIPTION
Fix for management IP assignment when:
- IPAddress is reserved (but not connected with any BaseObject), or
- mgmt ip is changed to address that already exist in Ralph
