### PR TITLE
Fix dc hosts update signal to not be called twice when Ralph2 sync is on

### DIFF
--- a/src/ralph/data_center/models/physical.py
+++ b/src/ralph/data_center/models/physical.py
@@ -699,4 +699,7 @@ if settings.HERMES_HOST_UPDATE_TOPIC_NAME:
 
     @receiver(post_save, sender=DataCenterAsset)
     def post_save_dc_asset(sender, instance, **kwargs):
-        return publish_host_update(instance)
+        # temporary, until Ralph2 sync is turned on
+        # see ralph.ralph2_sync.admin for details
+        if getattr(instance, '_handle_post_save', True):
+            return publish_host_update(instance)

--- a/src/ralph/virtual/models.py
+++ b/src/ralph/virtual/models.py
@@ -309,8 +309,14 @@ if settings.HERMES_HOST_UPDATE_TOPIC_NAME:
 
     @receiver(models.signals.post_save, sender=CloudHost)
     def post_save_cloud_host(sender, instance, **kwargs):
-        return publish_host_update(instance)
+        # temporary, until Ralph2 sync is turned on
+        # see ralph.ralph2_sync.admin for details
+        if getattr(instance, '_handle_post_save', True):
+            return publish_host_update(instance)
 
     @receiver(models.signals.post_save, sender=VirtualServer)
     def post_save_virtual_server(sender, instance, **kwargs):
-        return publish_host_update(instance)
+        # temporary, until Ralph2 sync is turned on
+        # see ralph.ralph2_sync.admin for details
+        if getattr(instance, '_handle_post_save', True):
+            return publish_host_update(instance)


### PR DESCRIPTION
To be removed when Ralph2 sync will be remove
