### PR TITLE
Ralph3 sync: fix vm ack and delete vm

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ python:
   - "2.7"
 # command to install dependencies, e.g. pip install -r requirements.txt --use-mirrors
 install:
+  - pip install -U pip==7.1.0
   - pip install git+https://github.com/allegro/django-bob@develop
   - pip install git+https://github.com/quamilek/bob-ajax-selects.git@develop
   - pip install git+https://github.com/allegro/ralph_assets.git@develop

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,6 @@ python:
   - "2.7"
 # command to install dependencies, e.g. pip install -r requirements.txt --use-mirrors
 install:
-  - pip install -U pip==7.1.0
   - pip install git+https://github.com/allegro/django-bob@develop
   - pip install git+https://github.com/quamilek/bob-ajax-selects.git@develop
   - pip install git+https://github.com/allegro/ralph_assets.git@develop

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ collectstatic:
 	ralph collectstatic --noinput
 
 install:
-	pip install -e . --use-mirrors --allow-all-external --allow-unverified ipaddr --allow-unverified postmarkup --allow-unverified pysphere --find-links=https://pypi.python.org/pypi/pysphere/0.1.8
+	pip install -e . --allow-all-external --allow-unverified ipaddr --allow-unverified postmarkup --allow-unverified pysphere --find-links=https://pypi.python.org/pypi/pysphere/0.1.8
 
 test-unittests:
 	DJANGO_SETTINGS_PROFILE=test-ralph coverage run --source=ralph --omit='*migrations*,*tests*,*__init__*,*wsgi.py,*__main__*,*settings*,*manage.py,src/ralph/util/demo/*' '$(VIRTUAL_ENV)/bin/ralph' test ralph

--- a/src/ralph/export_to_ng/publishers.py
+++ b/src/ralph/export_to_ng/publishers.py
@@ -73,12 +73,12 @@ def ralph3_sync(model, topic=None):
 
 
 @publisher(topic='ralph2_sync_ack', auto_publish_result=True)
-def publish_sync_ack_to_ralph3(obj, ralph3_id):
+def publish_sync_ack_to_ralph3(obj, ralph3_id, model=None):
     """
     Publish ACK to Ralph3 that some object was updated.
     """
     return {
-        'model': obj._meta.object_name,
+        'model': model or obj._meta.object_name,
         'id': obj.id,
         'ralph3_id': ralph3_id,
     }

--- a/src/ralph/export_to_ng/subscribers.py
+++ b/src/ralph/export_to_ng/subscribers.py
@@ -327,7 +327,7 @@ def sync_virtual_server_to_ralph2(data):
     _handle_custom_fields(data, vs)
     _handle_ips(data, vs)
     if created:
-        publish_sync_ack_to_ralph3(vs, data['id'])
+        publish_sync_ack_to_ralph3(vs, data['id'], 'VirtualServer')
 
 
 @sync_subscriber(
@@ -458,3 +458,14 @@ def sync_network_to_ralph2(data):
     if created:
         publish_sync_ack_to_ralph3(net, data['id'])
     return net
+
+
+@sync_subscriber(
+    topic='delete_virtual_server_in_ralph2',
+    disable_publishers=[sync_virtual_server_to_ralph3]
+)
+def delete_virtual_server_in_ralph2(data):
+    if data.get('ralph2_id'):
+        dev = Device.objects.get(id=data['ralph2_id'])
+        dev.deleted = True
+        dev.save(priority=SAVE_PRIORITY)

--- a/src/ralph/export_to_ng/tests/test_subscribers.py
+++ b/src/ralph/export_to_ng/tests/test_subscribers.py
@@ -30,6 +30,7 @@ from ralph.discovery.tests.util import (
 )
 from ralph.dnsedit.models import DHCPEntry
 from ralph.export_to_ng.subscribers import (
+    delete_virtual_server_in_ralph2,
     sync_dc_asset_to_ralph2_handler,
     sync_network_to_ralph2,
     sync_stacked_switch_to_ralph2,
@@ -513,6 +514,16 @@ class VirtualServerTestCase(TestCase):
         self.assertTrue(
             vs.ethernet_set.filter(mac='AABBCCDDEEFF').exists()
         )
+
+    def test_delete_virtual_servr(self):
+        vs = self.create_test_virtual_server()
+        data = {
+            'id': 1234,
+            'ralph2_id': vs.id,
+        }
+        delete_virtual_server_in_ralph2(data)
+        vs = vs.__class__.admin_objects.get(id=vs.id)
+        self.assertTrue(vs.deleted)
 
 
 class StackedSwitchSyncTestCase(TestCase):


### PR DESCRIPTION
- Fix sending ACK to Ralph3 for VirtualServer (send model=VirtualServer instead of Device)
- new handler for deleting virtual server
