### PR TITLE
DCHost API - add configuration_variables field

### DIFF
--- a/src/ralph/assets/api/serializers.py
+++ b/src/ralph/assets/api/serializers.py
@@ -410,7 +410,8 @@ class DCHostSerializer(ComponentSerializerMixin, BaseObjectSerializer):
     class Meta:
         model = BaseObject
         fields = [
-            'id', 'url', 'ethernet', 'memory', 'ipaddresses', 'custom_fields',
+            'id', 'url', 'ethernet', 'ipaddresses', 'custom_fields',
             '__str__', 'tags', 'service_env', 'configuration_path', 'hostname',
-            'created', 'modified', 'remarks', 'parent', 'object_type'
+            'created', 'modified', 'remarks', 'parent', 'object_type',
+            'configuration_variables',
         ]

--- a/src/ralph/assets/api/views.py
+++ b/src/ralph/assets/api/views.py
@@ -215,6 +215,7 @@ class DCHostFilterSet(NetworkableObjectFilters):
         model = models.BaseObject
 
 
+# TODO: move to data_center and use DCHost proxy model
 class DCHostViewSet(BaseObjectViewSetMixin, RalphAPIViewSet):
     queryset = models.BaseObject.polymorphic_objects
     serializer_class = serializers.DCHostSerializer
@@ -227,12 +228,15 @@ class DCHostViewSet(BaseObjectViewSetMixin, RalphAPIViewSet):
         'service_env', 'service_env__service', 'service_env__environment',
         'configuration_path', 'configuration_path__module'
     ]
-    prefetch_related = base_object_descendant_prefetch_related + [
+    prefetch_related = [
         'tags',
-        'memory_set',
         Prefetch(
             'ethernet_set',
             queryset=models.Ethernet.objects.select_related('ipaddress')
+        ),
+        Prefetch(
+            'custom_fields',
+            queryset=CustomFieldValue.objects.select_related('custom_field')
         ),
     ]
     extended_filter_fields = {


### PR DESCRIPTION
Add configuration_variables field to DCHosts api view.
Remove unnecessary prefetch_related and memory field.
