### PR TITLE
Fix OperationalError on network when lft > rght

### DIFF
--- a/src/ralph/admin/helpers.py
+++ b/src/ralph/admin/helpers.py
@@ -145,7 +145,3 @@ class CastToInteger(Func):
     def as_mysql(self, compiler, connection):
         self.extra['integer_type'] = 'SIGNED'
         return super().as_sql(compiler, connection)
-
-    def as_postgresql(self, compiler, connection):
-        self.extra['integer_type'] = 'INTEGER'
-        return super().as_sql(compiler, connection)

--- a/src/ralph/admin/helpers.py
+++ b/src/ralph/admin/helpers.py
@@ -145,3 +145,7 @@ class CastToInteger(Func):
     def as_mysql(self, compiler, connection):
         self.extra['integer_type'] = 'SIGNED'
         return super().as_sql(compiler, connection)
+
+    def as_psql(self, compiler, connection):
+        self.extra['integer_type'] = 'INTEGER'
+        return super().as_sql(compiler, connection)

--- a/src/ralph/admin/helpers.py
+++ b/src/ralph/admin/helpers.py
@@ -146,6 +146,6 @@ class CastToInteger(Func):
         self.extra['integer_type'] = 'SIGNED'
         return super().as_sql(compiler, connection)
 
-    def as_psql(self, compiler, connection):
+    def as_postgresql(self, compiler, connection):
         self.extra['integer_type'] = 'INTEGER'
         return super().as_sql(compiler, connection)

--- a/src/ralph/admin/helpers.py
+++ b/src/ralph/admin/helpers.py
@@ -5,6 +5,7 @@ from django.contrib.admin.utils import get_fields_from_path
 from django.contrib.contenttypes.models import ContentType
 from django.core.urlresolvers import reverse
 from django.db.models.constants import LOOKUP_SEP
+from django.db.models.expressions import Func
 
 
 def get_admin_url(obj, action):
@@ -128,3 +129,19 @@ def get_client_ip(request):
     else:
         ip = request.META.get('REMOTE_ADDR')
     return ip
+
+
+class CastToInteger(Func):
+    """
+    A helper class for casting values to signed integer in database.
+    """
+    function = 'CAST'
+    template = '%(function)s(%(expressions)s as %(integer_type)s)'
+
+    def __init__(self, *expressions, **extra):
+        super().__init__(*expressions, **extra)
+        self.extra['integer_type'] = 'INTEGER'
+
+    def as_mysql(self, compiler, connection):
+        self.extra['integer_type'] = 'SIGNED'
+        return super().as_sql(compiler, connection)

--- a/src/ralph/networks/admin.py
+++ b/src/ralph/networks/admin.py
@@ -2,7 +2,7 @@ from django import forms
 from django.conf import settings
 from django.contrib.admin.views.main import ORDER_VAR, SEARCH_VAR
 from django.core.urlresolvers import reverse
-from django.db.models import Count, Prefetch, F
+from django.db.models import Count, F, Prefetch
 from django.forms.models import ModelForm
 from django.utils.translation import ugettext_lazy as _
 

--- a/src/ralph/networks/admin.py
+++ b/src/ralph/networks/admin.py
@@ -246,7 +246,9 @@ class NetworkAdmin(RalphMPTTAdmin):
     def get_queryset(self, request):
         qs = super().get_queryset(request)
         qs = qs.annotate(ipaddress_count=Count('ips')).annotate(
-            subnetworks_count=CastToInteger(F('rght')) - CastToInteger(F('lft'))  # noqa
+            subnetworks_count=(
+                CastToInteger(F('rght')) - CastToInteger(F('lft'))
+            )
         )
         # Getting subnetwork counts, used for column ordering
         # https://github.com/django-mptt/django-mptt/blob/master/mptt/models.py#L594  # noqa

--- a/src/ralph/networks/admin.py
+++ b/src/ralph/networks/admin.py
@@ -245,16 +245,13 @@ class NetworkAdmin(RalphMPTTAdmin):
 
     def get_queryset(self, request):
         qs = super().get_queryset(request)
+        # Getting subnetwork counts, used for column ordering
+        # https://github.com/django-mptt/django-mptt/blob/master/mptt/models.py#L594  # noqa
         qs = qs.annotate(ipaddress_count=Count('ips')).annotate(
             subnetworks_count=(
                 CastToInteger(F('rght')) - CastToInteger(F('lft'))
             )
         )
