### PR TITLE
Fix available networks when rack is not assigned

### DIFF
--- a/src/ralph/data_center/models/physical.py
+++ b/src/ralph/data_center/models/physical.py
@@ -330,13 +330,18 @@ class NetworkableBaseObject(models.Model):
         return ''
 
     def _get_available_network_environments(self):
-        return list(NetworkEnvironment.objects.filter(
-            network__racks=self.rack_id
-        ).distinct())
+        if self.rack_id:
+            return list(NetworkEnvironment.objects.filter(
+                network__racks=self.rack_id
+            ).distinct())
+        return NetworkEnvironment.objects.none()
 
     def _get_available_networks(self, as_query=False):
-        qry = Network.objects.filter(racks=self.rack_id).distinct()
-        return qry if as_query else list(qry)
+        if self.rack_id:
+            query = Network.objects.filter(racks=self.rack_id).distinct()
+        else:
+            query = Network.objects.none()
+        return query if as_query else list(query)
 
     class Meta:
         abstract = True

--- a/src/ralph/data_center/tests/test_models.py
+++ b/src/ralph/data_center/tests/test_models.py
@@ -280,6 +280,27 @@ class DataCenterAssetTest(RalphTestCase):
         self.assertEqual(self.dc_asset.issue_next_free_hostname(), '')
 
     # =========================================================================
+    # available networks
+    # =========================================================================
+    def test_get_available_networks(self):
+        self._prepare_rack(self.dc_asset, '192.168.1.0/24')
+        self.net1 = self.net
+        self._prepare_rack(
+            self.dc_asset, '192.168.2.0/24', rack=self.dc_asset.rack
+        )
+        self.net3 = NetworkFactory(address='192.168.3.0/24')
+
+        self.assertCountEqual(
+            self.dc_asset._get_available_networks(),
+            [self.net1, self.net]
+        )
+
+    def test_get_available_networks_no_rack(self):
+        NetworkFactory(address='192.168.1.0/24')
+        NetworkFactory(address='192.168.2.0/24')
+        self.assertEqual(self.dc_asset._get_available_networks(), [])
+
+    # =========================================================================
     # other
     # =========================================================================
     def test_change_rack_in_descendants(self):

--- a/src/ralph/data_center/tests/test_models.py
+++ b/src/ralph/data_center/tests/test_models.py
@@ -283,16 +283,12 @@ class DataCenterAssetTest(RalphTestCase):
     # available networks
     # =========================================================================
     def test_get_available_networks(self):
-        self._prepare_rack(self.dc_asset, '192.168.1.0/24')
-        self.net1 = self.net
-        self._prepare_rack(
-            self.dc_asset, '192.168.2.0/24', rack=self.dc_asset.rack
-        )
+        self._prepare_rack(self.dc_asset, '192.168.1.1', '192.168.1.0/24')
         self.net3 = NetworkFactory(address='192.168.3.0/24')
 
         self.assertCountEqual(
             self.dc_asset._get_available_networks(),
-            [self.net1, self.net]
+            [self.net, self.net2]
         )
 
     def test_get_available_networks_no_rack(self):

--- a/src/ralph/networks/views.py
+++ b/src/ralph/networks/views.py
@@ -37,25 +37,32 @@ class NetworkView(RalphDetailViewAdmin):
     name = 'network'
     label = 'Network'
     url_name = 'network'
-    admin_attribute_list_to_copy = ['network_data']
-    readonly_fields = ('network_data',)
+    admin_attribute_list_to_copy = ['available_networks']
+    readonly_fields = ('available_networks',)
     inlines = [
         NetworkInline,
     ]
-    fields = ('network_data', )
+    fields = ('available_networks', )
 
-    def network_data(self, instance):
-        return TableWithUrl(
-            instance._get_available_networks(as_query=True),
-            ['name', 'address', 'network_environment'],
-            url_field='name',
-        ).render()
-    network_data.short_description = "Network data"
-    network_data.allow_tags = True
+    def available_networks(self, instance):
+        networks = instance._get_available_networks(
+            as_query=True
+        ).select_related('network_environment')
+        if networks:
+            result = TableWithUrl(
+                networks,
+                ['name', 'address', 'network_environment'],
+                url_field='name',
+            ).render()
+        else:
+            result = '&ndash;'
+        return result
+    available_networks.short_description = _('Available networks')
+    available_networks.allow_tags = True
     fieldsets = (
-        (_('Basic info'), {
+        (_(''), {
             'fields': (
-                'network_data',
+                'available_networks',
             )
         }),
     )


### PR DESCRIPTION
Fix for list of available networks when rack is not assigned (either directly to physical host, or indirectly, through vm's hypervisor).
