### PR TITLE
Prefetch related models for transition when checking for available actions for status

### DIFF
--- a/src/ralph/lib/transitions/models.py
+++ b/src/ralph/lib/transitions/models.py
@@ -414,7 +414,7 @@ def get_available_transitions_for_field(instance, field, user=None):
         return []
     transitions = Transition.objects.filter(
         model=instance.transition_models[field],
-    )
+    ).select_related('model', 'model__content_type').prefetch_related('actions')
     result = []
     for transition in transitions:
         # check if source field value is in values available for this transition


### PR DESCRIPTION
Reduce sql queries on detail view from N*3+1 (where N is number of transitions for object, ex. 16 for 5 transitions) to only 2.
