### PR TITLE
Fix MySQL 5.5 column renaming

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,8 @@ env:
         - DJANGO_CURRENT_VERSION=1.8.12
         - RALPH2_RALPH3_CROSS_VALIDATION_ENABLED=1
     matrix:
-        - DJANGO_VERSION=1.8.12 TEST_DB_ENGINE=mysql
-        - DJANGO_VERSION=1.8.12 TEST_DB_ENGINE=mysql55
+        - DJANGO_VERSION=1.8.12 TEST_DB_ENGINE=mysql MYSQL_VERSION=5.6
+        - DJANGO_VERSION=1.8.12 TEST_DB_ENGINE=mysql MYSQL_VERSION=5.5
         - DJANGO_VERSION=1.8.12 TEST_DB_ENGINE=psql
         # Django 1.9 build will not pass until #2132 will be merged
         # - DJANGO_VERSION=1.9 TEST_DB_ENGINE=sqlite
@@ -40,8 +40,7 @@ before_install:
     - export REDIS_PORT=6379
     - docker run -d -p "$REDIS_PORT:6379" redis:3.0;
     - export NEW_TAG=$RALPH_VERSION-snapshot-$(date "+%Y%m%d")-$TRAVIS_BUILD_NUMBER
-    - if [[ $TEST_DB_ENGINE == mysql ]]; then docker run -d -v $(pwd)/docker/mysql.cnf:/etc/mysql/conf.d/mysql.cnf -p "3306:3306" -e "MYSQL_ALLOW_EMPTY_PASSWORD=yes" -e "MYSQL_DATABASE=ralph_ng" -e "MYSQL_ROOT_PASSWORD=root" -e "MYSQL_USER=travis" -e "MYSQL_PASSWORD=travis" mysql:5.6; fi
-    - if [[ $TEST_DB_ENGINE == mysql55 ]]; then docker run -d -v $(pwd)/docker/mysql.cnf:/etc/mysql/conf.d/mysql.cnf -p "3306:3306" -e "MYSQL_ALLOW_EMPTY_PASSWORD=yes" -e "MYSQL_DATABASE=ralph_ng" -e "MYSQL_ROOT_PASSWORD=root" -e "MYSQL_USER=travis" -e "MYSQL_PASSWORD=travis" mysql:5.5; fi
+    - if [[ $TEST_DB_ENGINE == mysql ]]; then docker run -d -v $(pwd)/docker/mysql.cnf:/etc/mysql/conf.d/mysql.cnf -p "3306:3306" -e "MYSQL_ALLOW_EMPTY_PASSWORD=yes" -e "MYSQL_DATABASE=ralph_ng" -e "MYSQL_ROOT_PASSWORD=root" -e "MYSQL_USER=travis" -e "MYSQL_PASSWORD=travis" mysql:$MYSQL_VERSION; fi
     - if [[ $TEST_DB_ENGINE == psql ]]; then
         export DATABASE_PORT=5433;
         docker run -d -p "$DATABASE_PORT:5432" -e "POSTGRES_USER=travis" -e "POSTGRES_PASSWORD=travis" -e "POSTGRES_DB=ralph_ng" postgres:9.4;
@@ -64,7 +63,7 @@ script:
     - ./scripts/check_missing_migrations.sh
 
 after_success:
-    - if [[ $TEST_DB_ENGINE == mysql ]]; then coveralls; fi
+    - if [[ $TEST_DB_ENGINE == psql ]]; then coveralls; fi
 
 before_deploy:
     - sudo add-apt-repository -y ppa:spotify-jyrki/dh-virtualenv
@@ -78,13 +77,13 @@ deploy:
         on:
             branch: ng
             python: 3.4
-            condition: $TEST_DB_ENGINE = mysql && $DJANGO_VERSION = $DJANGO_CURRENT_VERSION
+            condition: $TEST_DB_ENGINE = psql && $DJANGO_VERSION = $DJANGO_CURRENT_VERSION
     -   provider: script
         script: scripts/travis_deploy_bintray.sh
         on:
             branch: ng
             python: 3.4
-            condition: $TEST_DB_ENGINE = mysql && $DJANGO_VERSION = $DJANGO_CURRENT_VERSION
+            condition: $TEST_DB_ENGINE = psql && $DJANGO_VERSION = $DJANGO_CURRENT_VERSION
 
 notifications:
   webhooks:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ env:
         - RALPH2_RALPH3_CROSS_VALIDATION_ENABLED=1
     matrix:
         - DJANGO_VERSION=1.8.12 TEST_DB_ENGINE=mysql
+        - DJANGO_VERSION=1.8.12 TEST_DB_ENGINE=mysql55
         - DJANGO_VERSION=1.8.12 TEST_DB_ENGINE=psql
         # Django 1.9 build will not pass until #2132 will be merged
         # - DJANGO_VERSION=1.9 TEST_DB_ENGINE=sqlite
