### PR TITLE
Improved cloudhost-list api SQL queries count

### DIFF
--- a/src/ralph/virtual/api.py
+++ b/src/ralph/virtual/api.py
@@ -171,7 +171,8 @@ class CloudHostViewSet(BaseObjectViewSetMixin, RalphAPIViewSet):
     save_serializer_class = SaveCloudHostSerializer
     select_related = [
         'parent', 'parent__cloudproject', 'cloudprovider', 'hypervisor',
-        'service_env__service', 'service_env__environment', 'content_type'
+        'service_env__service', 'service_env__environment', 'content_type',
+        'configuration_path__module',
     ]
     prefetch_related = base_object_descendant_prefetch_related + [
         'tags', 'cloudflavor__virtualcomponent_set__model', 'licences',

--- a/src/ralph/virtual/models.py
+++ b/src/ralph/virtual/models.py
@@ -71,7 +71,7 @@ class CloudFlavor(AdminAbsoluteUrlMixin, BaseObject):
         # use cached components if already prefetched (using prefetch_related)
         # otherwise, perform regular SQL query
         try:
-            components = self._prefetched_objects_cache['virtualcomponent']
+            components = self._prefetched_objects_cache['virtualcomponent_set']
         except (KeyError, AttributeError):
             return self.virtualcomponent_set.filter(
                 model__type=model_type

--- a/src/ralph/virtual/tests/test_api.py
+++ b/src/ralph/virtual/tests/test_api.py
@@ -89,11 +89,18 @@ class OpenstackModelsTestCase(RalphAPITestCase):
             model=self.test_disk,
         )
 
-    @data('cloudflavor', 'cloudhost', 'cloudproject', 'cloudprovider')
+    @data('cloudflavor', 'cloudproject', 'cloudprovider')
     def test_get_list(self, field):
         url = reverse(field + '-list')
         response = self.client.get(url, format='json')
         self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+    def test_get_cloudhost_list(self):
+        url = reverse('cloudhost-list')
+        with self.assertNumQueries(12):
+            response = self.client.get(url, format='json')
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data['count'], 2)
 
     @unpack
     @data(

--- a/src/ralph/virtual/tests/test_api.py
+++ b/src/ralph/virtual/tests/test_api.py
@@ -58,6 +58,7 @@ class OpenstackModelsTestCase(RalphAPITestCase):
             parent=self.cloud_project,
             cloudflavor=self.cloud_flavor
         )
+        self.cloud_host2 = CloudHostFactory()
 
         self.test_cpu = ComponentModel.objects.create(
             name='vcpu1',


### PR DESCRIPTION
Reduced SQL queries count (N+1) in cloudhost-list API view (fixed wrong key for checking prefetched objects).
