### PR TITLE
Fix internal server error during creating user

### DIFF
--- a/src/ralph/ralph2_sync/admin.py
+++ b/src/ralph/ralph2_sync/admin.py
@@ -15,7 +15,7 @@ class Ralph2SyncAdminMixin(object):
         # enable back syncing of object
         obj._handle_post_save = True
         # call post_save to trigger syning "manually"
-        post_save.send(sender=self.model, instance=obj, created=created)
+        post_save.send(sender=self.model, instance=obj, created=False)
 
     # log_addition and log_change are called after succesfull save (with m2m)
     # in regular form and bulk edit


### PR DESCRIPTION
Use `created=False` param in Ralph2SyncAdminMixin post_save trigger (it's not used in sync function anyway), to not trigger token creation twice.