@@ -40,6 +41,7 @@ before_install:
     - docker run -d -p "$REDIS_PORT:6379" redis:3.0;
     - export NEW_TAG=$RALPH_VERSION-snapshot-$(date "+%Y%m%d")-$TRAVIS_BUILD_NUMBER
     - if [[ $TEST_DB_ENGINE == mysql ]]; then docker run -d -v $(pwd)/docker/mysql.cnf:/etc/mysql/conf.d/mysql.cnf -p "3306:3306" -e "MYSQL_ALLOW_EMPTY_PASSWORD=yes" -e "MYSQL_DATABASE=ralph_ng" -e "MYSQL_ROOT_PASSWORD=root" -e "MYSQL_USER=travis" -e "MYSQL_PASSWORD=travis" mysql:5.6; fi
+    - if [[ $TEST_DB_ENGINE == mysql55 ]]; then docker run -d -v $(pwd)/docker/mysql.cnf:/etc/mysql/conf.d/mysql.cnf -p "3306:3306" -e "MYSQL_ALLOW_EMPTY_PASSWORD=yes" -e "MYSQL_DATABASE=ralph_ng" -e "MYSQL_ROOT_PASSWORD=root" -e "MYSQL_USER=travis" -e "MYSQL_PASSWORD=travis" mysql:5.5; fi
     - if [[ $TEST_DB_ENGINE == psql ]]; then
         export DATABASE_PORT=5433;
         docker run -d -p "$DATABASE_PORT:5432" -e "POSTGRES_USER=travis" -e "POSTGRES_PASSWORD=travis" -e "POSTGRES_DB=ralph_ng" postgres:9.4;

--- a/src/ralph/assets/_migration_helpers.py
+++ b/src/ralph/assets/_migration_helpers.py
@@ -3,9 +3,11 @@ from __future__ import unicode_literals
 
 import logging
 from collections import defaultdict
+from contextlib import ContextDecorator
 from functools import partial
 
 from django.db import connection, migrations, models
+from django.db.backends.base.schema import _related_non_m2m_objects
 
 logger = logging.getLogger(__name__)
 
@@ -111,6 +113,89 @@ def _foreign_key_check_wrap(operations):
     return operations
 
 
