### PR TITLE
Filter service by active status in API

### DIFF
--- a/src/ralph/admin/widgets.py
+++ b/src/ralph/admin/widgets.py
@@ -103,29 +103,28 @@ class PermissionsSelectWidget(forms.Widget):
             local_selected = set(local_values) & set(selected_choices or [])
             slug = slugify(group_key)
             label = title(group_key)
-            rendered_options += mark_safe(
-                '<li class="accordion-navigation">'
-                    '<a href="#{slug}">'
-                        '{title}<i class="right">'
-                            '<span class="counter">{selected}</span> of {total}'
-                        '</i>'
-                    '</a>'
-                    '<div id="{slug}" class="content">'
-                        '{all}{items}'
-                    '</div>'  # noqa
-                '</li>'.format(
-                    slug=slug,
-                    title=label,
-                    selected=len(local_selected),
-                    total=len(local_values),
-                    all=self.render_all_option(slugify(group_key)),
-                    items='<br />'.join([
-                        self.render_option(
-                            local_selected, c[0], c[1].split(separator)[-1]
-                        ) for c in items
-                    ])
-                )
-            )
+            rendered_options += mark_safe("""
+                <li class="accordion-navigation">
+                    <a href="#{slug}">
+                        {title}<i class="right">
+                            <span class="counter">{selected}</span> of {total}
+                        </i>
+                    </a>
+                    <div id="{slug}" class="content">
+                        {all}{items}
+                    </div>  # noqa
+                </li>""".format(
+                slug=slug,
+                title=label,
+                selected=len(local_selected),
+                total=len(local_values),
+                all=self.render_all_option(slugify(group_key)),
+                items='<br />'.join([
+                    self.render_option(
+                        local_selected, c[0], c[1].split(separator)[-1]
+                    ) for c in items
+                ])
+            ))
         return rendered_options
 
 

--- a/src/ralph/api/filters.py
+++ b/src/ralph/api/filters.py
@@ -6,6 +6,8 @@ from functools import reduce
 from django.contrib.contenttypes.models import ContentType
 from django.core.exceptions import FieldDoesNotExist
 from django.db import models
+from django.forms import Widget
+from django_filters import Filter
 from rest_framework.filters import BaseFilterBackend, DjangoFilterBackend
 
 from ralph.admin.helpers import get_field_by_relation_path
@@ -14,6 +16,23 @@ from ralph.data_importer.models import ImportedObjects
 from ralph.lib.mixins.models import TaggableMixin
 
 logger = logging.getLogger(__name__)
+
+TRUE_VALUES = dict.fromkeys([1, '1', 'true', 'True', 'yes'], True)
+FALSE_VALUES = dict.fromkeys([0, '0', 'false', 'False', 'no'], False)
+BOOL_VALUES = TRUE_VALUES.copy()
+BOOL_VALUES.update(FALSE_VALUES)
+
+
+class BooleanWidget(Widget):
+    def value_from_datadict(self, data, files, name):
+        value = data.get(name, None)
+        return BOOL_VALUES.get(value, None)
+
+
+class BooleanFilter(Filter):
+    def __init__(self, widget=None, *args, **kwargs):
+        widget = widget or BooleanWidget
+        super().__init__(widget=widget, *args, **kwargs)
 
 
 class AdditionalDjangoFilterBackend(DjangoFilterBackend):

--- a/src/ralph/assets/api/serializers.py
+++ b/src/ralph/assets/api/serializers.py
@@ -91,11 +91,11 @@ class SaveServiceSerializer(
     )
     business_owners = AdditionalLookupRelatedField(
         many=True, read_only=False, queryset=get_user_model().objects.all(),
-        lookup_fields=['username'],
+        lookup_fields=['username'], style={'base_template': 'input.html'}
     )
     technical_owners = AdditionalLookupRelatedField(
         many=True, read_only=False, queryset=get_user_model().objects.all(),
-        lookup_fields=['username'],
+        lookup_fields=['username'], style={'base_template': 'input.html'}
     )
     support_team = AdditionalLookupRelatedField(
         read_only=False, queryset=Team.objects.all(), lookup_fields=['name'],

--- a/src/ralph/assets/api/views.py
+++ b/src/ralph/assets/api/views.py
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
+import django_filters
 from django.db.models import Prefetch
 from rest_framework.exceptions import ValidationError
 
-import django_filters
 from ralph.api import RalphAPIViewSet
 from ralph.api.filters import BooleanFilter
 from ralph.api.utils import PolymorphicViewSetMixin

--- a/src/ralph/assets/api/views.py
+++ b/src/ralph/assets/api/views.py
@@ -2,7 +2,9 @@
 from django.db.models import Prefetch
 from rest_framework.exceptions import ValidationError
 
+import django_filters
 from ralph.api import RalphAPIViewSet
+from ralph.api.filters import BooleanFilter
 from ralph.api.utils import PolymorphicViewSetMixin
 from ralph.assets import models
 from ralph.assets.api import serializers
@@ -33,12 +35,21 @@ class EnvironmentViewSet(RalphAPIViewSet):
     serializer_class = serializers.EnvironmentSerializer
 
 
+class ServiceFilterSet(django_filters.FilterSet):
+    active = BooleanFilter(name='active')
+
+    class Meta:
+        model = models.Service
+        fields = ['active']
+
+
 class ServiceViewSet(RalphAPIViewSet):
     queryset = models.Service.objects.all()
     serializer_class = serializers.ServiceSerializer
     save_serializer_class = serializers.SaveServiceSerializer
     select_related = ['profit_center']
     prefetch_related = ['business_owners', 'technical_owners', 'environments']
+    additional_filter_class = ServiceFilterSet
 
 
 class ServiceEnvironmentViewSet(RalphAPIViewSet):


### PR DESCRIPTION
Since DRF's boolean filter is broken (django-filters NullBooleanField is not API-friendly - it's working with forms widgets), Ralph have to define it's own boolean API filter.

Use 1, true, True or yes in `active` query param to get active services.
Use 0, false, False or no in `active` query param to get inactive services.
