### PR TITLE
Change default content-type for DNSaaS REST client

### DIFF
--- a/src/ralph/dns/dnsaas.py
+++ b/src/ralph/dns/dnsaas.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-import json
 import logging
 from urllib.parse import urlencode, urljoin
 
@@ -118,7 +117,7 @@ class DNSaaS:
             ),
             'owner': settings.DNSAAS_OWNER
         }
-        request = self.session.patch(url, data=data)
+        request = self.session.patch(url, json=data)
         if request.status_code == 500:
             return {
                 'non_field_errors': [_('Internal Server Error from DNSAAS')]
@@ -196,7 +195,7 @@ class DNSaaS:
         return self._post(url, data)
 
     def _post(self, url, data):
-        response = self.session.post(url, data=json.dumps(data))
+        response = self.session.post(url, json=data)
         return self._request2result(response)
 
     def delete_dns_record(self, record_id):

--- a/src/ralph/dns/dnsaas.py
+++ b/src/ralph/dns/dnsaas.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+import json
 import logging
 from urllib.parse import urlencode, urljoin
 
@@ -17,7 +18,8 @@ class DNSaaS:
     def __init__(self, headers=None):
         self.session = requests.Session()
         _headers = {
-            'Authorization': 'Token {}'.format(settings.DNSAAS_TOKEN)
+            'Authorization': 'Token {}'.format(settings.DNSAAS_TOKEN),
+            'Content-Type': 'application/json'
         }
         if headers is not None:
             _headers.update(headers)
@@ -194,7 +196,7 @@ class DNSaaS:
         return self._post(url, data)
 
     def _post(self, url, data):
-        response = self.session.post(url, data=data)
+        response = self.session.post(url, data=json.dumps(data))
         return self._request2result(response)
 
     def delete_dns_record(self, record_id):


### PR DESCRIPTION
Now by default is `application/json`.
Moreover, according to RFC2616 HTTP/1.1 message SHOULD include `Content-Type`.
