### PR TITLE
Fix preboot variables tooltip formatting

### DIFF
--- a/src/ralph/deployment/models.py
+++ b/src/ralph/deployment/models.py
@@ -59,7 +59,7 @@ class PrebootItem(NamedMixin, Polymorphic, metaclass=PolymorphicBase):
 
 CONFIGURATION_HELP_TEXT = """
 All newline characters will be converted to Unix \\n newlines.
-<br>You can use {{variables}} in the body.
+<br>You can use {{{{variables}}}} in the body.
 <br>Available variables:
 
 <br>  - configuration_class_name (eg. 'www')


### PR DESCRIPTION
Use {{{{ instead of {{ in configuration field help text ({{ was parsed by str.format).
