### PR TITLE
Fix different sql queries count in admin views test

### DIFF
--- a/src/ralph/admin/tests/tests_views.py
+++ b/src/ralph/admin/tests/tests_views.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from importlib import import_module
 
-from ddt import ddt, data, unpack
+from ddt import data, ddt, unpack
 from django.contrib.auth import get_user_model
 from django.contrib.contenttypes.models import ContentType
 from django.core.urlresolvers import reverse

--- a/src/ralph/admin/tests/tests_views.py
+++ b/src/ralph/admin/tests/tests_views.py
@@ -151,14 +151,18 @@ class ViewsTest(TestCase):
             # Create next 10 records:
             factory_model.create_batch(10)
 
-            with CaptureQueriesContext(connections['default']) as cqc:
+            with CaptureQueriesContext(connections['default']) as cqc2:
                 change_list = model_admin.changelist_view(self.request)
                 self.assertEqual(
                     query_count,
-                    len(cqc),
-                    'Different query count for {}'.format(model_class_path)
+                    len(cqc2),
+                    'Different query count for {}: \n {} \nvs\n{}'.format(
+                        model_class_path,
+                        '\n'.join([q['sql'] for q in cqc.captured_queries]),
+                        '\n'.join([q['sql'] for q in cqc2.captured_queries]),
+                    )
                 )
-                self.assertFalse(len(cqc) > SQL_QUERY_LIMIT)
+                self.assertFalse(len(cqc2) > SQL_QUERY_LIMIT)
 
             if model_class_path not in EXCLUDE_ADD_VIEW:
                 change_form = model_admin.changeform_view(

--- a/src/ralph/admin/tests/tests_views.py
+++ b/src/ralph/admin/tests/tests_views.py
@@ -134,7 +134,9 @@ class ViewsTest(TestCase):
 
     @unpack
     @data(*ralph_site._registry.items())
-    def test_numbers(self, model, model_admin):
+    def test_numbers_of_sql_query_and_response_status_is_200(
+        self, model, model_admin
+    ):
             query_count = 0
             model_class_path = '{}.{}'.format(model.__module__, model.__name__)
             if model_class_path in EXCLUDE_MODELS:


### PR DESCRIPTION
The problem here was testing all admin views in single unit test. Because of that, depending on order of iterating through models (admins) registry, less or more objects of some type (especially BaseObject) could be created. This leads to following behaviour:

After adding first part (10) of objects, following query was executed:
```
SELECT ... 
FROM "assets_baseobject" 
WHERE "assets_baseobject"."content_type_id" IN (9, 8, 14, 15) 
ORDER BY "assets_baseobject"."id" DESC
```

After adding next 10 objects, when count of base objects hits over 100, limit clause was added to the query:
```
SELECT ... 
FROM "assets_baseobject" 
WHERE "assets_baseobject"."content_type_id" IN (9, 8, 14, 15) 
ORDER BY "assets_baseobject"."id" DESC
LIMIT 100
```

This `LIMIT` clause together with `DESC` ordering leads to omitting some of the objects available in first execution of the query, especially dropping all objects of particular type (subclass of BaseObject, for example CloudHost). This causes running one SQL less between consecutive checks.