### PR TITLE
Add missing apt-transport-https instruction

### DIFF
--- a/docs/installation/installation.md
+++ b/docs/installation/installation.md
@@ -8,9 +8,12 @@ with many development *bells and whistles* included.
 
 ## Debian/Ubuntu package - recommended
 
-Make sure, your installation is clean Ubuntu 14.04, without any other packages installed.
+Make sure, your installation is clean Ubuntu 14.04, without any other packages installed, 
+and `apt-transport-https` installed.
 
-First, add our official ralph repository:
+    sudo apt-get update && apt-get install apt-transport-https
+
+Now, add our official ralph repository:
 
     sudo apt-key adv --keyserver  hkp://keyserver.ubuntu.com:80 --recv-keys 379CE192D401AB61
     sudo sh -c "echo 'deb https://dl.bintray.com/vi4m/ralph wheezy main' >  /etc/apt/sources.list.d/vi4m_ralph.list"


### PR DESCRIPTION
Docker's Ubuntu 14.04 is missing apt-transport-https.
Add it to the manual instructions.
