### PR TITLE
[WIP] Bump reversion version to the 2.0.X

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -6,7 +6,7 @@ django-extensions==1.5.9
 django-filter==0.13.0
 django-import-export==0.4.2
 django-mptt==0.8.6
-django-reversion==1.8.6
+django-reversion==2.0.8
 django-rq==0.9.0
 django-taggit==0.17.1
 django-taggit-serializer==0.1.5

--- a/src/ralph/admin/mixins.py
+++ b/src/ralph/admin/mixins.py
@@ -21,7 +21,7 @@ from django.views.generic import TemplateView
 from import_export.admin import ImportExportModelAdmin
 from import_export.widgets import ForeignKeyWidget
 from mptt.admin import MPTTAdminForm, MPTTModelAdmin
-from reversion import VersionAdmin
+from reversion.admin import VersionAdmin
 
 from ralph.admin import widgets
 from ralph.admin.autocomplete import AjaxAutocompleteMixin

--- a/src/ralph/admin/templates/admin/change_list.html
+++ b/src/ralph/admin/templates/admin/change_list.html
@@ -51,7 +51,7 @@
                   {% block object-tools-items %}
                     {% if not is_popup %}
                       <li>
-                        <a href="{{recoverlist_url}}" class="recoverlink">
+                        <a href="{% url opts|admin_urlname:'recoverlist' %}" class="recoverlink">
                           <i class="fa fa-retweet" aria-hidden="true"></i>
                           {% blocktrans with cl.opts.verbose_name_plural|escape as name %}
                             Recover deleted {{name}}

--- a/src/ralph/ralph2_sync/admin.py
+++ b/src/ralph/ralph2_sync/admin.py
@@ -15,7 +15,9 @@ class Ralph2SyncAdminMixin(object):
         # enable back syncing of object
         obj._handle_post_save = True
         # call post_save to trigger syning "manually"
-        post_save.send(sender=self.model, instance=obj, created=False)
+        post_save.send(
+            sender=self.model, instance=obj, created=False, using='default'
+        )
 
     # log_addition and log_change are called after succesfull save (with m2m)
     # in regular form and bulk edit


### PR DESCRIPTION
This version has support for Django 1.10

Wait until https://github.com/etianen/django-reversion/pull/611 is merged (and new version of reversion released!) before merging this PR.