### PR TITLE
Filter in API by id__startswith

### DIFF
--- a/src/ralph/api/filters.py
+++ b/src/ralph/api/filters.py
@@ -144,6 +144,7 @@ class LookupFilterBackend(BaseFilterBackend):
     # allowed lookups depending on field type (using Django's __ convention)
     # for other types of fields, only strict lookup is allowed
     field_type_lookups = {
+        # TODO: in and range filters are not working (some iterable is required)
         models.IntegerField: {
             'lte', 'gte', 'lt', 'gt', 'exact', 'in', 'range', 'isnull'
         },
@@ -161,6 +162,9 @@ class LookupFilterBackend(BaseFilterBackend):
         },
         models.DecimalField: {
             'lte', 'gte', 'lt', 'gt', 'exact', 'in', 'range', 'isnull'
+        },
+        models.AutoField: {
+            'startswith', 'exact'
         }
     }
 

--- a/src/ralph/api/tests/api.py
+++ b/src/ralph/api/tests/api.py
@@ -81,6 +81,7 @@ class CarViewSet(RalphAPIViewSet):
 class BarViewSet(RalphAPIViewSet):
     queryset = Bar.objects.all()
     serializer_class = BarSerializer
+    filter_fields = ['id']
 
 
 router = RalphRouter()

--- a/src/ralph/api/tests/test_filters.py
+++ b/src/ralph/api/tests/test_filters.py
@@ -67,6 +67,7 @@ class TestLookupFilterBackend(RalphTestCase):
         self.client.login(username='test', password='test')
 
         Bar.objects.create(
+            id=999999,
             name='Bar11',
             date=date(2015, 3, 1),
             price=Decimal('21.4'),
@@ -183,6 +184,20 @@ class TestLookupFilterBackend(RalphTestCase):
         self.assertEqual(len(self.lookup_filter.filter_queryset(
             request, Bar.objects.all(), bvs)
         ), 4)
+
+    def test_query_filters_autofield(self):
+        request = self.request_factory.get('/api/bar')
+        bvs = BarViewSet()
+        request.query_params = QueryDict(urlencode({'id__startswith': '99999'}))
+        bvs.request = request
+        self.assertEqual(len(self.lookup_filter.filter_queryset(
+            request, Bar.objects.all(), bvs)
+        ), 1)
+
+        request.query_params = QueryDict(urlencode({'id__exact': '999999'}))
+        self.assertEqual(len(self.lookup_filter.filter_queryset(
+            request, Bar.objects.all(), bvs)
+        ), 1)
 
     def test_query_filters_isnull(self):
         request = self.request_factory.get('/api/bar')

--- a/src/ralph/assets/tests/test_api.py
+++ b/src/ralph/assets/tests/test_api.py
@@ -535,6 +535,7 @@ class BaseObjectAPITests(RalphAPITestCase):
             parent=self.conf_module_1, name='mod1'
         )
         self.conf_class_1 = ConfigurationClassFactory(
+            id=999999,
             module=self.conf_module_2, class_name='cls1'
         )
         self.dc_asset = DataCenterAssetFactory(
@@ -684,6 +685,30 @@ class BaseObjectAPITests(RalphAPITestCase):
         response = self.client.get(url, format='json')
         self.assertEqual(len(response.data['results']), 1)
         self.assertEqual(response.data['results'][0]['id'], self.dc_asset.id)
+
+    def test_filter_by_id_startswith(self):
+        url = '{}?{}'.format(
+            reverse('baseobject-list'), urlencode(
+                {'id__startswith': '99999'}
+            )
+        )
+        response = self.client.get(url, format='json')
+        self.assertEqual(len(response.data['results']), 1)
+        self.assertEqual(
+            response.data['results'][0]['id'], self.conf_class_1.id
+        )
+
+    def test_filter_by_id_exact(self):
+        url = '{}?{}'.format(
+            reverse('baseobject-list'), urlencode(
+                {'id__exact': '999999'}
+            )
+        )
+        response = self.client.get(url, format='json')
+        self.assertEqual(len(response.data['results']), 1)
+        self.assertEqual(
+            response.data['results'][0]['id'], self.conf_class_1.id
+        )
 
     def test_tags(self):
         url = '{}?{}'.format(


### PR DESCRIPTION
New lookup filter for AutoField which allows to filter by startswith and exact lookups.