+class DropAndCreateForeignKey(ContextDecorator):
+    """
+    Drop FK to old_field before migration operation and recreate FK (to the new
+    field) after migration operation.
+    """
+    def __init__(self, old_field, new_field, schema_editor):
+        self.old_field = old_field
+        self.new_field = new_field
+        self.schema_editor = schema_editor
+
+    def __enter__(self):
+        # copy from django.db.backends.base.schema.BaseDatabaseSchemaEditor._alter_field  # noqa
+        # drop any FK pointing to old_field
+        for _old_rel, new_rel in _related_non_m2m_objects(
+            self.old_field, self.new_field
+        ):
+            rel_fk_names = self.schema_editor._constraint_names(
+                new_rel.related_model, [new_rel.field.column], foreign_key=True
+            )
+            for fk_name in rel_fk_names:
+                logger.debug('Dropping FK to {} ({})'.format(
+                    new_rel.field, fk_name
+                ))
+                self.schema_editor.execute(
+                    self.schema_editor._delete_constraint_sql(
+                        self.schema_editor.sql_delete_fk,
+                        new_rel.related_model,
+                        fk_name
+                    )
+                )
+
+    def __exit__(self, *exc):
+        # copy from django.db.backends.base.schema.BaseDatabaseSchemaEditor._alter_field  # noqa
+        # (re)create any FK pointing to the new field
+        for rel in self.new_field.model._meta.related_objects:
+            if not rel.many_to_many:
+                logger.debug('Recreating FK to {}'.format(rel.field))
+                self.schema_editor.execute(
+                    self.schema_editor._create_fk_sql(
+                        rel.related_model, rel.field, "_fk"
+                    )
+                )
+
+
+class RenameFieldWithFKDrop(migrations.RenameField):
+    """
+    Rename field with dropping any FK pointing to it before actual renaming
+    and recreating them after renaming.
+
+    It's especially usefull for MySQL 5.5, where renaming field that is
+    referenced by another table is not supported (errno 150). The workaround
+    here is to drop FK first, then rename field, and then recreate FK. It's
+    supported fully since MySQL 5.6.6.
+
+    Resources:
+    https://code.djangoproject.com/ticket/24995
+    https://github.com/django/django/pull/4881
+    http://dev.mysql.com/doc/refman/5.5/en/create-table-foreign-keys.html
+    http://stackoverflow.com/questions/2014498/renaming-foreign-key-columns-in-mysql  # noqa
+    """
+    def database_forwards(
+        self, app_label, schema_editor, from_state, to_state
+    ):
+        to_model = to_state.apps.get_model(app_label, self.model_name)
+        if self.allow_migrate_model(schema_editor.connection.alias, to_model):
+            from_model = from_state.apps.get_model(app_label, self.model_name)
+            old_field = from_model._meta.get_field(self.old_name)
+            new_field = to_model._meta.get_field(self.new_name)
+            with DropAndCreateForeignKey(old_field, new_field, schema_editor):
+                schema_editor.alter_field(from_model, old_field, new_field)
+
+    def database_backwards(
+        self, app_label, schema_editor, from_state, to_state
+    ):
+        to_model = to_state.apps.get_model(app_label, self.model_name)
+        if self.allow_migrate_model(schema_editor.connection.alias, to_model):
+            from_model = from_state.apps.get_model(app_label, self.model_name)
+            old_field = from_model._meta.get_field(self.new_name)
+            new_field = to_model._meta.get_field(self.old_name)
+            with DropAndCreateForeignKey(old_field, new_field, schema_editor):
+                schema_editor.alter_field(from_model, old_field, new_field)
+
+
 class InheritFromBaseObject(migrations.SeparateDatabaseAndState):
     """
     Handle migrating model to inherit from BaseObject.
@@ -148,6 +233,7 @@ class InheritFromBaseObject(migrations.SeparateDatabaseAndState):
         ]
 
         database_operations = [
+            # RenameFieldWithFKDrop(
             migrations.RenameField(
                 model_name=model_name.lower(),
                 old_name='id',

--- a/src/ralph/assets/_migration_helpers.py
+++ b/src/ralph/assets/_migration_helpers.py
@@ -233,8 +233,7 @@ class InheritFromBaseObject(migrations.SeparateDatabaseAndState):
         ]
 
         database_operations = [
-            # RenameFieldWithFKDrop(
-            migrations.RenameField(
+            RenameFieldWithFKDrop(
                 model_name=model_name.lower(),
                 old_name='id',
                 new_name='baseobject_ptr_id'

--- a/src/ralph/security/tests/factories.py
+++ b/src/ralph/security/tests/factories.py
@@ -39,7 +39,7 @@ class VulnerabilityFactory(DjangoModelFactory):
 
     name = factory.Sequence(lambda n: 'vulnserability %d' % n)
     patch_deadline = factory.LazyAttribute(
-        lambda o: datetime.now() + timedelta(days=10)
+        lambda o: (datetime.now() + timedelta(days=10)).replace(microsecond=0)
     )
     risk = Risk.low
     external_vulnerability_id = factory.Sequence(lambda n: n)

--- a/src/ralph/security/tests/test_api.py
+++ b/src/ralph/security/tests/test_api.py
@@ -94,11 +94,11 @@ class SecurityScanAPITests(RalphAPITestCase):
         data = {
             'last_scan_date': (
                 datetime.now() + timedelta(days=10)
-            ).isoformat(),
+            ).replace(microsecond=0).isoformat(),
             'scan_status': ScanStatus.error.name,
             'next_scan_date': (
                 datetime.now() + timedelta(days=15)
-            ).isoformat(),
+            ).replace(microsecond=0).isoformat(),
             'details_url': self.security_scan.details_url + '-new',
             'rescan_url': self.security_scan.rescan_url + '-new',
             'host_ip': ip.address,
@@ -148,7 +148,9 @@ class VulnerabilityAPITests(RalphAPITestCase):
         self.assertEqual(response.data['name'], self.vulnerability.name)
         self.assertEqual(
             response.data['patch_deadline'],
-            self.vulnerability.patch_deadline.isoformat(),
+            self.vulnerability.patch_deadline.replace(
+                microsecond=0
+            ).isoformat(),
         )
         self.assertEqual(response.data['risk'], Risk.low.name)
         self.assertEqual(
@@ -162,7 +164,7 @@ class VulnerabilityAPITests(RalphAPITestCase):
             'name': "vulnerability name",
             'patch_deadline': (
                 datetime.now() + timedelta(days=10)
-            ).isoformat(),
+            ).replace(microsecond=0).isoformat(),
             'risk': Risk.low.name,
             'external_vulnerability_id': 100,
         }
@@ -186,7 +188,7 @@ class VulnerabilityAPITests(RalphAPITestCase):
             'name': self.vulnerability.name + ' new',
             'patch_deadline': (
                 self.vulnerability.patch_deadline + timedelta(days=3)
-            ).isoformat(),
+            ).replace(microsecond=0).isoformat(),
             'risk': Risk.high.name,
             'external_vulnerability_id': self.vulnerability.external_vulnerability_id + 10  # noqa
         }


### PR DESCRIPTION
Rename field with dropping any FK pointing to it before actual renaming
and recreating them after renaming.

It's especially usefull for MySQL 5.5, where renaming field that is
referenced by another table is not supported (errno 150). The workaround
here is to drop FK first, then rename field, and then recreate FK. It's
supported fully since MySQL 5.6.6.

Resources:
https://code.djangoproject.com/ticket/24995
https://github.com/django/django/pull/4881
http://dev.mysql.com/doc/refman/5.5/en/create-table-foreign-keys.html
http://stackoverflow.com/questions/2014498/renaming-foreign-key-columns-in-mysql 

This PR fixes #2799 and #2769 
