### PR TITLE
[API] Fix for 'isnull' filter + improvement for DateField/DateTimeField.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,6 @@ env:
         - DJANGO_CURRENT_VERSION=1.8.12
         - RALPH2_RALPH3_CROSS_VALIDATION_ENABLED=1
     matrix:
-        - DJANGO_VERSION=1.8.12 TEST_DB_ENGINE=sqlite
         - DJANGO_VERSION=1.8.12 TEST_DB_ENGINE=mysql
         - DJANGO_VERSION=1.8.12 TEST_DB_ENGINE=psql
         # Django 1.9 build will not pass until #2132 will be merged

--- a/src/ralph/api/filters.py
+++ b/src/ralph/api/filters.py
@@ -188,12 +188,13 @@ class LookupFilterBackend(BaseFilterBackend):
             ))
             if lookup in field_lookups:
                 if lookup == 'isnull':
-                    value_old = value
-                    value = BOOL_VALUES.get(value, value_old)
-                    if value == value_old:
+                    if value not in BOOL_VALUES:
                         logger.debug(
                             'Unknown value for isnull filter: {}'.format(value)
                         )
+                        return {}
+                    else:
+                        value = BOOL_VALUES[value]
                 result = {'{}__{}'.format(model_field_name, lookup): value}
         return result
 

--- a/src/ralph/api/filters.py
+++ b/src/ralph/api/filters.py
@@ -138,9 +138,13 @@ class LookupFilterBackend(BaseFilterBackend):
             'in', 'iendswith', 'isnull', 'regex', 'iregex'
         },
         models.DateField: {
-            'year', 'month', 'day', 'week_day', 'range', 'isnull'
+            'year', 'month', 'day', 'week_day', 'range', 'isnull', 'lte',
+            'gte', 'lt', 'gt'
         },
-        models.DateTimeField: {'hour', 'minute', 'second'},
+        models.DateTimeField: {
+            'year', 'month', 'day', 'week_day', 'hour', 'minute', 'second',
+            'range', 'isnull', 'lte', 'gte', 'lt', 'gt'
+        },
         models.DecimalField: {
             'lte', 'gte', 'lt', 'gt', 'exact', 'in', 'range', 'isnull'
         }
@@ -183,6 +187,13 @@ class LookupFilterBackend(BaseFilterBackend):
                 model, model_field_name, field_lookups
             ))
             if lookup in field_lookups:
+                if lookup == 'isnull':
+                    value_old = value
+                    value = BOOL_VALUES.get(value, value_old)
+                    if value == value_old:
+                        logger.debug(
+                            'Unknown value for isnull filter: {}'.format(value)
+                        )
                 result = {'{}__{}'.format(model_field_name, lookup): value}
         return result
 

--- a/src/ralph/api/tests/test_filters.py
+++ b/src/ralph/api/tests/test_filters.py
@@ -184,7 +184,7 @@ class TestLookupFilterBackend(RalphTestCase):
             request, Bar.objects.all(), bvs)
         ), 4)
 
-    def test_a_query_filters_isnull(self):
+    def test_query_filters_isnull(self):
         request = self.request_factory.get('/api/bar')
         bvs = BarViewSet()
 

--- a/src/ralph/api/tests/test_filters.py
+++ b/src/ralph/api/tests/test_filters.py
@@ -184,7 +184,7 @@ class TestLookupFilterBackend(RalphTestCase):
             request, Bar.objects.all(), bvs)
         ), 4)
 
-    def test_query_filters_isnull(self):
+    def test_a_query_filters_isnull(self):
         request = self.request_factory.get('/api/bar')
         bvs = BarViewSet()
 

--- a/src/ralph/tests/migrations/0007_auto_20160808_1324.py
+++ b/src/ralph/tests/migrations/0007_auto_20160808_1324.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('tests', '0006_auto_20160607_0842'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='bar',
+            name='date',
+            field=models.DateField(blank=True, null=True),
+        ),
+    ]

--- a/src/ralph/tests/models.py
+++ b/src/ralph/tests/models.py
@@ -58,7 +58,7 @@ class Car2(models.Model):
 class Bar(models.Model):
     name = models.CharField(max_length=255)
     created = models.DateTimeField(auto_now_add=True)
-    date = models.DateField()
+    date = models.DateField(blank=True, null=True)
     price = models.DecimalField(max_digits=5, decimal_places=2)
     count = models.IntegerField(default=0)
     foos = models.ManyToManyField(Foo, related_name='bars', blank=True)


### PR DESCRIPTION
This PR adds the following improvements/fixes to API filtering:
- extends filtering on `DateField` by adding `lte`, `gte`, `lt` and `gt` filters.
- extends filtering on `DateTimeField` by adding `year`, `month`, `day`, `week_day`, `range`, `isnull`, `lte`, `gte`, `lt`, and `gt` filters.
- fixes `isnull` filter by properly interpreting truthy values (`1`, `'1'`, `'true'`, `'True'`, `'yes'`) and falsey values (`0`, `'0'`, `'false'`, `'False'`, `'no'`).
