### PR TITLE
Fix broken build.

### DIFF
--- a/debian/ralph-core.postinst
+++ b/debian/ralph-core.postinst
@@ -3,7 +3,7 @@
 set -e
 
 if [ -z "$2" ]; then
-  # do install stuff
+  : # do install stuff
 else
   /opt/ralph/ralph-core/bin/ralph migrate
   /opt/ralph/ralph-core/bin/ralph sitetree_resync_apps


### PR DESCRIPTION
Installing debian package was not possible, since
debian/raph-core.postinst script was not valid.
I added empty(:) instruction to 'if' clause to be parsed
correctly.
