### PR TITLE
Network reserved ips as simple int field

### DIFF
--- a/src/ralph/data_center/models/mixins.py
+++ b/src/ralph/data_center/models/mixins.py
@@ -1,6 +1,6 @@
 from django.core.exceptions import ValidationError
 
-from ralph.networks.models import IPAddress, IPAddressStatus
+from ralph.networks.models import IPAddress
 
 
 class WithManagementIPMixin(object):
@@ -88,13 +88,7 @@ class WithManagementIPMixin(object):
         ip = self._get_management_ip()
         if ip:
             eth = ip.ethernet
-            # remove IP only if it's status is different than reserved
-            if ip.status != IPAddressStatus.reserved:
-                ip.delete()
-            else:
-                ip.is_management = False
-                ip.ethernet = None
-                ip.save()
+            ip.delete()
             eth.delete()
 
     @property

--- a/src/ralph/data_center/tests/test_forms.py
+++ b/src/ralph/data_center/tests/test_forms.py
@@ -8,7 +8,7 @@ from ralph.assets.models import Ethernet
 from ralph.data_center.models import DataCenterAsset
 from ralph.data_center.tests.factories import DataCenterAssetFactory
 from ralph.networks.forms import validate_is_management
-from ralph.networks.models import IPAddress, IPAddressStatus
+from ralph.networks.models import IPAddress
 from ralph.networks.tests.factories import IPAddressFactory
 from ralph.tests import RalphTestCase
 
@@ -82,22 +82,6 @@ class TestDataCenterAssetForm(RalphTestCase):
         self.assertEqual(response.status_code, 302)
         self.dca.refresh_from_db()
         self.assertEqual(self.dca.management_ip, '10.20.30.40')
-        self.assertEqual(self.dca.management_hostname, 'qwerty.mydc.net')
-
-    def test_enter_reserved_mgmt_ip_should_pass(self):
-        IPAddressFactory(
-            is_management=False, address='10.20.30.41',
-            ethernet=None, status=IPAddressStatus.reserved,
-        )
-        data = self._get_initial_data()
-        data.update({
-            'management_ip': '10.20.30.41',
-            'management_hostname': 'qwerty.mydc.net',
-        })
-        response = self.client.post(self.dca.get_absolute_url(), data)
-        self.assertEqual(response.status_code, 302)
-        self.dca.refresh_from_db()
-        self.assertEqual(self.dca.management_ip, '10.20.30.41')
         self.assertEqual(self.dca.management_hostname, 'qwerty.mydc.net')
 
     def test_enter_duplicated_mgmt_ip_should_not_pass(self):

--- a/src/ralph/data_center/tests/test_models.py
+++ b/src/ralph/data_center/tests/test_models.py
@@ -14,7 +14,7 @@ from ralph.data_center.tests.factories import (
     DataCenterAssetFactory,
     RackFactory
 )
