### PR TITLE
Fix creating DNS records during deployment

### DIFF
--- a/src/ralph/deployment/deployment.py
+++ b/src/ralph/deployment/deployment.py
@@ -511,6 +511,7 @@ def create_dns_entries(cls, instances, **kwargs):
             'name': instance.hostname,
             'type': RecordType.a.id,
             'content': ip,
+            'ptr': True,
         })
 
 

--- a/src/ralph/deployment/tests/test_deployment.py
+++ b/src/ralph/deployment/tests/test_deployment.py
@@ -1,6 +1,6 @@
-from ddt import data, ddt, unpack
 from unittest import mock
 
+from ddt import data, ddt, unpack
 from django.conf import settings
 from django.test import override_settings, TestCase
 

--- a/src/ralph/dns/dnsaas.py
+++ b/src/ralph/dns/dnsaas.py
@@ -189,8 +189,11 @@ class DNSaaS:
             'domain': domain,
             'owner': settings.DNSAAS_OWNER
         }
-        request = self.session.post(url, data=data)
-        return self._request2result(request)
+        return self._post(url, data)
+
+    def _post(self, url, data):
+        response = self.session.post(url, data=data)
+        return self._request2result(response)
 
     def delete_dns_record(self, record_id):
         """


### PR DESCRIPTION
Pass ptr field to `create_dns_record`
