### PR TITLE
Bumped django-mptt version to 0.8.6

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -5,7 +5,7 @@ dj.choices==0.10.0
 django-extensions==1.5.9
 django-filter==0.13.0
 django-import-export==0.4.2
-django-mptt==0.7.4
+django-mptt==0.8.6
 django-reversion==1.8.6
 django-rq==0.9.0
 django-taggit==0.17.1


### PR DESCRIPTION
Newest version of mptt provides fix for read only listing of mptt models.
