### PR TITLE
Limit async transition to one at a time for object

### DIFF
--- a/src/ralph/lib/transitions/async.py
+++ b/src/ralph/lib/transitions/async.py
@@ -58,7 +58,7 @@ def run_async_transition(job_id):
 def _perform_async_transition(transition_job):
     transition = transition_job.transition
     obj = transition_job.obj
-    _check_instances_for_transition([obj], transition)
+    _check_instances_for_transition([obj], transition, check_async_job=False)
     _check_action_with_instances([obj], transition)
 
     # check if this job isn't already finished

--- a/src/ralph/lib/transitions/tests/test_actions.py
+++ b/src/ralph/lib/transitions/tests/test_actions.py
@@ -16,8 +16,8 @@ from ralph.back_office.tests.factories import (
 )
 from ralph.lib.transitions.models import (
     JobStatus,
-    TransitionsHistory,
-    TransitionJob
+    TransitionJob,
+    TransitionsHistory
 )
 from ralph.lib.transitions.tests import TransitionTestCase
 from ralph.licences.tests.factories import LicenceFactory


### PR DESCRIPTION
For particular object, only one async transition could be running at once.
