### PR TITLE
Fix dc-hosts queries count

### DIFF
--- a/src/ralph/assets/tests/test_api.py
+++ b/src/ralph/assets/tests/test_api.py
@@ -803,6 +803,7 @@ class DCHostAPITests(RalphAPITestCase):
         )
         self.virtual.update_custom_field('test_cf', 'def')
         se = ServiceEnvironmentFactory(service__uid='sc-333')
+        # this will create additional DataCenterAsset (hypervisor)
         self.cloud_host = CloudHostFullFactory(
             configuration_path__module__name='ralph3',
             service_env=se,
@@ -817,7 +818,7 @@ class DCHostAPITests(RalphAPITestCase):
         with self.assertNumQueries(11):
             response = self.client.get(url, format='json')
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(response.data['count'], 3)
+        self.assertEqual(response.data['count'], 4)
 
     def test_filter_by_type_dc_asset(self):
         url = '{}?{}'.format(
@@ -826,7 +827,7 @@ class DCHostAPITests(RalphAPITestCase):
         )
         response = self.client.get(url, format='json')
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(response.data['count'], 1)
+        self.assertEqual(response.data['count'], 2)
         dca = response.data['results'][0]
         self.assertEqual(dca['hostname'], self.dc_asset.hostname)
         self.assertEqual(len(dca['ethernet']), 3)

--- a/src/ralph/assets/tests/test_api.py
+++ b/src/ralph/assets/tests/test_api.py
@@ -803,12 +803,12 @@ class DCHostAPITests(RalphAPITestCase):
         )
         self.virtual.update_custom_field('test_cf', 'def')
         se = ServiceEnvironmentFactory(service__uid='sc-333')
-        # this will create additional DataCenterAsset (hypervisor)
         self.cloud_host = CloudHostFullFactory(
             configuration_path__module__name='ralph3',
             service_env=se,
             parent__service_env=se,
-            hostname='aaaa'
+            hostname='aaaa',
+            hypervisor=self.dc_asset
         )
         self.cloud_host.ip_addresses = ['10.20.30.40']
         self.cloud_host.update_custom_field('test_cf', 'xyz')
@@ -818,7 +818,7 @@ class DCHostAPITests(RalphAPITestCase):
         with self.assertNumQueries(11):
             response = self.client.get(url, format='json')
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(response.data['count'], 4)
+        self.assertEqual(response.data['count'], 3)
 
     def test_filter_by_type_dc_asset(self):
         url = '{}?{}'.format(
@@ -827,7 +827,7 @@ class DCHostAPITests(RalphAPITestCase):
         )
         response = self.client.get(url, format='json')
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(response.data['count'], 2)
+        self.assertEqual(response.data['count'], 1)
         dca = response.data['results'][0]
         self.assertEqual(dca['hostname'], self.dc_asset.hostname)
         self.assertEqual(len(dca['ethernet']), 3)

--- a/src/ralph/data_center/admin.py
+++ b/src/ralph/data_center/admin.py
@@ -6,7 +6,7 @@ from django.conf import settings
 from django.contrib.admin import SimpleListFilter
 from django.contrib.admin.views.main import ChangeList
 from django.contrib.contenttypes.models import ContentType
-from django.db.models import Q, Prefetch
+from django.db.models import Prefetch, Q
 from django.utils.translation import ugettext_lazy as _
 
 from ralph.admin import RalphAdmin, RalphTabularInline, register

