### PR TITLE
Fix import statement for MagicMock

### DIFF
--- a/src/ralph/deployment/forms.py
+++ b/src/ralph/deployment/forms.py
@@ -1,4 +1,5 @@
-from mock import MagicMock
+from unittest.mock import MagicMock
+
 from django import forms
 from django.template import TemplateSyntaxError
 


### PR DESCRIPTION
Import `MagicMock` from standard library instead of external dependencies.
