### PR TITLE
Support for multiple providers in openstack_sync mgmt command

### DIFF
--- a/src/ralph/settings/base.py
+++ b/src/ralph/settings/base.py
@@ -379,7 +379,9 @@ INVENTORY_TAG_APPEND_DATE = bool_from_env('INVENTORY_TAG_APPEND_DATE', True)
 MAP_IMPORTED_ID_TO_NEW_ID = False
 
 OPENSTACK_INSTANCES = json.loads(os.environ.get('OPENSTACK_INSTANCES', '[]'))
-
+DEFAULT_OPENSTACK_PROVIDER_NAME = os.environ.get(
+    'DEFAULT_OPENSTACK_PROVIDER_NAME', 'openstack'
+)
 # issue tracker url for Operations urls (issues ids) - should end with /
 ISSUE_TRACKER_URL = os.environ.get('ISSUE_TRACKER_URL', '')
 

--- a/src/ralph/virtual/management/commands/openstack_sync.py
+++ b/src/ralph/virtual/management/commands/openstack_sync.py
@@ -291,8 +291,7 @@ class Command(BaseCommand):
                     name=provider_name,
                 )
                 self._save_object(
-                    self.cloud_provider,
-                    'Add {} CloudProvider'.format(self.openstack_provider_name)
+                    cloud_provider, 'Add {} CloudProvider'.format(provider_name)
                 )
             return cloud_provider
         self.cloud_provider = _get_or_create(self.openstack_provider_name)

--- a/src/ralph/virtual/management/commands/openstack_sync.py
+++ b/src/ralph/virtual/management/commands/openstack_sync.py
@@ -9,7 +9,7 @@ import reversion as revisions
 from django.conf import settings
 from django.core.exceptions import MultipleObjectsReturned, ObjectDoesNotExist
 from django.core.management.base import BaseCommand
-from django.db import transaction
+from django.db import IntegrityError, transaction
 
 from ralph.data_center.models.physical import DataCenterAsset
 from ralph.lib import network
@@ -23,7 +23,10 @@ from ralph.virtual.models import (
 logger = logging.getLogger(__name__)
 
 try:
-    from keystoneclient.v2_0 import client as ks
+    from keystoneclient.v2_0 import client as ks_v2_client
+    from keystoneclient.v3 import client as ks_v3_client
+    from keystoneauth1 import session as ks_session
+    from keystoneauth1.identity import v3 as ks_v3_identity
     keystone_client_exists = True
 except ImportError:
     keystone_client_exists = False
@@ -34,6 +37,9 @@ try:
     nova_client_exists = True
 except ImportError:
     nova_client_exists = False
+
+
+DEFAULT_OPENSTACK_PROVIDER_NAME = 'openstack'
 
 
 class EmptyListError(Exception):
@@ -51,6 +57,15 @@ class Command(BaseCommand):
         self.summary = defaultdict(int)
         self.openstack_projects = {}
         self.openstack_flavors = {}
+        self.openstack_provider_name = DEFAULT_OPENSTACK_PROVIDER_NAME
+
+    def add_arguments(self, parser):
+        super().add_arguments(parser)
+        parser.add_argument(
+            '--provider',
+            help='OpenStack provider name',
+            default=DEFAULT_OPENSTACK_PROVIDER_NAME,
+        )
 
     @staticmethod
     def _get_novaclient_connection(site):
@@ -62,6 +77,28 @@ class Command(BaseCommand):
             site['auth_url']
         )
         return nt
+
+    @staticmethod
+    def _get_keystone_client(site):
+        if site.get('keystone_version', '').startswith('3'):
+            auth = ks_v3_identity.Password(
+                auth_url=site.get('keystone_auth_url', site['auth_url']),
+                username=site['username'],
+                password=site['password'],
+                user_domain_name=site.get('user_domain_name', 'default'),
+                project_name=site['tenant_name'],
+                project_domain_name=site.get('project_domain_name', 'default'),
+            )
+            session = ks_session.Session(auth=auth)
+            client = ks_v3_client.Client(session=session, version=(3,))
+        else:
+            client = ks_v2_client.Client(
+                username=site['username'],
+                password=site['password'],
+                tenant_name=site['tenant_name'],
+                auth_url=site['auth_url'],
+            )
+        return client
 
     @staticmethod
     def _get_servers_list(nt, site):
@@ -132,19 +169,21 @@ class Command(BaseCommand):
             )
         return flavors
 
+    def _get_keystone_projects(self, keystone_client):
+        if keystone_client.version == 'v3':
+            projects_resource = keystone_client.projects
+        else:
+            projects_resource = keystone_client.tenants
+        yield from projects_resource.list()
+
     def _update_projects(self, site):
         """
         Returns a map tenant_id->tenant_name
         :rtype: dict
         """
-        keystone_client = ks.Client(
-            username=site['username'],
-            password=site['password'],
-            tenant_name=site['tenant_name'],
-            auth_url=site['auth_url'],
-        )
+        keystone_client = self._get_keystone_client(site)
 
-        for project in keystone_client.tenants.list():
+        for project in self._get_keystone_projects(keystone_client):
             if project.id not in self.openstack_projects:
                 self.openstack_projects[project.id] = {
                     'name': project.name,
@@ -153,8 +192,19 @@ class Command(BaseCommand):
                 }
             self.openstack_projects[project.id]['tags'].append(site['tag'])
 
+    def _get_instances_from_settings(self):
+        """
+        Filter instances from OPENSTACK_INSTANCES (from settings) and yield
+        only the ones matching current opeenstack provider.
+        """
+        for os_instance in settings.OPENSTACK_INSTANCES:
+            if os_instance.get(
+                'provider', DEFAULT_OPENSTACK_PROVIDER_NAME
+            ) == self.openstack_provider_name:
+                yield os_instance
+
     def _process_openstack_instances(self):
