### PR TITLE
Fix commiting async job to worker

### DIFF
--- a/src/ralph/assets/tests/test_api.py
+++ b/src/ralph/assets/tests/test_api.py
@@ -803,7 +803,6 @@ class DCHostAPITests(RalphAPITestCase):
         )
         self.virtual.update_custom_field('test_cf', 'def')
         se = ServiceEnvironmentFactory(service__uid='sc-333')
-        # this will create additional DataCenterAsset (hypervisor)
         self.cloud_host = CloudHostFullFactory(
             configuration_path__module__name='ralph3',
             service_env=se,
@@ -819,7 +818,7 @@ class DCHostAPITests(RalphAPITestCase):
         with self.assertNumQueries(11):
             response = self.client.get(url, format='json')
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(response.data['count'], 4)
+        self.assertEqual(response.data['count'], 3)
 
     def test_filter_by_type_dc_asset(self):
         url = '{}?{}'.format(
@@ -828,7 +827,7 @@ class DCHostAPITests(RalphAPITestCase):
         )
         response = self.client.get(url, format='json')
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(response.data['count'], 2)
+        self.assertEqual(response.data['count'], 1)
         dca = response.data['results'][0]
         self.assertEqual(dca['hostname'], self.dc_asset.hostname)
         self.assertEqual(len(dca['ethernet']), 3)

--- a/src/ralph/assets/tests/test_api.py
+++ b/src/ralph/assets/tests/test_api.py
@@ -803,6 +803,7 @@ class DCHostAPITests(RalphAPITestCase):
         )
         self.virtual.update_custom_field('test_cf', 'def')
         se = ServiceEnvironmentFactory(service__uid='sc-333')
+        # this will create additional DataCenterAsset (hypervisor)
         self.cloud_host = CloudHostFullFactory(
             configuration_path__module__name='ralph3',
             service_env=se,
@@ -818,7 +819,7 @@ class DCHostAPITests(RalphAPITestCase):
         with self.assertNumQueries(11):
             response = self.client.get(url, format='json')
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(response.data['count'], 3)
+        self.assertEqual(response.data['count'], 4)
 
     def test_filter_by_type_dc_asset(self):
         url = '{}?{}'.format(
@@ -827,7 +828,7 @@ class DCHostAPITests(RalphAPITestCase):
         )
         response = self.client.get(url, format='json')
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(response.data['count'], 1)
+        self.assertEqual(response.data['count'], 2)
         dca = response.data['results'][0]
         self.assertEqual(dca['hostname'], self.dc_asset.hostname)
         self.assertEqual(len(dca['ethernet']), 3)

--- a/src/ralph/lib/external_services/models.py
+++ b/src/ralph/lib/external_services/models.py
@@ -201,6 +201,7 @@ class Job(TimeStampMixin):
             _dumped_params=cls.prepare_params(**kwargs),
             **(defaults or {})
         )
+        # commit transaction to allow worker to fetch it using job id
         transaction.commit()
         service.run_async(job_id=obj.id)
         return obj.id, obj

--- a/src/ralph/lib/external_services/models.py
+++ b/src/ralph/lib/external_services/models.py
@@ -7,7 +7,7 @@ from dateutil.parser import parse
 from dj.choices import Choices
 from django.contrib.auth import get_user_model
 from django.contrib.contenttypes.models import ContentType
-from django.db import models
+from django.db import models, transaction
 from django.db.models.query import QuerySet
 from django.utils.translation import ugettext_lazy as _
 from django_extensions.db.fields.json import JSONField
@@ -201,6 +201,7 @@ class Job(TimeStampMixin):
             _dumped_params=cls.prepare_params(**kwargs),
             **(defaults or {})
         )
+        transaction.commit()
         service.run_async(job_id=obj.id)
         return obj.id, obj
 

--- a/src/ralph/lib/external_services/tests.py
+++ b/src/ralph/lib/external_services/tests.py
@@ -3,7 +3,7 @@ import json
 
 from django.contrib.auth import get_user_model
 from django.contrib.contenttypes.models import ContentType
-from django.test import RequestFactory, TestCase
+from django.test import RequestFactory, TestCase, TransactionTestCase
 
 from ralph.lib.external_services.models import Job, JobStatus
 from ralph.tests.models import Bar, Foo