--- a/src/ralph/data_center/models/virtual.py
+++ b/src/ralph/data_center/models/virtual.py
@@ -84,7 +84,7 @@ class Cluster(
         return '{} ({})'.format(self.name or self.hostname, self.type)
 
     def get_location(self):
-        return self.masters[0].get_location() if self.masters else None
+        return self.masters[0].get_location() if self.masters else []
 
     @property
     def model(self):

--- a/src/ralph/data_center/tests/factories.py
+++ b/src/ralph/data_center/tests/factories.py
@@ -64,7 +64,9 @@ class ClusterTypeFactory(DjangoModelFactory):
 
 class ClusterFactory(DjangoModelFactory):
 
-    name = factory.Iterator(['Databases', 'Applications'])
+    name = factory.Iterator(
+        ['Databases', 'Applications', 'Switch', 'Load balancer']
+    )
     type = factory.SubFactory(ClusterTypeFactory)
     configuration_path = factory.SubFactory(ConfigurationClassFactory)
     service_env = factory.SubFactory(ServiceEnvironmentFactory)

--- a/src/ralph/data_center/tests/test_view.py
+++ b/src/ralph/data_center/tests/test_view.py
@@ -1,11 +1,18 @@
 from django.core.urlresolvers import reverse
-from django.test import RequestFactory, TestCase
+from django.test import TestCase
 
-from ralph.data_center.tests.factories import DataCenterAssetFullFactory
-from ralph.tests.mixins import ClientMixin, ReloadUrlsMixin
+from ralph.data_center.tests.factories import (
+    ClusterFactory,
+    DataCenterAssetFullFactory
+)
+from ralph.tests.mixins import ClientMixin
+from ralph.virtual.tests.factories import (
+    CloudHostFullFactory,
+    VirtualServerFullFactory
+)
 
 
-class DataCentrAssetViewTest(ClientMixin, TestCase):
+class DataCenterAssetViewTest(ClientMixin, TestCase):
     def test_changelist_view(self):
         self.login_as_user()
         DataCenterAssetFullFactory.create_batch(10)
@@ -13,3 +20,77 @@ class DataCentrAssetViewTest(ClientMixin, TestCase):
             self.client.get(
                 reverse('admin:data_center_datacenterasset_changelist'),
             )
+
+
+class DCHostViewTest(ClientMixin, TestCase):
+    def setUp(self):
+        self.login_as_user()
+
+    def test_changelist_view(self):
+        DataCenterAssetFullFactory.create_batch(5)
+        VirtualServerFullFactory.create_batch(5)
+        CloudHostFullFactory.create_batch(4)
+        ClusterFactory.create_batch(4)
+        with self.assertNumQueries(19):
+            result = self.client.get(
+                reverse('admin:data_center_dchost_changelist'),
+            )
+        # DCAssets - 5
+        # VirtualServer + hypervisors - 10
+        # Cluster - 4
+        # CloudHost + hypervisors - 8
+        self.assertEqual(result.context_data['cl'].result_count, 27)
+
+    def test_changelist_datacenterasset_location(self):
+        DataCenterAssetFullFactory(
+            rack__name='Rack #1',
+            rack__server_room__name='SR1',
+            rack__server_room__data_center__name='DC1',
+        )
+        result = self.client.get(
+            reverse('admin:data_center_dchost_changelist'),
+        )
+        self.assertContains(result, 'DC1 / SR1 / Rack #1')
+
+    def test_changelist_virtualserver_location(self):
+        VirtualServerFullFactory(
+            parent=DataCenterAssetFullFactory(
+                rack__name='Rack #1',
+                rack__server_room__name='SR1',
+                rack__server_room__data_center__name='DC1',
+                hostname='s12345.mydc.net',
+            )
+        )
+        result = self.client.get(
+            reverse('admin:data_center_dchost_changelist'),
+        )
+        self.assertContains(result, 'DC1 / SR1 / Rack #1 / s12345.mydc.net')
+
+    def test_changelist_cloudhost_location(self):
+        CloudHostFullFactory(
+            hypervisor=DataCenterAssetFullFactory(
+                rack__name='Rack #1',
+                rack__server_room__name='SR1',
+                rack__server_room__data_center__name='DC1',
+                hostname='s12345.mydc.net',
+            )
+        )
+        result = self.client.get(
+            reverse('admin:data_center_dchost_changelist'),
+        )
+        self.assertContains(result, 'DC1 / SR1 / Rack #1 / s12345.mydc.net')
+
+    def test_changelist_cluster_location(self):
+        cluster = ClusterFactory()
+        cluster.baseobjectcluster_set.create(
+            is_master=True,
+            base_object=DataCenterAssetFullFactory(
+                rack__name='Rack #1',
+                rack__server_room__name='SR1',
+                rack__server_room__data_center__name='DC1',
+            )
+        )
+        result = self.client.get(
+            reverse('admin:data_center_dchost_changelist'),
+        )
+        self.assertContains(result, 'DC1 / SR1 / Rack #1')

--- a/src/ralph/virtual/tests/factories.py
+++ b/src/ralph/virtual/tests/factories.py
@@ -68,7 +68,7 @@ class CloudHostFactory(DjangoModelFactory):
         CloudProviderFactory,
         name='openstack',
     )
-    host_id = factory.Iterator(['host_id1', 'host_id2', 'host_id3'])
+    host_id = factory.Iterator(['host_id1', 'host_id2', 'host_id3', 'host_id4'])
     parent = factory.SubFactory(CloudProjectFactory)
     configuration_path = factory.SubFactory(ConfigurationClassFactory)
     service_env = factory.SubFactory(ServiceEnvironmentFactory)
@@ -79,6 +79,8 @@ class CloudHostFactory(DjangoModelFactory):
 
 
 class CloudHostFullFactory(CloudHostFactory):
+    hypervisor = factory.SubFactory(DataCenterAssetFactory)
+
     @factory.post_generation
     def post_tags(self, create, extracted, **kwargs):
         self.tags.add('abc, cde', 'xyz')


### PR DESCRIPTION
Location field was injected without proper select_related.

From now:
- location is shown for VirtualServer and CloudHost as well
- location is no longer "clickable" (it pointed to dcasset view with some filter) - it might be some TODO after this PR to create rack/server_room/dc filter for DCHost
- there is no redundant (n+1) sql on this view