-        # Getting subnetwork counts, used for column ordering
-        # https://github.com/django-mptt/django-mptt/blob/master/mptt/models.py#L594  # noqa
-        # qs = qs.extra(select={
-        #     'subnetworks_count': F('rght') #'CAST(rght AS SIGNED) - CAST(lft AS SIGNED)'
-        # })
         return qs
 
     def get_paginator(

--- a/src/ralph/networks/admin.py
+++ b/src/ralph/networks/admin.py
@@ -2,12 +2,13 @@ from django import forms
 from django.conf import settings
 from django.contrib.admin.views.main import ORDER_VAR, SEARCH_VAR
 from django.core.urlresolvers import reverse
-from django.db.models import Count, Prefetch
+from django.db.models import Count, Prefetch, F
 from django.forms.models import ModelForm
 from django.utils.translation import ugettext_lazy as _
 
 from ralph.admin import RalphAdmin, register
 from ralph.admin.filters import RelatedAutocompleteFieldListFilter
+from ralph.admin.helpers import CastToInteger
 from ralph.admin.mixins import RalphAdminFormMixin, RalphMPTTAdmin
 from ralph.admin.views.main import RalphChangeList
 from ralph.assets.models import BaseObject
@@ -244,12 +245,14 @@ class NetworkAdmin(RalphMPTTAdmin):
 
     def get_queryset(self, request):
         qs = super().get_queryset(request)
-        qs = qs.annotate(ipaddress_count=Count('ips'))
+        qs = qs.annotate(ipaddress_count=Count('ips')).annotate(
+            subnetworks_count=CastToInteger(F('rght')) - CastToInteger(F('lft'))
+        )
         # Getting subnetwork counts, used for column ordering
         # https://github.com/django-mptt/django-mptt/blob/master/mptt/models.py#L594  # noqa
-        qs = qs.extra(select={
-            'subnetworks_count': 'CAST(rght AS SIGNED) - CAST(lft AS SIGNED)'
-        })
+        # qs = qs.extra(select={
+        #     'subnetworks_count': F('rght') #'CAST(rght AS SIGNED) - CAST(lft AS SIGNED)'
+        # })
         return qs
 
     def get_paginator(

--- a/src/ralph/networks/admin.py
+++ b/src/ralph/networks/admin.py
@@ -246,7 +246,7 @@ class NetworkAdmin(RalphMPTTAdmin):
     def get_queryset(self, request):
         qs = super().get_queryset(request)
         qs = qs.annotate(ipaddress_count=Count('ips')).annotate(
-            subnetworks_count=CastToInteger(F('rght')) - CastToInteger(F('lft'))
+            subnetworks_count=CastToInteger(F('rght')) - CastToInteger(F('lft'))  # noqa
         )
         # Getting subnetwork counts, used for column ordering
         # https://github.com/django-mptt/django-mptt/blob/master/mptt/models.py#L594  # noqa

--- a/src/ralph/networks/admin.py
+++ b/src/ralph/networks/admin.py
@@ -247,7 +247,9 @@ class NetworkAdmin(RalphMPTTAdmin):
         qs = qs.annotate(ipaddress_count=Count('ips'))
         # Getting subnetwork counts, used for column ordering
         # https://github.com/django-mptt/django-mptt/blob/master/mptt/models.py#L594  # noqa
-        qs = qs.extra(select={'subnetworks_count': 'rght - lft'})
+        qs = qs.extra(select={
+            'subnetworks_count': 'CAST(rght AS SIGNED) - CAST(lft AS SIGNED)'
+        })
         return qs
 
     def get_paginator(

--- a/src/ralph/networks/tests/test_models.py
+++ b/src/ralph/networks/tests/test_models.py
@@ -2,7 +2,9 @@ from ipaddress import ip_address, ip_network
 
 from ddt import data, ddt, unpack
 from django.core.exceptions import ValidationError
+from django.db.models import F
 
+from ralph.admin.helpers import CastToInteger
 from ralph.assets.models import AssetLastHostname
 from ralph.assets.tests.factories import EthernetFactory
 from ralph.networks.models.choices import IPAddressStatus
@@ -71,9 +73,11 @@ class SimpleNetworkTest(RalphTestCase):
 
     def test_subnetworks_count_cast_to_integer(self):
         net = Network.objects.get(pk=self.net1.pk)
-        count = Network.objects.filter(id=self.net1.id).extra(select={
-            'subnetworks_count': 'CAST(rght AS SIGNED) - CAST(lft AS SIGNED)'
-        }).values_list('subnetworks_count', flat=True)[0]
+        count = Network.objects.filter(id=self.net1.id).annotate(
+            subnetworks_count=(
+                CastToInteger(F('rght')) - CastToInteger(F('lft'))
+            )
+        ).values_list('subnetworks_count', flat=True)[0]
         self.assertTrue(count)
 
 

--- a/src/ralph/networks/tests/test_models.py
+++ b/src/ralph/networks/tests/test_models.py
@@ -47,6 +47,7 @@ class SimpleNetworkTest(RalphTestCase):
         self.ip2.save()
         self.ip3 = IPAddress(address='192.168.128.11')
         self.ip3.save()
+        Network.objects.rebuild()
 
     @unpack
     @data(
@@ -67,6 +68,13 @@ class SimpleNetworkTest(RalphTestCase):
         self.assertEquals(
             list(res), list(Network.objects.filter(name__in=correct))
         )
+
+    def test_subnetworks_count_cast_to_integer(self):
+        net = Network.objects.get(pk=self.net1.pk)
+        count = Network.objects.filter(id=self.net1.id).extra(select={
+            'subnetworks_count': 'CAST(rght AS SIGNED) - CAST(lft AS SIGNED)'
+        }).values_list('subnetworks_count', flat=True)[0]
+        self.assertTrue(count)
 
 
 @ddt


### PR DESCRIPTION
Network's view raised `OperationalError` (BIGINT UNSIGNED value is out of
range) when lft > rght.
