### PR TITLE
Calculate metrics for transitions

### DIFF
--- a/src/ralph/lib/external_services/models.py
+++ b/src/ralph/lib/external_services/models.py
@@ -14,9 +14,9 @@ from django.utils.translation import ugettext_lazy as _
 from django_extensions.db.fields.json import JSONField
 
 from ralph.lib.external_services.base import InternalService
+from ralph.lib.metrics import mark
 from ralph.lib.mixins.fields import NullableCharField
 from ralph.lib.mixins.models import TimeStampMixin
-from ralph.lib.metrics import mark
 
 logger = logging.getLogger(__name__)
 

--- a/src/ralph/lib/external_services/worker.py
+++ b/src/ralph/lib/external_services/worker.py
@@ -1,5 +1,9 @@
+import logging
+from django.conf import settings
 from django.db import connection
 from rq import Worker
+
+logger = logging.getLogger(__name__)
 
 
 class RalphWorker(Worker):
@@ -35,7 +39,27 @@ class RalphWorker(Worker):
         * https://dev.mysql.com/doc/refman/5.7/en/error-lost-connection.html
         * http://dev.mysql.com/doc/refman/5.7/en/server-system-variables.html#sysvar_wait_timeout  # noqa
         """
+        reporter = self._start_metrics_reporter()
         connection.close_if_unusable_or_obsolete()
         result = super().perform_job(*args, **kwargs)
         connection.close_if_unusable_or_obsolete()
+        self._send_metrics(reporter)
         return result
+
+    def _start_metrics_reporter(self):
+        """
+        Enable metrology reporter in job process (threads are not "inherited"
+        when forking).
+        """
+        if settings.MEASURE_JOBS_STATS:
+            reporter = settings.GET_REPORTER()
+            if reporter:
+                logger.debug('Starting metrics reporter on worker')
+                reporter.start()
+                return reporter
+
+    def _send_metrics(self, reporter):
+        # atexit (which is used by metrology) is not called when os._exit
+        # is used (which is used by RQ to exit from forked process)
+        if reporter:
+            reporter._exit()

--- a/src/ralph/lib/external_services/worker.py
+++ b/src/ralph/lib/external_services/worker.py
@@ -1,9 +1,7 @@
-import logging
-from django.conf import settings
 from django.db import connection
 from rq import Worker
 
-logger = logging.getLogger(__name__)
+from ralph.lib.metrics.reporter import MetricsReporter
 
 
 class RalphWorker(Worker):
@@ -39,27 +37,8 @@ class RalphWorker(Worker):
         * https://dev.mysql.com/doc/refman/5.7/en/error-lost-connection.html
         * http://dev.mysql.com/doc/refman/5.7/en/server-system-variables.html#sysvar_wait_timeout  # noqa
         """
-        reporter = self._start_metrics_reporter()
-        connection.close_if_unusable_or_obsolete()
-        result = super().perform_job(*args, **kwargs)
-        connection.close_if_unusable_or_obsolete()
-        self._send_metrics(reporter)
+        with MetricsReporter():
+            connection.close_if_unusable_or_obsolete()
+            result = super().perform_job(*args, **kwargs)
+            connection.close_if_unusable_or_obsolete()
         return result
-
-    def _start_metrics_reporter(self):
-        """
-        Enable metrology reporter in job process (threads are not "inherited"
-        when forking).
-        """
-        if settings.MEASURE_JOBS_STATS:
-            reporter = settings.GET_REPORTER()
-            if reporter:
-                logger.debug('Starting metrics reporter on worker')
-                reporter.start()
-                return reporter
-
-    def _send_metrics(self, reporter):
-        # atexit (which is used by metrology) is not called when os._exit
-        # is used (which is used by RQ to exit from forked process)
-        if reporter:
-            reporter._exit()

--- a/src/ralph/lib/metrics/__init__.py
+++ b/src/ralph/lib/metrics/__init__.py
@@ -1,0 +1,7 @@
+from .reporter import MetricsReporter
+from .utils import mark
+
+__all__ = [
+    'mark',
+    'MetricsReporter',
+]

