### PR TITLE
Add extra condition to receivers

### DIFF
--- a/src/ralph/networks/receivers.py
+++ b/src/ralph/networks/receivers.py
@@ -3,7 +3,10 @@ from ralph.virtual.models import CloudHost
 
 
 def update_dns_record(instance, created, *args, **kwargs):
-    if isinstance(instance.ethernet.base_object, CloudHost):
+    if (
+        instance.ethernet and
+        isinstance(instance.ethernet.base_object, CloudHost)
+    ):
         return
     keys = ['address', 'hostname']
     data_to_send = {
@@ -20,7 +23,10 @@ def update_dns_record(instance, created, *args, **kwargs):
 
 
 def delete_dns_record(instance, *args, **kwargs):
-    if isinstance(instance.ethernet.base_object, CloudHost):
+    if (
+        instance.ethernet and
+        isinstance(instance.ethernet.base_object, CloudHost)
+    ):
         return
     DNSaaS().send_ipaddress_data({
         'address': instance.address,


### PR DESCRIPTION
To avoid error like: 'NoneType' object has no attribute 'base_object'