-from ralph.networks.models import IPAddress, IPAddressStatus
+from ralph.networks.models import IPAddress
 from ralph.networks.tests.factories import (
     IPAddressFactory,
     NetworkEnvironmentFactory,
@@ -317,20 +317,6 @@ class DataCenterAssetTest(RalphTestCase):
         self.assertFalse(
             IPAddress.objects.filter(address='10.20.30.40').exists()
         )
-
-    def test_change_mgmt_ip_reserved_for_existing_ip_without_object_should_pass(self):  # noqa
-        IPAddressFactory(
-            address='10.20.30.40',
-            is_management=True,
-            ethernet__base_object=self.dc_asset,
-            status=IPAddressStatus.reserved
-        )
-        self.assertEqual(self.dc_asset.management_ip, '10.20.30.40')
-        self.dc_asset.management_ip = '10.20.30.43'
-        self.dc_asset.refresh_from_db()
-        self.assertEqual(self.dc_asset.management_ip, '10.20.30.43')
-        reserved_ip = IPAddress.objects.get(address='10.20.30.40')
-        self.assertFalse(reserved_ip.is_management)
 
     def test_change_mgmt_ip_for_existing_ip_with_object_should_not_pass(self):
         IPAddressFactory(address='10.20.30.42')

--- a/src/ralph/deployment/tests/test_transitions.py
+++ b/src/ralph/deployment/tests/test_transitions.py
@@ -14,7 +14,6 @@ from ralph.data_center.tests.factories import (
 from ralph.lib.transitions.conf import TRANSITION_ORIGINAL_STATUS
 from ralph.lib.transitions.tests import TransitionTestCase
 from ralph.networks.tests.factories import (
-    IPAddressFactory,
     NetworkEnvironmentFactory,
     NetworkFactory
 )
@@ -51,9 +50,9 @@ class _BaseDeploymentTransitionTestCase(object):
         cls.net = NetworkFactory(
             network_environment=cls.net_env,
             address='10.20.30.0/24',
+            # reserve 10.20.30.1, 10.20.30.2, 10.20.30.3, 10.20.30.4, 10.20.30.5
+            reserved_from_beginning=5
         )
-        # reserve 10.20.30.1, 10.20.30.2, 10.20.30.3, 10.20.30.4, 10.20.30.5
-        cls.net.reserve_margin_addresses(bottom_count=5)
         cls.net_2 = NetworkFactory(
             network_environment=cls.net_env_2,
             address='11.20.30.0/24',

--- a/src/ralph/dhcp/models.py
+++ b/src/ralph/dhcp/models.py
@@ -2,7 +2,7 @@ from django.db import models
 from django.utils import timezone
 from django.utils.translation import ugettext_lazy as _
 
-from ralph.networks.models.networks import IPAddress, IPAddressStatus
+from ralph.networks.models.networks import IPAddress  # , IPAddressStatus
 
 
 class DHCPEntryManager(models.Manager):
@@ -15,8 +15,6 @@ class DHCPEntryManager(models.Manager):
             ethernet__base_object__isnull=False,
             ethernet__isnull=False,
             ethernet__mac__isnull=False,
-        ).exclude(
-            status=IPAddressStatus.reserved.id
         )
 
 

--- a/src/ralph/dhcp/models.py
+++ b/src/ralph/dhcp/models.py
@@ -2,7 +2,7 @@ from django.db import models
 from django.utils import timezone
 from django.utils.translation import ugettext_lazy as _
 
-from ralph.networks.models.networks import IPAddress  # , IPAddressStatus
+from ralph.networks.models.networks import IPAddress
 
 
 class DHCPEntryManager(models.Manager):

--- a/src/ralph/networks/migrations/0007_auto_20160804_0719.py
+++ b/src/ralph/networks/migrations/0007_auto_20160804_0719.py
@@ -1,0 +1,90 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+import ipaddress
+from itertools import chain
+
+from django.db import migrations, models
+
+IPADDRESS_STATUS_RESERVED = 2
+
+
+def _reserve_margin_addresses(network, bottom_count, top_count, IPAddress):
+        ips = []
+        ips_query = IPAddress.objects.filter(
+            models.Q(
+                number__gte=network.min_ip + 1,
+                number__lte=network.min_ip + bottom_count + 1
+            ) |
+            models.Q(
+                number__gte=network.max_ip - top_count,
+                number__lte=network.max_ip
+            )
+        )
+        existing_ips = set(ips_query.values_list('number', flat=True))
+        to_create = set(chain.from_iterable([
+            range(int(network.min_ip + 1), int(network.min_ip + bottom_count + 1)),  # noqa
+            range(int(network.max_ip - top_count), int(network.max_ip))
+        ]))
+        to_create = to_create - existing_ips
+        for ip_as_int in to_create:
+            ips.append(IPAddress(
+                address=str(ipaddress.ip_address(ip_as_int)),
+                number=ip_as_int,
+                network=network,
+                status=IPADDRESS_STATUS_RESERVED
+            ))
+        print('Creating {} ips for {}'.format(len(ips), network))
+        IPAddress.objects.bulk_create(ips)
+        ips_query.update(status=IPADDRESS_STATUS_RESERVED)
+
+
+def create_reserved_ips(apps, schema_editor):
+    IPAddress = apps.get_model('networks', 'IPAddress')
+    Network = apps.get_model('networks', 'Network')
+
+    for network in Network.objects.all():
+        _reserve_margin_addresses(
+            network,
+            network.reserved_from_beginning,
+            network.reserved_from_end,
+            IPAddress
+        )
+
+
+def remove_reserved_ips(apps, schema_editor):
+    IPAddress = apps.get_model('networks', 'IPAddress')
+    ips = IPAddress.objects.filter(
+        models.Q(ethernet__isnull=True) | (
+            models.Q(ethernet__base_object__isnull=True) &
+            models.Q(ethernet__mac__isnull=False)
+        ),
+        status=IPADDRESS_STATUS_RESERVED,
+        gateway_network__isnull=True,
+    )
+    print('Removing {} reserved IPs'.format(ips.count()))
+    ips.delete()
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('networks', '0006_auto_20160804_1409'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='network',
+            name='reserved_from_beginning',
+            field=models.PositiveIntegerField(help_text='Number of addresses to be omitted in DHCP automatic assignmentcounted from the first IP in range (excluding network address)', default=10),
+        ),
+        migrations.AddField(
+            model_name='network',
+            name='reserved_from_end',
+            field=models.PositiveIntegerField(help_text='Number of addresses to be omitted in DHCP automatic assignmentcounted from the last IP in range (excluding broadcast address)', default=0),
+        ),
+        migrations.RunPython(
+            remove_reserved_ips,
+            reverse_code=create_reserved_ips
+        ),
+    ]

--- a/src/ralph/networks/migrations/0008_auto_20160808_0719.py
+++ b/src/ralph/networks/migrations/0008_auto_20160808_0719.py
@@ -69,7 +69,7 @@ def remove_reserved_ips(apps, schema_editor):
 class Migration(migrations.Migration):
 
     dependencies = [
-        ('networks', '0006_auto_20160804_1409'),
+        ('networks', '0007_auto_20160804_1409'),
     ]
 
     operations = [

--- a/src/ralph/networks/models/networks.py
+++ b/src/ralph/networks/models/networks.py
@@ -3,12 +3,10 @@ import ipaddress
 import logging
 import socket
 import struct
-from itertools import chain
 
 from django.conf import settings
 from django.core.exceptions import ValidationError
 from django.db import models, transaction
-from django.db.models import Q
 from django.db.models.signals import post_migrate
 from django.db.utils import ProgrammingError
 from django.dispatch import receiver

--- a/src/ralph/networks/models/networks.py
+++ b/src/ralph/networks/models/networks.py
@@ -263,6 +263,20 @@ class Network(
         verbose_name=_('DNS servers'),
         blank=True,
     )
+    reserved_from_beginning = models.PositiveIntegerField(
+        help_text=_(
+            'Number of addresses to be omitted in DHCP automatic assignment'
+            'counted from the first IP in range (excluding network address)'
+        ),
+        default=settings.DEFAULT_NETWORK_BOTTOM_MARGIN,
+    )
+    reserved_from_end = models.PositiveIntegerField(
+        help_text=_(
+            'Number of addresses to be omitted in DHCP automatic assignment'
+            'counted from the last IP in range (excluding broadcast address)'
+        ),
+        default=settings.DEFAULT_NETWORK_TOP_MARGIN,
+    )
 
     @property
     def network(self):
@@ -311,29 +325,15 @@ class Network(
     def _has_address_changed(self):
         return self.address != self._old_address
 
-    def _get_reserved_count(self, ips, margin_num):
-        if not ips or ips[0] != margin_num:
-            return 0
-        reserved_count = 1
-        for num1, num2 in zip(ips, ips[1:]):
-            if abs(num2 - num1) != 1:
-                break
-            reserved_count += 1
-        return reserved_count
-
     @property
     def reserved_bottom(self):
-        reserved = IPAddress.objects.filter(
-            network=self, status=IPAddressStatus.reserved
-        ).values_list('number', flat=True).order_by('number')
-        return self._get_reserved_count(reserved, self.min_ip + 1)
+        # DEPRECATED
+        return self.reserved_from_beginning
 
     @property
     def reserved_top(self):
-        reserved = IPAddress.objects.filter(
-            network=self, status=IPAddressStatus.reserved
-        ).values_list('number', flat=True).order_by('-number')
-        return self._get_reserved_count(reserved, self.max_ip - 1)
+        # DEPRECATED
+        return self.reserved_from_end
 
     class Meta:
         verbose_name = _('network')
@@ -359,6 +359,8 @@ class Network(
             >>> network.min_ip, network.max_ip, network.gateway
             (3232235776, 3232236031, None)
         """
+        # TODO: gateway status? reserved? or maybe regular ip field instead of
+        # PK?
         if self.gateway_id and not self.gateway.is_gateway:
             self.gateway.is_gateway = True
             self.gateway.status = IPAddressStatus.reserved
@@ -460,48 +462,25 @@ class Network(
     def get_immediate_subnetworks(self):
         return self.get_children()
 
-    def reserve_margin_addresses(self, bottom_count=0, top_count=0):
-        ips = []
-        existing_ips = set(IPAddress.objects.filter(
-            Q(
-                number__gte=self.min_ip + 1,
-                number__lte=self.min_ip + bottom_count + 1
-            ) |
-            Q(number__gte=self.max_ip - top_count, number__lte=self.max_ip)
-        ).values_list('number', flat=True))
-        to_create = set(chain.from_iterable([
-            range(int(self.min_ip + 1), int(self.min_ip + bottom_count + 1)),
-            range(int(self.max_ip - top_count), int(self.max_ip))
-        ]))
-        to_create = to_create - existing_ips
-        for ip_as_int in to_create:
-            ips.append(IPAddress(
-                address=str(ipaddress.ip_address(ip_as_int)),
-                number=ip_as_int,
-                network=self,
-                status=IPAddressStatus.reserved
-            ))
-        IPAddress.objects.bulk_create(ips)
-        # TODO: handle decreasing count
-        return len(to_create), existing_ips - to_create
-
     def get_first_free_ip(self):
         used_ips = set(IPAddress.objects.filter(
             number__range=(self.min_ip, self.max_ip)
         ).values_list(
             'number', flat=True
         ))
-        min_ip = int(self.min_ip if self.netmask == 31 else self.min_ip + 1)
-        max_ip = int(self.max_ip + 1 if self.netmask == 31 else self.max_ip)
-        ip_as_int = None
-        for ip_as_int in range(min_ip, max_ip):
-            if ip_as_int not in used_ips:
+        # add one to omit network address
+        min_ip = int(self.min_ip + 1 + self.reserved_from_beginning)
+        # subtract 1 to omit broadcast address
+        max_ip = int(self.max_ip - 1 - self.reserved_from_end)
+        free_ip_as_int = None
+        for free_ip_as_int in range(min_ip, max_ip + 1):
+            if free_ip_as_int not in used_ips:
                 break
         # TODO: do it better
-        last = ip_as_int in used_ips
+        last = free_ip_as_int in used_ips
         return (
-            ipaddress.ip_address(ip_as_int)
-            if ip_as_int and not last else None
+            ipaddress.ip_address(free_ip_as_int)
+            if free_ip_as_int and not last else None
         )
 
     def issue_next_free_ip(self):

--- a/src/ralph/networks/tests/test_api.py
+++ b/src/ralph/networks/tests/test_api.py
@@ -70,7 +70,7 @@ class IPAddressAPITests(RalphAPITestCase):
             'hostname': 'another-hostname',
             'is_management': True,
             'is_gateway': True,
-            'status': 'reserved',
+            # 'status': 'reserved',
             'ethernet': self.eth.id,
             'dhcp_expose': True,
         }
@@ -84,7 +84,7 @@ class IPAddressAPITests(RalphAPITestCase):
         self.assertTrue(self.ip1.dhcp_expose)
         self.assertTrue(self.ip1.is_gateway)
         self.assertEqual(self.ip1.ethernet, self.eth)
-        self.assertEqual(self.ip1.status, IPAddressStatus.reserved)
+        # self.assertEqual(self.ip1.status, IPAddressStatus.reserved)
 
     def test_change_ip_address_already_occupied_should_not_pass(self):
         data = {'address': '127.0.0.2'}

--- a/src/ralph/networks/tests/test_api.py
+++ b/src/ralph/networks/tests/test_api.py
@@ -70,7 +70,6 @@ class IPAddressAPITests(RalphAPITestCase):
             'hostname': 'another-hostname',
             'is_management': True,
             'is_gateway': True,
-            # 'status': 'reserved',
             'ethernet': self.eth.id,
             'dhcp_expose': True,
         }
@@ -84,7 +83,6 @@ class IPAddressAPITests(RalphAPITestCase):
         self.assertTrue(self.ip1.dhcp_expose)
         self.assertTrue(self.ip1.is_gateway)
         self.assertEqual(self.ip1.ethernet, self.eth)
-        # self.assertEqual(self.ip1.status, IPAddressStatus.reserved)
 
     def test_change_ip_address_already_occupied_should_not_pass(self):
         data = {'address': '127.0.0.2'}

--- a/src/ralph/networks/tests/test_api.py
+++ b/src/ralph/networks/tests/test_api.py
@@ -4,7 +4,6 @@ from rest_framework import status
 
 from ralph.api.tests._base import RalphAPITestCase
 from ralph.assets.tests.factories import EthernetFactory
-from ralph.networks.models import IPAddressStatus
 from ralph.networks.tests.factories import IPAddressFactory, NetworkFactory
 
 

--- a/src/ralph/networks/tests/test_models.py
+++ b/src/ralph/networks/tests/test_models.py
@@ -152,18 +152,6 @@ class NetworkTest(RalphTestCase):
         result = ip.get_network()
         self.assertEqual(None, result)
 
-    # def test_reserve_margin_addresses_should_reserve_free_addresses(self):
-    #     net = Network.objects.create(
-    #         name='ip_address_should_return_network',
-    #         address='10.1.1.0/24',
-    #     )
-    #     ip1 = IPAddress.objects.create(address='10.1.1.1')
-    #     ip2 = IPAddress.objects.create(address='10.1.1.254')
-    #     result = net.reserve_margin_addresses(bottom_count=10, top_count=10)
-    #     self.assertEqual(18, net.ips.filter(status=IPAddressStatus.reserved).count())  # noqa
-    #     self.assertEqual(18, result[0])
-    #     self.assertEqual(set([ip1.number, ip2.number]), result[1])
-
     def test_create_ip_address(self):
         Network.objects.create(
             name='test_create_ip_address',
@@ -291,60 +279,6 @@ class NetworkTest(RalphTestCase):
         net.delete()
         ip.refresh_from_db()
         self.assertTrue(ip)
-
-    # def test_reserved_count(self):
-    #     net = Network.objects.create(
-    #         name='net', address='192.169.58.0/24'
-    #     )
-    #     self.assertEqual(net.reserved_bottom, 0)
-    #     self.assertEqual(net.reserved_top, 0)
-
-    #     # add one reserved IP
-    #     ip11 = IPAddress.objects.create(
-    #         address='192.169.58.1', status=IPAddressStatus.reserved
-    #     )
-    #     self.assertEqual(net.reserved_bottom, 1)
-    #     ip21 = IPAddress.objects.create(
-    #         address='192.169.58.254', status=IPAddressStatus.reserved
-    #     )
-    #     self.assertEqual(net.reserved_top, 1)
-
-    #     # add another reserved IP on both sides
-    #     ip12 = IPAddress.objects.create(
-    #         address='192.169.58.2', status=IPAddressStatus.reserved
-    #     )
-    #     self.assertEqual(net.reserved_bottom, 2)
-    #     ip22 = IPAddress.objects.create(
-    #         address='192.169.58.253', status=IPAddressStatus.reserved
-    #     )
-    #     self.assertEqual(net.reserved_top, 2)
-
-    #     # add more reserved IPs inside network
-    #     IPAddress.objects.create(
-    #         address='192.169.58.3', status=IPAddressStatus.reserved
-    #     )
-    #     IPAddress.objects.create(
-    #         address='192.169.58.252', status=IPAddressStatus.reserved
-    #     )
-    #     IPAddress.objects.create(
-    #         address='192.169.58.10', status=IPAddressStatus.reserved
-    #     )
-    #     IPAddress.objects.create(
-    #         address='192.169.58.240', status=IPAddressStatus.reserved
-    #     )
-    #     self.assertEqual(net.reserved_bottom, 3)
-    #     self.assertEqual(net.reserved_top, 3)
-
-    #     # delete reversed IPs
-    #     ip12.delete()
-    #     ip22.delete()
-    #     self.assertEqual(net.reserved_bottom, 1)
-    #     self.assertEqual(net.reserved_top, 1)
-
-    #     ip11.delete()
-    #     ip21.delete()
-    #     self.assertEqual(net.reserved_bottom, 0)
-    #     self.assertEqual(net.reserved_top, 0)
 
 
 class NetworkEnvironmentTest(RalphTestCase):

--- a/src/ralph/ralph2_sync/subscribers.py
+++ b/src/ralph/ralph2_sync/subscribers.py
@@ -504,13 +504,13 @@ def sync_network_to_ralph3(data):
     net.remarks = data['remarks']
     net.vlan = data['vlan']
     net.dhcp_broadcast = data['dhcp_broadcast']
-    if data['reserved_ips']:
-        for address in data['reserved_ips']:
-            ip = IPAddress.objects.get_or_create(
-                address=address,
-                defaults=dict(status=IPAddressStatus.reserved)
-            )[0]
-            ip.save()  # trigger save to reassign to proper network
+    # if data['reserved_ips']:
+    #     for address in data['reserved_ips']:
+    #         ip = IPAddress.objects.get_or_create(
+    #             address=address,
+    #             defaults=dict(status=IPAddressStatus.reserved)
+    #         )[0]
+    #         ip.save()  # trigger save to reassign to proper network
     if 'gateway' in data:
         if data['gateway']:
             net.gateway = IPAddress.objects.update_or_create(

--- a/src/ralph/ralph2_sync/subscribers.py
+++ b/src/ralph/ralph2_sync/subscribers.py
@@ -504,13 +504,10 @@ def sync_network_to_ralph3(data):
     net.remarks = data['remarks']
     net.vlan = data['vlan']
     net.dhcp_broadcast = data['dhcp_broadcast']
-    # if data['reserved_ips']:
-    #     for address in data['reserved_ips']:
-    #         ip = IPAddress.objects.get_or_create(
-    #             address=address,
-    #             defaults=dict(status=IPAddressStatus.reserved)
-    #         )[0]
-    #         ip.save()  # trigger save to reassign to proper network
+    if 'reserved_from_beginning' in data:
+        net.reserved_from_beginning = data['reserved_from_beginning']
+    if 'reserved_from_end' in data:
+        net.reserved_from_end = data['reserved_from_end']
     if 'gateway' in data:
         if data['gateway']:
             net.gateway = IPAddress.objects.update_or_create(

--- a/src/ralph/ralph2_sync/tests/test_publishers.py
+++ b/src/ralph/ralph2_sync/tests/test_publishers.py
@@ -361,11 +361,12 @@ class NetworkPublisherTestCase(TestCase):
             network_environment=self.net_env,
             kind=self.net_kind,
             gateway=IPAddressFactory(address='192.168.0.1'),
+            reserved_from_beginning=10,
+            reserved_from_end=5
         )
         ImportedObjects.create(
             self.net, 10
         )
-        self.net.reserve_margin_addresses(10, 5)
         self.terminator1 = DataCenterAssetFactory(hostname='h1.mydc.net')
         self.terminator2 = ClusterFactory(hostname='ss1.mydc.net')
         self.net.terminators.add(self.terminator1, self.terminator2)


### PR DESCRIPTION
POC of using plain int field to mark some ips as reserved (in network & dhcp) instead of creating instance of the ip with reserved status.