@@ -72,7 +72,7 @@ class JobDumpParamsTestCase(TestCase):
         self.assertEqual(result, self.sample_obj)
 
 
-class JobRunTestCase(TestCase):
+class JobRunTestCase(TransactionTestCase):
     def setUp(self):
         self.foo = Foo.objects.create(bar='bar')
         self.request_factory = RequestFactory()

--- a/src/ralph/lib/transitions/api/views.py
+++ b/src/ralph/lib/transitions/api/views.py
@@ -31,7 +31,7 @@ from ralph.lib.transitions.models import (
     TransitionJob,
     TransitionModel
 )
-from ralph.lib.transitions.views import collect_actions
+from ralph.lib.transitions.views import collect_actions, NonAtomicView
 
 FIELD_MAP = {
     forms.CharField: (serializers.CharField, [
@@ -99,7 +99,7 @@ class AvailableTransitionViewSet(TransitionViewSet):
         return queryset
 
 
-class TransitionViewMixin(APIView):
+class TransitionViewMixin(NonAtomicView, APIView):
 
     def initial(self, request, *args, **kwargs):
         self.obj = self.transition.model.content_type.get_object_for_this_type(

--- a/src/ralph/lib/transitions/apps.py
+++ b/src/ralph/lib/transitions/apps.py
@@ -5,14 +5,3 @@ from django.apps import AppConfig
 class TransitionAppConfig(AppConfig):
     name = 'ralph.lib.transitions'
     verbose_name = 'Transitions'
-
-    def ready(self):
-        from ralph.lib.transitions.models import update_models_attrs
-        try:
-            # RuntimeError raised when database is empty (e.g. after tests).
-            # The best solution would be run update_models_attrs after loaded
-            # all apps. Django apps mechanism doesn't have any signal for
-            # this sitiuation.
-            update_models_attrs()
-        except RuntimeError:
-            pass

--- a/src/ralph/lib/transitions/models.py
+++ b/src/ralph/lib/transitions/models.py
@@ -659,7 +659,6 @@ def update_models_attrs(sender, **kwargs):
     """
     if sender.name == 'ralph.' + Transition._meta.app_label:
         for model, field_names in _transitions_fields.items():
-            ContentType.objects.get_for_model(model)
             content_type = ContentType.objects.get_for_model(model)
             for field_name in field_names:
                 transition_model, _ = TransitionModel.objects.get_or_create(

--- a/src/ralph/lib/transitions/models.py
+++ b/src/ralph/lib/transitions/models.py
@@ -143,10 +143,10 @@ def _check_and_get_transition(obj, transition, field):
             'Model {} not found in registry'.format(obj.__class__)
         )
     if isinstance(transition, str):
-        transition_model = obj.transition_models[field]
         transition = Transition.objects.get(
             name=transition,
-            model=transition_model,
+            model__content_type=ContentType.objects.get_for_model(obj),
+            model__field_name=field
         )
     return transition
 
@@ -410,10 +410,9 @@ def get_available_transitions_for_field(instance, field, user=None):
     """
     Returns list of all available transitions for field.
     """
-    if not hasattr(instance, 'transition_models'):
-        return []
     transitions = Transition.objects.filter(
-        model=instance.transition_models[field],
+        model__content_type=ContentType.objects.get_for_model(instance),
+        model__field_name=field,
     ).select_related('model', 'model__content_type').prefetch_related('actions')
     result = []
     for transition in transitions:
@@ -459,6 +458,13 @@ class TransitionModel(AdminAbsoluteUrlMixin, models.Model):
 
     def __str__(self):
         return '{} {}'.format(self.content_type, self.field_name)
+
+    @classmethod
+    def get_for_field(cls, model, field_name):
+        return cls._default_manager.get(
+            content_type=ContentType.objects.get_for_model(model),
+            field_name=field_name
+        )
 
 
 class Transition(models.Model):
@@ -647,22 +653,22 @@ class TransitionJobAction(TimeStampMixin):
     # TODO: add retries field and max retries param for async action
 
 
-def update_models_attrs():
+def update_models_attrs(sender, **kwargs):
     """
-    Add to class new attribute `transition_models` which is dict with all
-    transitionable models (key) and fields (value as list).
+    Create TransitionModel for each model which has TransitionField.
     """
-    for model, field_names in _transitions_fields.items():
-        ContentType.objects.get_for_model(model)
-        content_type = ContentType.objects.get_for_model(model)
-        transition_models = {}
-        for field_name in field_names:
-            transition_model, _ = TransitionModel.objects.get_or_create(
-                content_type=content_type,
-                field_name=field_name
-            )
-            transition_models[field_name] = transition_model
-        setattr(model, 'transition_models', transition_models)
+    if sender.name == 'ralph.' + Transition._meta.app_label:
+        for model, field_names in _transitions_fields.items():
+            ContentType.objects.get_for_model(model)
+            content_type = ContentType.objects.get_for_model(model)
+            for field_name in field_names:
+                transition_model, _ = TransitionModel.objects.get_or_create(
+                    content_type=content_type,
+                    field_name=field_name
+                )
+
+
+post_migrate.connect(update_models_attrs)
 
 
 def update_transitions_after_migrate(**kwargs):

--- a/src/ralph/lib/transitions/tests/__init__.py
+++ b/src/ralph/lib/transitions/tests/__init__.py
@@ -12,7 +12,7 @@ from ralph.lib.transitions.models import (
 from ralph.tests.models import Order
 
 
-class TransitionTestCase(TestCase):
+class TransitionTestCaseMixin(object):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
@@ -44,3 +44,7 @@ class TransitionTestCase(TestCase):
             actions = Action.actions_for_model(model)
         transition.actions.add(*[x for x in actions])
         return transition_model, transition, actions
+
+
+class TransitionTestCase(TransitionTestCaseMixin, TestCase):
+    pass

--- a/src/ralph/lib/transitions/tests/__init__.py
+++ b/src/ralph/lib/transitions/tests/__init__.py
@@ -6,18 +6,13 @@ from ralph.lib.transitions.forms import TransitionForm
 from ralph.lib.transitions.models import (
     Action,
     Transition,
-    update_models_attrs,
+    TransitionModel,
 )
 
 from ralph.tests.models import Order
 
 
 class TransitionTestCaseMixin(object):
-    @classmethod
-    def setUpClass(cls):
-        super().setUpClass()
-        update_models_attrs()
-
     def _get_form(self, obj=None):
         class Form(TransitionForm):
             if obj:
@@ -28,7 +23,7 @@ class TransitionTestCaseMixin(object):
         self, model, name, actions=None, field='status',
         source=None, target=None, **kwargs
     ):
-        transition_model = model.transition_models[field]
+        transition_model = TransitionModel.get_for_field(model, field)
         transition_kwargs = dict(name=name, model=transition_model, **kwargs)
         if source:
             transition_kwargs['source'] = source

--- a/src/ralph/lib/transitions/tests/test_actions.py
+++ b/src/ralph/lib/transitions/tests/test_actions.py
@@ -16,7 +16,10 @@ from ralph.back_office.tests.factories import (
 )
 from ralph.lib.external_services.models import JobStatus
 from ralph.lib.transitions.models import TransitionJob, TransitionsHistory
-from ralph.lib.transitions.tests import TransitionTestCase, TransitionTestCaseMixin
+from ralph.lib.transitions.tests import (
+    TransitionTestCase,
+    TransitionTestCaseMixin
+)
 from ralph.licences.tests.factories import LicenceFactory
 
 

--- a/src/ralph/lib/transitions/tests/test_actions.py
+++ b/src/ralph/lib/transitions/tests/test_actions.py
@@ -3,7 +3,7 @@ from dj.choices import Country
 from django.contrib.auth import get_user_model
 from django.contrib.contenttypes.models import ContentType
 from django.core.urlresolvers import reverse
-from django.test import Client
+from django.test import Client, TransactionTestCase
 from rest_framework.test import APIClient
 
 from ralph.accounts.tests.factories import UserFactory
@@ -16,11 +16,11 @@ from ralph.back_office.tests.factories import (
 )
 from ralph.lib.external_services.models import JobStatus
 from ralph.lib.transitions.models import TransitionJob, TransitionsHistory
-from ralph.lib.transitions.tests import TransitionTestCase
+from ralph.lib.transitions.tests import TransitionTestCase, TransitionTestCaseMixin
 from ralph.licences.tests.factories import LicenceFactory
 
 
-class TransitionActionTest(TransitionTestCase):
+class TransitionActionTestMixin(object):
     def setUp(self):
         super().setUp()
         self.warehouse_1 = WarehouseFactory(name='api_test')
@@ -92,6 +92,8 @@ class TransitionActionTest(TransitionTestCase):
             object_id=object_id
         ).last()
 
+
+class TransitionActionTest(TransitionActionTestMixin, TransitionTestCase):
     def test_sync_api(self):
         response = self.api_client.post(
             reverse(
@@ -162,6 +164,36 @@ class TransitionActionTest(TransitionTestCase):
             ['This field is required.']
         )
 
+    def test_api_options(self):
+        request = self.api_client.options(
+            reverse(
+                'transition-view',
+                args=(self.transition_1.id, self.bo.pk)
+            )
+        )
+        self.assertEqual(request.status_code, 200)
+        self.assertEqual(
+            request.data['actions']['POST'][
+                'remarks'
+            ]['type'], 'string'
+        )
+        self.assertEqual(
+            request.data['actions']['POST'][
+                'loan_end_date'
+            ]['type'], 'date'
+        )
+        self.assertEqual(
+            request.data['actions']['POST'][
+                'country'
+            ]['type'], 'choice'
+        )
+
+
+class TestAsyncActions(
+    TransitionActionTestMixin,
+    TransitionTestCaseMixin,
+    TransactionTestCase
+):
     def test_async_api(self):
         response = self.api_client.post(
             reverse(
@@ -248,27 +280,3 @@ class TransitionActionTest(TransitionTestCase):
                 'Another async transition for this object is already started'
             ]
         })
-
-    def test_api_options(self):
-        request = self.api_client.options(
-            reverse(
-                'transitions-view',
-                args=(self.transition_1.id, self.bo.pk)
-            )
-        )
-        self.assertEqual(request.status_code, 200)
-        self.assertEqual(
-            request.data['actions']['POST'][
-                'remarks'
-            ]['type'], 'string'
-        )
-        self.assertEqual(
-            request.data['actions']['POST'][
-                'loan_end_date'
-            ]['type'], 'date'
-        )
-        self.assertEqual(
-            request.data['actions']['POST'][
-                'country'
-            ]['type'], 'choice'
-        )

--- a/src/ralph/lib/transitions/tests/test_async.py
+++ b/src/ralph/lib/transitions/tests/test_async.py
@@ -2,7 +2,7 @@
 Test asynchronous transitions
 """
 from django.contrib.auth import get_user_model
-from django.test import RequestFactory
+from django.test import RequestFactory, TransactionTestCase
 
 from ralph.lib.external_services.models import JobStatus
 from ralph.lib.transitions.models import (
@@ -10,11 +10,11 @@ from ralph.lib.transitions.models import (
     TransitionJob,
     TransitionsHistory
 )
-from ralph.lib.transitions.tests import TransitionTestCase
+from ralph.lib.transitions.tests import TransitionTestCaseMixin
 from ralph.tests.models import AsyncOrder, Foo, OrderStatus
 
 
-class AsyncTransitionsTest(TransitionTestCase):
+class AsyncTransitionsTest(TransitionTestCaseMixin, TransactionTestCase):
 
     def setUp(self):
         super().setUp()

--- a/src/ralph/lib/transitions/tests/test_async.py
+++ b/src/ralph/lib/transitions/tests/test_async.py
@@ -9,7 +9,6 @@ from ralph.lib.transitions.models import (
     run_transition,
     TransitionJob,
     TransitionsHistory,
-    update_models_attrs
 )
 from ralph.lib.transitions.tests import TransitionTestCaseMixin
 from ralph.tests.models import AsyncOrder, Foo, OrderStatus
@@ -19,7 +18,6 @@ class AsyncTransitionsTest(TransitionTestCaseMixin, TransactionTestCase):
 
     def setUp(self):
         super().setUp()
-        # update_models_attrs()
         self.request = RequestFactory()
         self.request.user = get_user_model().objects.create_user(
             username='test1',
@@ -99,81 +97,81 @@ class AsyncTransitionsTest(TransitionTestCaseMixin, TransactionTestCase):
                 ]
             )
 
-    # def test_freezing_action_during_async_transition(self):
-    #     async_order = AsyncOrder.objects.create(name='test')
-    #     async_order2 = AsyncOrder.objects.create(name='test3')
-    #     async_orders = [async_order, async_order2]
-    #     _, transition, _ = self._create_transition(
-    #         model=async_order, name='prepare',
-    #         source=[OrderStatus.new.id], target=OrderStatus.to_send.id,
-    #         actions=[
-    #             'freezing_action',
-    #             'long_running_action',
-    #             'assing_user',
-    #         ],
-    #         async_service_name='ASYNC_TRANSITIONS',
-    #     )
-    #     job_ids = run_transition(
-    #         instances=async_orders,
-    #         transition_obj_or_name=transition,
-    #         request=self.request,
-    #         field='status',
-    #         data={'name': 'def', 'foo': self.foo}
-    #     )
-    #     for job_id, async_order in zip(job_ids, async_orders):
-    #         job = TransitionJob.objects.get(pk=job_id)
-    #         async_order.refresh_from_db()
-    #         self.assertEqual(job.status, JobStatus.FREEZED)
+    def test_freezing_action_during_async_transition(self):
+        async_order = AsyncOrder.objects.create(name='test')
+        async_order2 = AsyncOrder.objects.create(name='test3')
+        async_orders = [async_order, async_order2]
+        _, transition, _ = self._create_transition(
+            model=async_order, name='prepare',
+            source=[OrderStatus.new.id], target=OrderStatus.to_send.id,
+            actions=[
+                'freezing_action',
+                'long_running_action',
+                'assing_user',
+            ],
+            async_service_name='ASYNC_TRANSITIONS',
+        )
+        job_ids = run_transition(
+            instances=async_orders,
+            transition_obj_or_name=transition,
+            request=self.request,
+            field='status',
+            data={'name': 'def', 'foo': self.foo}
+        )
+        for job_id, async_order in zip(job_ids, async_orders):
+            job = TransitionJob.objects.get(pk=job_id)
+            async_order.refresh_from_db()
+            self.assertEqual(job.status, JobStatus.FREEZED)
 
-    #     # unfreeze
-    #     for job_id in job_ids:
-    #         job = TransitionJob.objects.get(pk=job_id)
-    #         job.unfreeze()
+        # unfreeze
+        for job_id in job_ids:
+            job = TransitionJob.objects.get(pk=job_id)
+            job.unfreeze()
 
-    #     for job_id, async_order in zip(job_ids, async_orders):
-    #         job = TransitionJob.objects.get(pk=job_id)
-    #         async_order.refresh_from_db()
-    #         self.assertEqual(job.status, JobStatus.FINISHED)
-    #         self.assertEqual(async_order.counter, 2)
-    #         self.assertEqual(async_order.name, 'def')
-    #         # check if shared params and history kwargs are properly stored
-    #         # during freezing
-    #         self.assertEqual(
-    #             job.params['shared_params'][async_order.pk]['test'], 'freezing'
-    #         )
-    #         # check history entries
-    #         th = TransitionsHistory.objects.get(object_id=async_order.id)
-    #         self.assertCountEqual(
-    #             th.actions,
-    #             [
-    #                 "Assign user",
-    #                 "Long runnign action",
-    #                 "Freezing action"
-    #             ]
-    #         )
+        for job_id, async_order in zip(job_ids, async_orders):
+            job = TransitionJob.objects.get(pk=job_id)
+            async_order.refresh_from_db()
+            self.assertEqual(job.status, JobStatus.FINISHED)
+            self.assertEqual(async_order.counter, 2)
+            self.assertEqual(async_order.name, 'def')
+            # check if shared params and history kwargs are properly stored
+            # during freezing
+            self.assertEqual(
+                job.params['shared_params'][async_order.pk]['test'], 'freezing'
+            )
+            # check history entries
+            th = TransitionsHistory.objects.get(object_id=async_order.id)
+            self.assertCountEqual(
+                th.actions,
+                [
+                    "Assign user",
+                    "Long runnign action",
+                    "Freezing action"
+                ]
+            )
 
-    # def test_run_failing_async_transition(self):
-    #     async_order = AsyncOrder.objects.create(name='test')
-    #     async_order2 = AsyncOrder.objects.create(name='test')
-    #     _, transition, _ = self._create_transition(
-    #         model=async_order, name='prepare',
-    #         source=[OrderStatus.new.id], target=OrderStatus.to_send.id,
-    #         actions=['failing_action'],
-    #         async_service_name='ASYNC_TRANSITIONS',
-    #     )
-    #     job_ids = run_transition(
-    #         instances=[async_order, async_order2],
-    #         transition_obj_or_name=transition,
-    #         request=self.request,
-    #         field='status',
-    #         data={'name': 'def', 'foo': self.foo}
-    #     )
-    #     for job_id, order in zip(job_ids, [async_order, async_order2]):
-    #         job = TransitionJob.objects.get(pk=job_id)
-    #         self.assertEqual(job.status, JobStatus.FAILED.id)
-    #         self.assertEqual(
-    #             job.params['shared_params'][order.pk]['test'],
-    #             'failing'
-    #         )
-    #         with self.assertRaises(TransitionsHistory.DoesNotExist):
-    #             TransitionsHistory.objects.get(object_id=async_order.id)
+    def test_run_failing_async_transition(self):
+        async_order = AsyncOrder.objects.create(name='test')
+        async_order2 = AsyncOrder.objects.create(name='test')
+        _, transition, _ = self._create_transition(
+            model=async_order, name='prepare',
+            source=[OrderStatus.new.id], target=OrderStatus.to_send.id,
+            actions=['failing_action'],
+            async_service_name='ASYNC_TRANSITIONS',
+        )
+        job_ids = run_transition(
+            instances=[async_order, async_order2],
+            transition_obj_or_name=transition,
+            request=self.request,
+            field='status',
+            data={'name': 'def', 'foo': self.foo}
+        )
+        for job_id, order in zip(job_ids, [async_order, async_order2]):
+            job = TransitionJob.objects.get(pk=job_id)
+            self.assertEqual(job.status, JobStatus.FAILED.id)
+            self.assertEqual(
+                job.params['shared_params'][order.pk]['test'],
+                'failing'
+            )
+            with self.assertRaises(TransitionsHistory.DoesNotExist):
+                TransitionsHistory.objects.get(object_id=async_order.id)

--- a/src/ralph/lib/transitions/tests/test_async.py
+++ b/src/ralph/lib/transitions/tests/test_async.py
@@ -7,8 +7,8 @@ from django.test import RequestFactory, TransactionTestCase
 from ralph.lib.external_services.models import JobStatus
 from ralph.lib.transitions.models import (
     run_transition,
-    TransitionsHistory,
-    TransitionJob
+    TransitionJob,
+    TransitionsHistory
 )
 from ralph.lib.transitions.tests import TransitionTestCaseMixin
 from ralph.tests.models import AsyncOrder, Foo, OrderStatus

--- a/src/ralph/lib/transitions/tests/test_async.py
+++ b/src/ralph/lib/transitions/tests/test_async.py
@@ -7,8 +7,8 @@ from django.test import RequestFactory, TransactionTestCase
 from ralph.lib.external_services.models import JobStatus
 from ralph.lib.transitions.models import (
     run_transition,
-    TransitionJob,
     TransitionsHistory,
+    TransitionJob
 )
 from ralph.lib.transitions.tests import TransitionTestCaseMixin
 from ralph.tests.models import AsyncOrder, Foo, OrderStatus

--- a/src/ralph/lib/transitions/tests/test_async.py
+++ b/src/ralph/lib/transitions/tests/test_async.py
@@ -8,7 +8,8 @@ from ralph.lib.external_services.models import JobStatus
 from ralph.lib.transitions.models import (
     run_transition,
     TransitionJob,
-    TransitionsHistory
+    TransitionsHistory,
+    update_models_attrs
 )
 from ralph.lib.transitions.tests import TransitionTestCaseMixin
 from ralph.tests.models import AsyncOrder, Foo, OrderStatus
@@ -18,6 +19,7 @@ class AsyncTransitionsTest(TransitionTestCaseMixin, TransactionTestCase):
 
     def setUp(self):
         super().setUp()
+        # update_models_attrs()
         self.request = RequestFactory()
         self.request.user = get_user_model().objects.create_user(
             username='test1',
@@ -97,81 +99,81 @@ class AsyncTransitionsTest(TransitionTestCaseMixin, TransactionTestCase):
                 ]
             )
 
-    def test_freezing_action_during_async_transition(self):
-        async_order = AsyncOrder.objects.create(name='test')
-        async_order2 = AsyncOrder.objects.create(name='test3')
-        async_orders = [async_order, async_order2]
-        _, transition, _ = self._create_transition(
-            model=async_order, name='prepare',
-            source=[OrderStatus.new.id], target=OrderStatus.to_send.id,
-            actions=[
-                'freezing_action',
-                'long_running_action',
-                'assing_user',
-            ],
-            async_service_name='ASYNC_TRANSITIONS',
-        )
-        job_ids = run_transition(
-            instances=async_orders,
-            transition_obj_or_name=transition,
-            request=self.request,
-            field='status',
-            data={'name': 'def', 'foo': self.foo}
-        )
-        for job_id, async_order in zip(job_ids, async_orders):
-            job = TransitionJob.objects.get(pk=job_id)
-            async_order.refresh_from_db()
-            self.assertEqual(job.status, JobStatus.FREEZED)
+    # def test_freezing_action_during_async_transition(self):
+    #     async_order = AsyncOrder.objects.create(name='test')
+    #     async_order2 = AsyncOrder.objects.create(name='test3')
+    #     async_orders = [async_order, async_order2]
+    #     _, transition, _ = self._create_transition(
+    #         model=async_order, name='prepare',
+    #         source=[OrderStatus.new.id], target=OrderStatus.to_send.id,
+    #         actions=[
+    #             'freezing_action',
+    #             'long_running_action',
+    #             'assing_user',
+    #         ],
+    #         async_service_name='ASYNC_TRANSITIONS',
+    #     )
+    #     job_ids = run_transition(
+    #         instances=async_orders,
+    #         transition_obj_or_name=transition,
+    #         request=self.request,
+    #         field='status',
+    #         data={'name': 'def', 'foo': self.foo}
+    #     )
+    #     for job_id, async_order in zip(job_ids, async_orders):
+    #         job = TransitionJob.objects.get(pk=job_id)
+    #         async_order.refresh_from_db()
+    #         self.assertEqual(job.status, JobStatus.FREEZED)
 
-        # unfreeze
-        for job_id in job_ids:
-            job = TransitionJob.objects.get(pk=job_id)
-            job.unfreeze()
+    #     # unfreeze
+    #     for job_id in job_ids:
+    #         job = TransitionJob.objects.get(pk=job_id)
+    #         job.unfreeze()
 
-        for job_id, async_order in zip(job_ids, async_orders):
-            job = TransitionJob.objects.get(pk=job_id)
-            async_order.refresh_from_db()
-            self.assertEqual(job.status, JobStatus.FINISHED)
-            self.assertEqual(async_order.counter, 2)
-            self.assertEqual(async_order.name, 'def')
-            # check if shared params and history kwargs are properly stored
-            # during freezing
-            self.assertEqual(
-                job.params['shared_params'][async_order.pk]['test'], 'freezing'
-            )
-            # check history entries
-            th = TransitionsHistory.objects.get(object_id=async_order.id)
-            self.assertCountEqual(
-                th.actions,
-                [
-                    "Assign user",
-                    "Long runnign action",
-                    "Freezing action"
-                ]
-            )
+    #     for job_id, async_order in zip(job_ids, async_orders):
+    #         job = TransitionJob.objects.get(pk=job_id)
+    #         async_order.refresh_from_db()
+    #         self.assertEqual(job.status, JobStatus.FINISHED)
+    #         self.assertEqual(async_order.counter, 2)
+    #         self.assertEqual(async_order.name, 'def')
+    #         # check if shared params and history kwargs are properly stored
+    #         # during freezing
+    #         self.assertEqual(
+    #             job.params['shared_params'][async_order.pk]['test'], 'freezing'
+    #         )
+    #         # check history entries
+    #         th = TransitionsHistory.objects.get(object_id=async_order.id)
+    #         self.assertCountEqual(
+    #             th.actions,
+    #             [
+    #                 "Assign user",
+    #                 "Long runnign action",
+    #                 "Freezing action"
+    #             ]
+    #         )
 
-    def test_run_failing_async_transition(self):
-        async_order = AsyncOrder.objects.create(name='test')
-        async_order2 = AsyncOrder.objects.create(name='test')
-        _, transition, _ = self._create_transition(
-            model=async_order, name='prepare',
-            source=[OrderStatus.new.id], target=OrderStatus.to_send.id,
-            actions=['failing_action'],
-            async_service_name='ASYNC_TRANSITIONS',
-        )
-        job_ids = run_transition(
-            instances=[async_order, async_order2],
-            transition_obj_or_name=transition,
-            request=self.request,
-            field='status',
-            data={'name': 'def', 'foo': self.foo}
-        )
-        for job_id, order in zip(job_ids, [async_order, async_order2]):
-            job = TransitionJob.objects.get(pk=job_id)
-            self.assertEqual(job.status, JobStatus.FAILED.id)
-            self.assertEqual(
-                job.params['shared_params'][order.pk]['test'],
-                'failing'
-            )
-            with self.assertRaises(TransitionsHistory.DoesNotExist):
-                TransitionsHistory.objects.get(object_id=async_order.id)
+    # def test_run_failing_async_transition(self):
+    #     async_order = AsyncOrder.objects.create(name='test')
+    #     async_order2 = AsyncOrder.objects.create(name='test')
+    #     _, transition, _ = self._create_transition(
+    #         model=async_order, name='prepare',
+    #         source=[OrderStatus.new.id], target=OrderStatus.to_send.id,
+    #         actions=['failing_action'],
+    #         async_service_name='ASYNC_TRANSITIONS',
+    #     )
+    #     job_ids = run_transition(
+    #         instances=[async_order, async_order2],
+    #         transition_obj_or_name=transition,
+    #         request=self.request,
+    #         field='status',
+    #         data={'name': 'def', 'foo': self.foo}
+    #     )
+    #     for job_id, order in zip(job_ids, [async_order, async_order2]):
+    #         job = TransitionJob.objects.get(pk=job_id)
+    #         self.assertEqual(job.status, JobStatus.FAILED.id)
+    #         self.assertEqual(
+    #             job.params['shared_params'][order.pk]['test'],
+    #             'failing'
+    #         )
+    #         with self.assertRaises(TransitionsHistory.DoesNotExist):
+    #             TransitionsHistory.objects.get(object_id=async_order.id)

--- a/src/ralph/lib/transitions/tests/test_models.py
+++ b/src/ralph/lib/transitions/tests/test_models.py
@@ -12,7 +12,8 @@ from ralph.lib.transitions.models import (
     _check_and_get_transition,
     _create_graph_from_actions,
     run_field_transition,
-    Transition
+    Transition,
+    TransitionModel
 )
 from ralph.lib.transitions.tests import TransitionTestCase
 from ralph.tests.models import Foo, Order, OrderStatus
@@ -125,7 +126,7 @@ class TransitionsTest(TransitionTestCase):
         order = Order.objects.create(status=OrderStatus.to_send.id)
         Transition.objects.create(
             name=transition_name,
-            model=order.transition_models['status'],
+            model=TransitionModel.get_for_field(order, 'status'),
             source=[OrderStatus.to_send.id],
             target=OrderStatus.sended.id,
         )
@@ -147,7 +148,7 @@ class TransitionsTest(TransitionTestCase):
         order = Order.objects.create()
         transition = Transition.objects.create(
             name='send',
-            model=order.transition_models['status'],
+            model=TransitionModel.get_for_field(order, 'status'),
             source=[OrderStatus.new.id],
             target=OrderStatus.sended.id,
         )
@@ -178,7 +179,7 @@ class TransitionsTest(TransitionTestCase):
         order = Order.objects.create()
         transition = Transition.objects.create(
             name='send',
-            model=order.transition_models['status'],
+            model=TransitionModel.get_for_field(order, 'status'),
             source=[OrderStatus.to_send.id],
             target=OrderStatus.sended.id,
         )


### PR DESCRIPTION
When async transition (job) is scheduled to worker, transaction has to be already commited to allow worker to fetch job from database. This cannot be done in atomic block (especially when whole request is atomic), so from now transition view is non-atomic (gui + api) for async transitions and is commited manually after creating job object in database.