--- a/src/ralph/lib/metrics/middlewares.py
+++ b/src/ralph/lib/metrics/middlewares.py
@@ -14,7 +14,7 @@ REQUESTS_COUNTER_METRIC_PREFIX = getattr(
 
 METRIC_NAME_TMPL = getattr(
     settings,
-    'METRIC_NAME_TMPL',
+    'REQUESTS_METRIC_NAME_TMPL',
     '{prefix}.{url_name}.{request_method}.{status_code}'
 )
 

--- a/src/ralph/lib/metrics/reporter.py
+++ b/src/ralph/lib/metrics/reporter.py
@@ -1,0 +1,51 @@
+import logging
+
+from django.conf import settings
+
+logger = logging.getLogger(__name__)
+
+
+class MetricsReporter(object):
+    """
+    Context manager for short-living processes, which have no accesss to
+    global metrology reporter (for example are running in forked process) and/or
+    exits using `os._exit`.
+
+    This context manager provides starting metrology reporter when entering it
+    and sending metrics when exiting.
+
+    Example:
+
+    with MetricsReporter():
+        <do some task here>
+    """
+    def __init__(self):
+        self.reporter = None
+
+    def __enter__(self):
+        self._start_metrics_reporter()
+
+    def __exit__(self, exc, exv, trace):
+        self._stop_reporter()
+
+    def _start_metrics_reporter(self):
+        """
+        Enable metrology reporter in job process (threads are not "inherited"
+        when forking).
+        """
+        if settings.COLLECT_METRICS:
+            self.reporter = settings.GET_REPORTER()
+            if self.reporter:
+                logger.debug('Starting metrics reporter on worker')
+                self.reporter.start()
+            else:
+                logger.warning(
+                    'Reporter not started - GET_REPOTER method returned None'
+                )
+
+    def _stop_reporter(self):
+        # `atexit` (which is used by metrology) is not called when `os._exit`
+        # is used (which is used by RQ to exit from forked process)
+        if self.reporter:
+            logger.debug('Stopping reporter')
+            self.reporter._exit()

--- a/src/ralph/lib/metrics/reporter.py
+++ b/src/ralph/lib/metrics/reporter.py
@@ -14,6 +14,10 @@ class MetricsReporter(object):
     This context manager provides starting metrology reporter when entering it
     and sending metrics when exiting.
 
+    To use this context manager, set `COLLECT_METRICS` in your settings to True
+    and overwrite `GET_REPORTER` function in settings to return proper
+    reporter for your needs.
+
     Example:
 
     with MetricsReporter():
@@ -40,7 +44,7 @@ class MetricsReporter(object):
                 self.reporter.start()
             else:
                 logger.warning(
-                    'Reporter not started - GET_REPOTER method returned None'
+                    'Reporter not started - GET_REPORTER method returned None'
                 )
 
     def _stop_reporter(self):

--- a/src/ralph/lib/metrics/utils.py
+++ b/src/ralph/lib/metrics/utils.py
@@ -1,0 +1,18 @@
+import logging
+
+from django.conf import settings
+from metrology import Metrology
+
+logger = logging.getLogger(__name__)
+
+
+def mark(metric_name):
+    """
+    Mark event in metrics collector.
+    """
+    if settings.COLLECT_METRICS:
+        logger.info('New mark event: {}'.format(metric_name), extra={
+            'metric_name': metric_name
+        })
+        counter = Metrology.meter(metric_name)
+        counter.mark()

--- a/src/ralph/lib/transitions/models.py
+++ b/src/ralph/lib/transitions/models.py
@@ -386,13 +386,16 @@ def _post_transition_instance_processing(
 
 @transaction.atomic
 def run_field_transition(
-    instances, transition, field, data={}, **kwargs
+    instances, transition_obj_or_name, field, data={}, **kwargs
 ):
     """
     Execute all actions assigned to the selected transition.
     """
     first_instance = instances[0]
     _compare_instances_types(instances)
+    transition = _check_and_get_transition(
+        first_instance, transition_obj_or_name, field
+    )
     _check_instances_for_transition(instances, transition)
     attachment = None
     history_kwargs = defaultdict(dict)

--- a/src/ralph/settings/base.py
+++ b/src/ralph/settings/base.py
@@ -473,3 +473,13 @@ RALPH2_HERMES_ROLE_PROPERTY_WHITELIST = json.loads(
 ENABLE_SAVE_DESCENDANTS_DURING_NETWORK_SYNC = bool_from_env(
     'ENABLE_SAVE_DESCENDANTS_DURING_NETWORK_SYNC', True
 )
+
+
+# METRICS
+MEASURE_JOBS_STATS = False
+
+
+# overwrite this function to use metrics reporter in RQ worker
+# it should return instance of `metrology.reporter.base.Reporter`
+def GET_REPORTER():
+    pass

--- a/src/ralph/settings/base.py
+++ b/src/ralph/settings/base.py
@@ -476,7 +476,7 @@ ENABLE_SAVE_DESCENDANTS_DURING_NETWORK_SYNC = bool_from_env(
 
 
 # METRICS
-MEASURE_JOBS_STATS = False
+COLLECT_METRICS = False
 
 
 # overwrite this function to use metrics reporter in RQ worker


### PR DESCRIPTION
* handle metrics in async transitions on worker (need to use dedicated worker class to run metrology reporter on worker)
* handle metrics in synchronous transition

Metrics are stored in following format:
`<GLOBAL_PREFIX>.jobs.<synchronous_transitions|ASYNC_TRANSITIONS>.<transition_name>.<model_name>.<success|failed|...>.<metric_name>`