### PR TITLE
Add index to object_id in to custom fields

### DIFF
--- a/src/ralph/lib/custom_fields/migrations/0003_auto_20160804_1305.py
+++ b/src/ralph/lib/custom_fields/migrations/0003_auto_20160804_1305.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('custom_fields', '0002_customfield_use_as_configuration_variable'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='customfieldvalue',
+            name='object_id',
+            field=models.PositiveIntegerField(db_index=True),
+        ),
+    ]

--- a/src/ralph/lib/custom_fields/models.py
+++ b/src/ralph/lib/custom_fields/models.py
@@ -115,7 +115,7 @@ class CustomFieldValue(TimeStampMixin, models.Model):
     # of integers or other Django filters like gte, lte.
     value = models.CharField(max_length=CUSTOM_FIELD_VALUE_MAX_LENGTH)
     content_type = models.ForeignKey(ContentType)
-    object_id = models.PositiveIntegerField()
+    object_id = models.PositiveIntegerField(db_index=True)
     object = generic.GenericForeignKey('content_type', 'object_id')
 
     class Meta:


### PR DESCRIPTION
Custom field values inline in details view of asset generate query with where
statement which contains object_id. Now is more efficient -- ~1ms vs ~20ms in environment.
