### PR TITLE
Fix CloudHost hostnames assignment

### DIFF
--- a/src/ralph/virtual/management/commands/openstack_sync.py
+++ b/src/ralph/virtual/management/commands/openstack_sync.py
@@ -258,9 +258,11 @@ class Command(BaseCommand):
         ).select_related(
             'hypervisor', 'parent', 'parent__cloudproject',
         ).prefetch_related('tags'):
-            ips = dict(server.ethernet_set.select_related('ipaddress').values_list(
-                'ipaddress__address', 'ipaddress__hostname'
-            ))
+            ips = dict(
+                server.ethernet_set.select_related('ipaddress').values_list(
+                    'ipaddress__address', 'ipaddress__hostname'
+                )
+            )
             new_server = {
                 'hostname': server.hostname,
                 'hypervisor': server.hypervisor,

--- a/src/ralph/virtual/models.py
+++ b/src/ralph/virtual/models.py
@@ -193,8 +193,8 @@ class CloudHost(PreviousStateMixin, AdminAbsoluteUrlMixin, BaseObject):
 
     @ip_addresses.setter
     def ip_addresses(self, value):
-        if set(self.ip_addresses) == set(value):
-            return
+        # value is a list (of ips) or dict (of ip:hostname pairs)
+        # when value is a dict, set will work on keys only
         for ip in set(value) - set(self.ip_addresses):
             try:
                 new_ip = IPAddress.objects.get(address=ip)
@@ -212,6 +212,22 @@ class CloudHost(PreviousStateMixin, AdminAbsoluteUrlMixin, BaseObject):
                     address=ip
                 )
                 new_ip.save()
+        # refresh hostnames
+        if isinstance(value, dict):
+            for address, hostname in value.items():
+                try:
+                    ip = IPAddress.objects.get(address=address)
+                except IPAddress.DoesNotExist:
+                    logger.debug('IP {} not found'.format(address))
+                else:
+                    if ip.hostname != hostname:
+                        logger.info(
+                            'Setting {} for IP {} (previous value: {})'.format(
+                                hostname, address, ip.hostname
+                            )
+                        )
+                        ip.hostname = hostname
+                        ip.save()
 
         to_delete = set(self.ip_addresses) - set(value)
         Ethernet.objects.filter(

--- a/src/ralph/virtual/tests/test_models.py
+++ b/src/ralph/virtual/tests/test_models.py
@@ -4,6 +4,7 @@ from ralph.assets.models.assets import ServiceEnvironment
 from ralph.assets.models.choices import ComponentType
 from ralph.assets.models.components import ComponentModel
 from ralph.assets.tests.factories import EnvironmentFactory, ServiceFactory
+from ralph.networks.models import IPAddress
 from ralph.tests import RalphTestCase
 from ralph.virtual.models import CloudHost, VirtualComponent
 from ralph.virtual.tests.factories import (
@@ -85,6 +86,36 @@ class OpenstackModelsTestCase(RalphTestCase):
         self.cloud_host.ip_addresses = ip_addresses
         self.assertEqual(set(self.cloud_host.ip_addresses), set(ip_addresses))
         self.cloud_host.ip_addresses = ip_addresses2
+        self.assertEqual(set(self.cloud_host.ip_addresses), set(ip_addresses2))
+
+    def test_ip_hostname_update(self):
+        ip_addresses = {
+            '10.0.0.1': 'hostname1.mydc.net',
+            '10.0.0.2': 'hostname2.mydc.net',
+        }
+        ip_addresses2 = {
+            '10.0.0.1': 'hostname3.mydc.net',
+            '10.0.0.3': 'hostname4.mydc.net',
+        }
+        self.cloud_host.ip_addresses = ip_addresses
+        self.assertEqual(set(self.cloud_host.ip_addresses), set(ip_addresses))
+        self.assertEqual(
+            IPAddress.objects.get(address='10.0.0.1').hostname,
+            'hostname1.mydc.net'
+        )
+        self.assertEqual(
+            IPAddress.objects.get(address='10.0.0.2').hostname,
+            'hostname2.mydc.net'
+        )
+        self.cloud_host.ip_addresses = ip_addresses2
+        self.assertEqual(
+            IPAddress.objects.get(address='10.0.0.1').hostname,
+            'hostname3.mydc.net'
+        )
+        self.assertEqual(
+            IPAddress.objects.get(address='10.0.0.3').hostname,
+            'hostname4.mydc.net'
+        )
         self.assertEqual(set(self.cloud_host.ip_addresses), set(ip_addresses2))
 
     def test_service_env_inheritance_on_project_change(self):


### PR DESCRIPTION
Refresh hostname from DNS with every sync with OpenStack (if there were wrong PTR in DNS records, it was never fixed (refreshed) for particular IP).