-        for site in settings.OPENSTACK_INSTANCES:
+        for site in self._get_instances_from_settings():
             logger.info('Processing {} ({})'.format(
                 site['auth_url'], site['tag']
             ))
@@ -218,7 +268,7 @@ class Command(BaseCommand):
                         new_server
                     )
                 except KeyError:
-                    logger.error('Project {} not found for server {}'.format(
+                    logger.warning('Project {} not found for server {}'.format(
                         project_id, host_id,
                     ))
 
@@ -231,12 +281,24 @@ class Command(BaseCommand):
 
     def _get_cloud_provider(self):
         """Get or create cloud provider object"""
-        try:
-            self.cloud_provider = CloudProvider.objects.get(name='openstack')
-        except ObjectDoesNotExist:
-            self.cloud_provider = CloudProvider(name='openstack')
-            self._save_object(self.cloud_provider,
-                              'Add openstack CloudProvider')
+        def _get_or_create(provider_name):
+            try:
+                cloud_provider = CloudProvider.objects.get(
+                    name=provider_name,
+                )
+            except ObjectDoesNotExist:
+                cloud_provider = CloudProvider(
+                    name=provider_name,
+                )
+                self._save_object(
+                    self.cloud_provider,
+                    'Add {} CloudProvider'.format(self.openstack_provider_name)
+                )
+            return cloud_provider
+        self.cloud_provider = _get_or_create(self.openstack_provider_name)
+        self.default_cloud_provider = _get_or_create(
+            DEFAULT_OPENSTACK_PROVIDER_NAME
+        )
 
     def _get_ralph_data(self):
         """Get configuration from ralph DB"""
@@ -245,16 +307,20 @@ class Command(BaseCommand):
         projects = CloudProject.objects.filter(
             cloudprovider=self.cloud_provider
         ).prefetch_related('tags')
-        for project in projects:
-            project_id = project.project_id
-            self.ralph_projects[project_id] = {
+
+        def _get_project_info(project):
+            return {
                 'name': project.name,
                 'servers': {},
                 'tags': project.tags.names(),
             }
 
+        for project in projects:
+            project_id = project.project_id
+            self.ralph_projects[project_id] = _get_project_info(project)
+
         for server in CloudHost.objects.filter(
-            parent__in=projects
+            cloudprovider=self.cloud_provider,
         ).select_related(
             'hypervisor', 'parent', 'parent__cloudproject',
         ).prefetch_related('tags'):
@@ -272,6 +338,11 @@ class Command(BaseCommand):
             }
             host_id = server.host_id
             project_id = server.parent.cloudproject.project_id
+            # workaround for projects with the same id in multiple providers
+            if project_id not in self.ralph_projects:
+                self.ralph_projects[project_id] = _get_project_info(
+                    CloudProject.objects.get(project_id=project_id)
+                )
             self.ralph_projects[project_id]['servers'][host_id] = new_server
 
         for flavor in CloudFlavor.objects.filter(
@@ -286,7 +357,7 @@ class Command(BaseCommand):
             obj = DataCenterAsset.objects.get(hostname=host_name)
             return obj
         except (MultipleObjectsReturned, ObjectDoesNotExist):
-            logger.error('Hypervisor {} not found for {}'.format(
+            logger.warning('Hypervisor {} not found for {}'.format(
                 host_name, server_id,
             ))
             return None
@@ -300,7 +371,7 @@ class Command(BaseCommand):
         try:
             flavor = self._get_flavors()[openstack_server['flavor_id']]
         except KeyError:
-            logger.error(
+            logger.warning(
                 'Flavor {} not found for host {}'.format(
                     openstack_server['flavor_id'], openstack_server
                 )
@@ -340,7 +411,7 @@ class Command(BaseCommand):
         try:
             flavor = self._get_flavors()[openstack_server['flavor_id']]
         except KeyError:
-            logger.error(
+            logger.warning(
                 'Flavor {} not found for host {}'.format(
                     openstack_server['flavor_id'], openstack_server
                 )
@@ -454,7 +525,18 @@ class Command(BaseCommand):
                 project_id=project_id,
                 cloudprovider=self.cloud_provider,
             )
-            self._save_object(project, 'Add project %s' % project.name)
+            try:
+                with transaction.atomic():
+                    self._save_object(project, 'Add project %s' % project.name)
+            except IntegrityError:
+                logger.warning(
+                    'Duplicated project ID ({}) for project {}'.format(
+                        project.project_id, project.name
+                    )
+                )
+                project = CloudProject.objects.get(
+                    project_id=project_id
+                )
             for tag in data['tags']:
                 project.tags.add(tag)
         self.summary['total_projects'] += 1
@@ -571,7 +653,9 @@ class Command(BaseCommand):
         if not hasattr(settings, 'OPENSTACK_INSTANCES'):
             logger.error('Nothing to sync')
             return
+        self.openstack_provider_name = options['provider']
         self.stdout.write("syncing...")
+
         self._get_cloud_provider()
         self._process_openstack_instances()
         self._get_ralph_data()

--- a/src/ralph/virtual/management/commands/openstack_sync.py
+++ b/src/ralph/virtual/management/commands/openstack_sync.py
@@ -39,7 +39,7 @@ except ImportError:
     nova_client_exists = False
 
 
-DEFAULT_OPENSTACK_PROVIDER_NAME = 'openstack'
+DEFAULT_OPENSTACK_PROVIDER_NAME = settings.DEFAULT_OPENSTACK_PROVIDER_NAME
 
 
 class EmptyListError(Exception):


### PR DESCRIPTION
* set `provider` key in site definition in settings to distinguish OpenStack providers
* allow to specify different auth_url and version for keystone
* support for keystone v3