### PR TITLE
Fix network environment calculation for DCAsset & VirtualServer

### DIFF
--- a/src/ralph/data_center/models/physical.py
+++ b/src/ralph/data_center/models/physical.py
@@ -291,12 +291,18 @@ class NetworkableBaseObject(models.Model):
             * find networks which are "connected" to rack assigned to me
             * find all (distinct) network environments assigned to these
               networks
+            * filter networks by ips currently assigned to object,
             * return first founded network environment if there is any,
               otherwise return `None`
         """
         if self.rack_id:
+            # TODO: better handling (when server in multiple environments)
             return NetworkEnvironment.objects.filter(
-                network__racks=self.rack
+                network__racks=self.rack,
+                # filter env by ips assigned to current object
+                network__in=self.ipaddresses.filter(
+                    is_management=False
+                ).values_list('network', flat=True)
             ).distinct().first()
 
     @property

--- a/src/ralph/deployment/tests/test_deployment.py
+++ b/src/ralph/deployment/tests/test_deployment.py
@@ -145,7 +145,7 @@ class _BaseTestDeploymentActionsTestCase(object):
 
     def test_assign_new_hostname(self):
         self._prepare_rack()
-        next_free_hostname = self.instance.get_next_free_hostname()
+        next_free_hostname = 'server_10001.mydc.net'
         history = {self.instance.pk: {}}
         self.instance.__class__.assign_new_hostname(
             [self.instance], {'value': self.net_env.id}, history_kwargs=history


### PR DESCRIPTION
Don't rely only on rack in which server is installed - use ips assigned to server when calculating network env as well (assume, that server has non-management ips only in one environment).
