### PR TITLE
Fix syncing m2m relations to Ralph2

### DIFF
--- a/src/ralph/admin/mixins.py
+++ b/src/ralph/admin/mixins.py
@@ -32,6 +32,7 @@ from ralph.lib.permissions.admin import (
 )
 from ralph.lib.permissions.models import PermByFieldMixin
 from ralph.lib.permissions.views import PermissionViewMetaClass
+from ralph.ralph2_sync.admin import Ralph2SyncAdminMixin
 
 logger = logging.getLogger(__name__)
 
@@ -119,7 +120,7 @@ class RalphAdminChecks(admin.checks.ModelAdminChecks):
         return result
 
 
-class RalphAdminMixin(RalphAutocompleteMixin):
+class RalphAdminMixin(Ralph2SyncAdminMixin, RalphAutocompleteMixin):
     """Ralph admin mixin."""
 
     list_views = None

--- a/src/ralph/networks/admin.py
+++ b/src/ralph/networks/admin.py
@@ -174,7 +174,7 @@ class NetworkAdmin(RalphMPTTAdmin):
         """
         bottom_margin = form.cleaned_data.get('bottom_margin', None)
         top_margin = form.cleaned_data.get('top_margin', None)
-        obj.save()
+        super().save_model(request, obj, form, change)
         if bottom_margin and top_margin:
             obj.reserve_margin_addresses(
                 bottom_count=form.cleaned_data['bottom_margin'],

--- a/src/ralph/ralph2_sync/admin.py
+++ b/src/ralph/ralph2_sync/admin.py
@@ -1,0 +1,28 @@
+from django.db.models.signals import post_save
+
+
+class Ralph2SyncAdminMixin(object):
+    """
+    Mixin for Django Admin to properly handle syncing related objects (m2m).
+    Sync is triggered after saving m2m, not before (like in regular admin).
+    """
+    def save_model(self, request, obj, form, change):
+        # hold on syncing until m2m relations are saved
+        obj._handle_post_save = False
+        return super().save_model(request, obj, form, change)
+
+    def _sync_to_ralph2(self, obj, created=False):
+        # enable back syncing of object
+        obj._handle_post_save = True
+        # call post_save to trigger syning "manually"
+        post_save.send(sender=self.model, instance=obj, created=created)
+
+    # log_addition and log_change are called after succesfull save (with m2m)
+    # in regular form and bulk edit
+    def log_addition(self, request, obj):
+        self._sync_to_ralph2(obj, True)
+        return super().log_addition(request, obj)
+
+    def log_change(self, request, obj, change_message):
+        self._sync_to_ralph2(obj, False)
+        return super().log_change(request, obj, change_message)


### PR DESCRIPTION
Fix for syncing related objects (m2m) when saving in GUI. Now syncing is triggered after saving m2m relations.
