### PR TITLE
Fix starting multiple async transitions through API

### DIFF
--- a/src/ralph/lib/transitions/api/views.py
+++ b/src/ralph/lib/transitions/api/views.py
@@ -1,9 +1,12 @@
 # -*- coding: utf-8 -*-
+import itertools
+
 from django import forms
 from django.core.urlresolvers import reverse
 from rest_framework import serializers, status
 from rest_framework.exceptions import ValidationError as DRFValidationError
 from rest_framework.response import Response
+from rest_framework.settings import api_settings
 from rest_framework.views import APIView
 
 from ralph.api import RalphReadOnlyAPIViewSet
@@ -16,7 +19,9 @@ from ralph.lib.transitions.api.serializers import (
     TransitionModelSerializer,
     TransitionSerializer
 )
+from ralph.lib.transitions.exceptions import TransitionNotAllowedError
 from ralph.lib.transitions.models import (
+    _check_instances_for_transition,
     _transition_data_validation,
     Action,
     run_transition,
@@ -158,9 +163,20 @@ class TransitionView(APIView):
                     ]
             raise DRFValidationError(api_errors)
 
+    def _check_instances(self):
+        try:
+            _check_instances_for_transition(self.objects, self.transition)
+        except TransitionNotAllowedError as e:
+            raise DRFValidationError({
+                api_settings.NON_FIELD_ERRORS_KEY: list(itertools.chain(
+                    *e.errors.values()
+                ))
+            })
+
     def post(self, request, *args, **kwargs):
         serializer = self.get_serializer_class()(data=request.data)
         serializer.is_valid(raise_exception=True)
+        self._check_instances()
         self._run_additional_validation(serializer.validated_data)
         result = {}
         data = self.add_function_name_to_data(serializer.validated_data)

--- a/src/ralph/lib/transitions/models.py
+++ b/src/ralph/lib/transitions/models.py
@@ -189,7 +189,7 @@ def _check_instances_for_transition(
                     )
                 )
                 errors[instance].append(
-                    'Another async transition for this object is already stared'
+                    'Another async transition for this object is already started'  # noqa
                 )
 
     if errors:

--- a/src/ralph/lib/transitions/tests/test_actions.py
+++ b/src/ralph/lib/transitions/tests/test_actions.py
@@ -227,6 +227,28 @@ class TransitionActionTest(TransitionTestCase):
             str(list(request.context['messages'])[1])
         )
 
+    def test_async_api_running_new_when_another_in_progress_should_return_error(self):  # noqa
+        # mock another async job running
+        TransitionJob.objects.create(
+            obj=self.bo,
+            transition=self.transition_2,
+            status=JobStatus.STARTED,
+            service_name='ASYNC',
+        )
+        response = self.api_client.post(
+            reverse(
+                'transition-view',
+                args=(self.transition_2.id, self.bo.pk)
+            ),
+            self.prepare_api_data()
+        )
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.data, {
+            'non_field_errors': [
+                'Another async transition for this object is already stared'
+            ]
+        })
+
     def test_api_options(self):
         request = self.api_client.options(
             reverse(

--- a/src/ralph/lib/transitions/tests/test_actions.py
+++ b/src/ralph/lib/transitions/tests/test_actions.py
@@ -223,7 +223,7 @@ class TransitionActionTest(TransitionTestCase):
             )
         )
         self.assertIn(
-            'Another async transition for this object is already stared',
+            'Another async transition for this object is already started',
             str(list(request.context['messages'])[1])
         )
 
@@ -245,7 +245,7 @@ class TransitionActionTest(TransitionTestCase):
         self.assertEqual(response.status_code, 400)
         self.assertEqual(response.data, {
             'non_field_errors': [
-                'Another async transition for this object is already stared'
+                'Another async transition for this object is already started'
             ]
         })
 


### PR DESCRIPTION
Only one active transition could be started at a time. Continuation of #2644.
