### PR TITLE
Bump South version; add `rest_framework.authtoken` app.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -69,7 +69,7 @@ setup(
         'rq>=0.3.7',
         'rq-scheduler==0.3.6',
         'setproctitle==1.1.8',
-        'South==0.7.6',
+        'South==1.0.2',
         'splunk-sdk==0.8.0',
         'SQLAlchemy==0.7.8',
         'null==0.6.1',

--- a/src/ralph/settings.py
+++ b/src/ralph/settings.py
@@ -88,6 +88,7 @@ INSTALLED_APPS = [
     'ralph.scan',
     'ralph.notifications',
     'rest_framework',
+    'rest_framework.authtoken',
     'ajax_select',
     'powerdns',
 ]


### PR DESCRIPTION
Needed by https://github.com/allegro/ralph_pricing/pull/507.

Requires running `ralph syncdb` and `ralph migrate rest_framework.authtoken` after merging (and obviously, `pip install -e .` to refresh dependencies).
