### PR TITLE
Inheritance of custom fields (v1)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ test: clean
 
 flake: isort
 	flake8 src/ralph
-	flake8 src/ralph/settings --ignore=F405 --exclude=local.py
+	flake8 src/ralph/settings --ignore=F405 --exclude=*local.py
 	@cat scripts/flake.txt
 
 clean:

--- a/src/ralph/assets/admin.py
+++ b/src/ralph/assets/admin.py
@@ -60,7 +60,7 @@ class ConfigurationClassAdmin(CustomFieldValueAdminMixin, RalphAdmin):
 
 
 @register(ConfigurationModule)
-class ConfigurationModuleAdmin(RalphMPTTAdmin):
+class ConfigurationModuleAdmin(CustomFieldValueAdminMixin, RalphMPTTAdmin):
     list_display = ['name']
     search_fields = ['name']
     readonly_fields = [
@@ -104,13 +104,13 @@ class ConfigurationModuleAdmin(RalphMPTTAdmin):
 
 
 @register(ServiceEnvironment)
-class ServiceEnvironmentAdmin(RalphAdmin):
+class ServiceEnvironmentAdmin(CustomFieldValueAdminMixin, RalphAdmin):
 
     search_fields = ['service__name', 'environment__name']
     list_select_related = ['service', 'environment']
     raw_id_fields = ['service', 'environment']
     resource_class = resources.ServiceEnvironmentResource
-    exclude = ('parent', 'service_env', 'content_type')
+    fields = ('service', 'environment', 'remarks', 'tags')
 
 
 class ServiceEnvironmentInline(RalphTabularInline):

--- a/src/ralph/assets/admin.py
+++ b/src/ralph/assets/admin.py
@@ -37,7 +37,7 @@ from ralph.lib.table import Table, TableWithUrl
 
 
 @register(ConfigurationClass)
-class ConfigurationClassAdmin(RalphAdmin):
+class ConfigurationClassAdmin(CustomFieldValueAdminMixin, RalphAdmin):
     fields = ['class_name', 'module', 'path']
     readonly_fields = ['path']
     raw_id_fields = ['module']

--- a/src/ralph/assets/api/views.py
+++ b/src/ralph/assets/api/views.py
@@ -94,10 +94,11 @@ base_object_descendant_prefetch_related = [
     Prefetch('licences', queryset=BaseObjectLicence.objects.select_related(
         *BaseObjectLicenceViewSet.select_related
     )),
-    Prefetch(
-        'custom_fields',
-        queryset=CustomFieldValue.objects.select_related('custom_field')
-    ),
+    'custom_fields',
+    # Prefetch(
+    #     'custom_fields',
+    #     queryset=CustomFieldValue.objects.select_related('custom_field')
+    # ),
     'service_env__service__business_owners',
     'service_env__service__technical_owners',
 ]

--- a/src/ralph/assets/api/views.py
+++ b/src/ralph/assets/api/views.py
@@ -9,7 +9,6 @@ from ralph.api.utils import PolymorphicViewSetMixin
 from ralph.assets import models
 from ralph.assets.api import serializers
 from ralph.assets.api.filters import NetworkableObjectFilters
-from ralph.lib.custom_fields.models import CustomFieldValue
 from ralph.licences.api import BaseObjectLicenceViewSet
 from ralph.licences.models import BaseObjectLicence
 from ralph.networks.models import IPAddress
@@ -95,10 +94,6 @@ base_object_descendant_prefetch_related = [
         *BaseObjectLicenceViewSet.select_related
     )),
     'custom_fields',
-    # Prefetch(
-    #     'custom_fields',
-    #     queryset=CustomFieldValue.objects.select_related('custom_field')
-    # ),
     'service_env__service__business_owners',
     'service_env__service__technical_owners',
 ]
@@ -243,13 +238,10 @@ class DCHostViewSet(BaseObjectViewSetMixin, RalphAPIViewSet):
     ]
     prefetch_related = [
         'tags',
+        'custom_fields',
         Prefetch(
             'ethernet_set',
             queryset=models.Ethernet.objects.select_related('ipaddress')
-        ),
-        Prefetch(
-            'custom_fields',
-            queryset=CustomFieldValue.objects.select_related('custom_field')
         ),
     ]
     extended_filter_fields = {

--- a/src/ralph/assets/tests/test_api.py
+++ b/src/ralph/assets/tests/test_api.py
@@ -858,7 +858,7 @@ class DCHostAPITests(RalphAPITestCase):
 
     def test_get_dc_hosts_list(self):
         url = reverse('dchost-list')
-        with self.assertNumQueries(12):
+        with self.assertNumQueries(11):
             response = self.client.get(url, format='json')
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data['count'], 3)

--- a/src/ralph/assets/tests/test_api.py
+++ b/src/ralph/assets/tests/test_api.py
@@ -858,7 +858,7 @@ class DCHostAPITests(RalphAPITestCase):
 
     def test_get_dc_hosts_list(self):
         url = reverse('dchost-list')
-        with self.assertNumQueries(11):
+        with self.assertNumQueries(12):
             response = self.client.get(url, format='json')
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data['count'], 3)

--- a/src/ralph/data_center/models/physical.py
+++ b/src/ralph/data_center/models/physical.py
@@ -441,6 +441,7 @@ class DataCenterAsset(
         ('location', 'Location'),
         ('model__name', 'Model'),
     ]
+    custom_fields_inheritance = ['configuration_path']
 
     class Meta:
         verbose_name = _('data center asset')

--- a/src/ralph/data_center/models/physical.py
+++ b/src/ralph/data_center/models/physical.py
@@ -293,6 +293,11 @@ class Rack(AdminAbsoluteUrlMixin, NamedMixin.NonUnique, models.Model):
 
 class NetworkableBaseObject(models.Model):
     # TODO: hostname field and not-abstract cls
+    custom_fields_inheritance = [
+        'configuration_path',
+        'configuration_path__module',
+        'service_env',
+    ]
 
     @cached_property
     def network_environment(self):
@@ -441,7 +446,6 @@ class DataCenterAsset(
         ('location', 'Location'),
         ('model__name', 'Model'),
     ]
-    custom_fields_inheritance = ['configuration_path']
 
     class Meta:
         verbose_name = _('data center asset')

--- a/src/ralph/lib/custom_fields/fields.py
+++ b/src/ralph/lib/custom_fields/fields.py
@@ -1,0 +1,322 @@
+import operator
+from collections import defaultdict
+from functools import reduce
+
+from django.contrib.contenttypes.fields import (
+    create_generic_related_manager,
+    GenericRelation,
+    ReverseGenericRelatedObjectsDescriptor
+)
+from django.contrib.contenttypes.models import ContentType
+from django.db import connection, models
+
+from ralph.admin.helpers import get_field_by_relation_path, getattr_dunder
+
+
+class CustomFieldsWithInheritanceRelation(GenericRelation):
+    """
+    Relation for custom fields which handle inheritance of custom fields values
+    from dependent models (fields) specified in custom_fields_inheritance.
+
+    To use inheritance of custom fields, define `custom_fields_inheritance`
+    in your model, specifying paths of fields from which `CustomFieldValue`s
+    should be inherited. `custom_fields_inheritance` supports dunder convention
+    for nested fields.
+
+    Example:
+    class Restaurant(models.Model):
+        city = models.ForeignKey(City)
+
+        custom_fields = CustomFieldsWithInheritanceRelation(CustomFieldValue)
+        custom_fields_inheritance = ['city', 'city__country']
+    """
+    def contribute_to_class(self, cls, name, **kwargs):
+        super().contribute_to_class(cls, name, **kwargs)
+        # use ReverseGenericRelatedWithInheritanceObjectsDescriptor
+        # instead of ReverseGenericRelatedObjectsDescriptor
+        setattr(
+            cls,
+            self.name,
+            ReverseGenericRelatedWithInheritanceObjectsDescriptor(
+                self,
+                self.for_concrete_model
+            )
+        )
+
+
+class ReverseGenericRelatedWithInheritanceObjectsDescriptor(
+    ReverseGenericRelatedObjectsDescriptor
+):
+    def __get__(self, instance, instance_type=None):
+        """
+        Overwrite of ReverseGenericRelatedObjectsDescriptor's __get__
+
+        The only difference is calling another (custom) function to get
+        RelatedManager, which properly handles inheritance of custom fields
+        """
+        if instance is None:
+            return self
+        rel_model = self.field.rel.to
+        superclass = rel_model._default_manager.__class__
+        # difference here comparing to Django!
+        RelatedManager = create_generic_related_manager_with_iheritance(
+            superclass
+        )
+
+        qn = connection.ops.quote_name
+        content_type = ContentType.objects.db_manager(
+            instance._state.db
+        ).get_for_model(
+            instance, for_concrete_model=self.for_concrete_model)
+
+        join_cols = self.field.get_joining_columns(reverse_join=True)[0]
+        manager = RelatedManager(
+            model=rel_model,
+            instance=instance,
+            source_col_name=qn(join_cols[0]),
+            target_col_name=qn(join_cols[1]),
+            content_type=content_type,
+            content_type_field_name=self.field.content_type_field_name,
+            object_id_field_name=self.field.object_id_field_name,
+            prefetch_cache_name=self.field.attname,
+        )
+
+        return manager
+
+
+def create_generic_related_manager_with_iheritance(superclass):  # noqa: C901
+    """
+    Extension to Django's create_generic_related_manager.
+
+    Differences:
+    * overwrite `get_queryset` to properly handle fetching custom fields for
+    single object
+    * overwrite `get_prefetch_queryset` to properly prefetch custom fields
+    with inheritance  of more than one instance
+    """
+    # get Django's GenericRelatedObject manager first
+    manager = create_generic_related_manager(superclass)
+
+    class GenericRelatedObjectWithInheritanceManager(manager):
+        def __init__(self, *args, **kwargs):
+            super().__init__(*args, **kwargs)
+            # don't use filters for single content type and single object id,
+            # like in Django's GenericRelatedObject
+            self.core_filters = {}
+            # construct inheritance filters based on
+            # `custom_fields_inheritance` defined on model
+            self.inheritance_filters = [
+                self._get_inheritance_filters_for_single_instance()
+            ]
+
+        def _get_inheritance_filters_for_single_instance(self):
+            """
+            Return queryset filter for CustomFieldValue with inheritance for
+            single instance.
+
+            Final format of queryset will look similar to:
+            (Q(content_type_id=X) & Q(object_id=Y)) | (Q(content_type_id=A) & Q(object_id=B)) | ...  # noqa
+            """
+            inheritance_filters = [
+                # custom field of instance
+                models.Q(**{
+                    self.content_type_field_name: self.content_type.id
+                }) &
+                # object id of instance
+                models.Q(**{
+                    self.object_id_field_name: self.instance.id
+                })
+            ]
+            # for each related field (foreign key), add it's content_type
+            # and object_id to queryset filter
+            for field_path in self.instance.custom_fields_inheritance:
+                # TODO: add some validator for it
+                field = get_field_by_relation_path(self.instance, field_path)
+                content_type = ContentType.objects.get_for_model(field.rel.to)
+                value = getattr_dunder(self.instance, field_path)
+                # filter only if related field has some value
+                if value:
+                    inheritance_filters.append(
+                        models.Q(**{
+                            self.content_type_field_name: content_type.id
+                        }) &
+                        models.Q(**{
+                            self.object_id_field_name: value.pk
+                        })
+                    )
+            return reduce(operator.or_, inheritance_filters)
+
+        def _prioretitize_custom_field_values(self, qs):
+            """
+            Sort custom field values by priorities and leave the ones with
+            biggest priority for each custom field type.
+
+            Priority is defined as follows:
+            * the biggest priority has custom field defined directly for
+              instance
+            * then next priority has CFV from first field on
+              `custom_fields_inheritance` list, then second from this list and
+              so on
+            """
+            ct_priority = [self.content_type.id]
+            for field_path in self.instance.custom_fields_inheritance:
+                field = get_field_by_relation_path(self.instance, field_path)
+                content_type = ContentType.objects.get_for_model(field.rel.to)
+                ct_priority.append(content_type.id)
+            ct_priority = {
+                ct_id: index for (index, ct_id) in enumerate(ct_priority)
+            }
+            custom_fields_seen = set()
+            custom_fields_values_ids = set()
+            result = []
+            for cfv in sorted(
+                qs, key=lambda cfv: ct_priority[cfv.content_type_id]
+            ):
+                if cfv.custom_field_id in custom_fields_seen:
+                    continue
+                custom_fields_seen.add(cfv.custom_field_id)
+                custom_fields_values_ids.add(cfv.id)
+                result.append(cfv)
+            return custom_fields_values_ids, result
+
+        def get_queryset(self):
+            try:
+                return self.instance._prefetched_objects_cache[
+                    self.prefetch_cache_name
+                ]
+            except (AttributeError, KeyError):
+                super_qs = super().get_queryset()
+                qs = super_qs.filter(
+                    *self.inheritance_filters
+                )
+                custom_field_values_ids = (
+                    self._prioretitize_custom_field_values(qs)[0]
+                )
+                return super_qs.filter(pk__in=custom_field_values_ids)
+
+        def get_prefetch_queryset(self, instances, queryset=None):
+            """
+            Prefetch custom fields with inheritance of values for multiple
+            instances.
+
+            This implementation is one-big-workaround for Django's handling of
+            prefetch_related (especially in
+            django.db.models.query:prefetch_one_level)
+            """
+            if queryset is None:
+                queryset = super().get_queryset()
+
+            queryset._add_hints(instance=instances[0])
+            queryset = queryset.using(queryset._db or self._db)
+            content_type = ContentType.objects.get_for_model(
+                instances[0]
+            )
+            # store possible content types of CustomFieldValue
+            content_types = set([content_type])
+            # store possible values of object id
+            objects_ids = set()
+            # mapping from instance id to content_type and object id of
+            # dependent fields for inheritance
+            instances_cfs = defaultdict(set)
+            # process every instance (no inheritance here right now)
+            for instance in instances:
+                objects_ids.add(instance.pk)
+                instances_cfs[instance.pk].add((content_type.pk, instance.pk))
+            # process each dependent field from `custom_fields_inheritance`
+            for field_path in self.instance.custom_fields_inheritance:
+                # assume that field is foreign key
+                field = get_field_by_relation_path(self.instance, field_path)
+                content_type = ContentType.objects.get_for_model(field.rel.to)
+                content_types.add(content_type)
+                # for each instance, get value of this dependent field
+                for instance in instances:
+                    value = getattr_dunder(instance, field_path)
+                    if value:
+                        objects_ids.add(value.pk)
+                        # store mapping from instance to content type and value
+                        # of dependent field to know, which CustomFieldValue
+                        # assign later to instance
+                        instances_cfs[instance.pk].add(
+                            (content_type.pk, value.pk)
+                        )
+
+            # filter by possible content types and objects ids
+            # notice that thus this filter is not perfect (filter separately
+            # for content types and for objects ids, without correlation
+            # between particular content type and value), this simplify
+            # (and speedup) query
+            # alternative solution is to do something similar to fetching
+            # custom fields for single instance: correlate content type with
+            # possible values for this single content type, for example:
+            # (Q(content_type_id=A) & Q(object_id__in=[B, C, D])) | (Q(content_type_id=X) & Q(object_id__in=[Y, Z])) | ... # noqa
+            query = {
+                '%s__in' % self.content_type_field_name: content_types,
+                '%s__in' % self.object_id_field_name: set(objects_ids)
+            }
+
+            qs = list(queryset.filter(**query))
+
+            # this fragment of code (at least similar one) is normally done in
+            # Django's `prefetch_one_level`, but it does NOT handle M2M case
+            # (that single prefetched object (in this case CustomFieldValue)
+            # could be assigned to multiple instances - it works only with
+            # many-to-one case)
+
+            # mapping from content_type and object_id to `CustomFieldValue`s
+            rel_obj_cache = defaultdict(list)
+            for rel_obj in qs:
+                rel_obj_cache[
+                    (rel_obj.content_type_id, rel_obj.object_id)
+                ].append(
+                    rel_obj
+                )
+
+            # for each instance reconstruct it's CustomFieldValues
+            # using `instances_cfs` mapping (from instance pk to content_type
+            # and object_id of possible CustomFieldValue)
+            for obj in instances:
+                vals = []
+                # fetch `CustomFieldsValue`s for this instance - use mapping
+                # from instance pk to content type id and object id of it's
+                # dependent fields
+                for content_type_id, obj_id in instances_cfs[obj.id]:
+                    try:
+                        vals.extend(rel_obj_cache[
+                            (content_type_id, obj_id)
+                        ])
+                    except KeyError:
+                        # ignore if there is no CustomFieldValue for such
+                        # content_type_id and object_id
+                        pass
+
+                vals = self._prioretitize_custom_field_values(vals)[1]
+
+                # store `CustomFieldValue`s of instance in cache
+                instance_custom_fields_queryset = getattr(
+                    obj, 'custom_fields'
+                ).all()
+                instance_custom_fields_queryset._result_cache = vals
+                instance_custom_fields_queryset._prefetch_done = True
+                obj._prefetched_objects_cache[
+                    self.prefetch_cache_name
+                ] = instance_custom_fields_queryset
+
+            # main "hack" for Django - since all querysets are already
+            # prefetched, `prefetch_one_level` has nothing to do, thus
+            # `rel_obj_attr` and `instance_attr` (second and third item)
+            # returns constant value, to not assign it to any object.
+            return (
+                qs,
+                lambda relobj: None,
+                lambda obj: -1,
+                # most important part of this workaround - return single=True,
+                # to force `prefetch_one_level` to just do setattr to instance
+                # under returned cache_name (suffixed with '__empty' below)
+                True,
+                # cache_name is also changed to not assign empty result
+                # to `custom_fields` (and overwrite prefetched custom fields
+                # assigned above)
+                self.prefetch_cache_name + '__empty'
+            )
+
+    return GenericRelatedObjectWithInheritanceManager

--- a/src/ralph/lib/custom_fields/fields.py
+++ b/src/ralph/lib/custom_fields/fields.py
@@ -44,7 +44,7 @@ class CustomFieldsWithInheritanceRelation(GenericRelation):
         )
 
 
-def _prioretitize_custom_field_values(objects, model, content_type):
+def _prioritize_custom_field_values(objects, model, content_type):
     """
     Sort custom field values by priorities and leave the ones with
     biggest priority for each custom field type.
@@ -81,24 +81,24 @@ def _prioretitize_custom_field_values(objects, model, content_type):
 class CustomFieldValueQuerySet(models.QuerySet):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self._prioretitize = False
-        self._prioretitize_model_or_instance = None
+        self._prioritize = False
+        self._prioritize_model_or_instance = None
 
-    def prioretitize(self, model_or_instance):
-        self._prioretitize = True
-        self._prioretitize_model_or_instance = model_or_instance
+    def prioritize(self, model_or_instance):
+        self._prioritize = True
+        self._prioritize_model_or_instance = model_or_instance
         return self
 
     def iterator(self):
-        if self._prioretitize:
+        if self._prioritize:
             # set if to False to not fall into recursion when calling
-            # `_prioretitize_custom_field_values`
-            self._prioretitize = False
-            for cfv_id, cfv in _prioretitize_custom_field_values(
+            # `_prioritize_custom_field_values`
+            self._prioritize = False
+            for cfv_id, cfv in _prioritize_custom_field_values(
                 self,
-                self._prioretitize_model_or_instance,
+                self._prioritize_model_or_instance,
                 ContentType.objects.get_for_model(
-                    self._prioretitize_model_or_instance
+                    self._prioritize_model_or_instance
                 )
             ):
                 yield cfv
@@ -121,7 +121,7 @@ class ReverseGenericRelatedWithInheritanceObjectsDescriptor(
         rel_model = self.field.rel.to
         # difference here comparing to Django!
         superclass = rel_model.inherited_objects.__class__
-        RelatedManager = create_generic_related_manager_with_iheritance(
+        RelatedManager = create_generic_related_manager_with_inheritance(
             superclass
         )
 
@@ -146,7 +146,7 @@ class ReverseGenericRelatedWithInheritanceObjectsDescriptor(
         return manager
 
 
-def create_generic_related_manager_with_iheritance(superclass):  # noqa: C901
+def create_generic_related_manager_with_inheritance(superclass):  # noqa: C901
     """
     Extension to Django's create_generic_related_manager.
 
@@ -218,7 +218,7 @@ def create_generic_related_manager_with_iheritance(superclass):  # noqa: C901
             except (AttributeError, KeyError):
                 return super().get_queryset().filter(
                     *self.inheritance_filters
-                ).prioretitize(self.instance)
+                ).prioritize(self.instance)
 
         def get_prefetch_queryset(self, instances, queryset=None):
             """
@@ -318,7 +318,7 @@ def create_generic_related_manager_with_iheritance(superclass):  # noqa: C901
                         pass
 
                 vals = [
-                    v[1] for v in _prioretitize_custom_field_values(
+                    v[1] for v in _prioritize_custom_field_values(
                         vals, self.instance, self.content_type
                     )
                 ]

--- a/src/ralph/lib/custom_fields/fields.py
+++ b/src/ralph/lib/custom_fields/fields.py
@@ -32,12 +32,12 @@ class CustomFieldsWithInheritanceRelation(GenericRelation):
     """
     def contribute_to_class(self, cls, name, **kwargs):
         super().contribute_to_class(cls, name, **kwargs)
-        # use ReverseGenericRelatedWithInheritanceObjectsDescriptor
+        # use ReverseGenericRelatedObjectsWithInheritanceDescriptor
         # instead of ReverseGenericRelatedObjectsDescriptor
         setattr(
             cls,
             self.name,
-            ReverseGenericRelatedWithInheritanceObjectsDescriptor(
+            ReverseGenericRelatedObjectsWithInheritanceDescriptor(
                 self,
                 self.for_concrete_model
             )
@@ -106,7 +106,7 @@ class CustomFieldValueQuerySet(models.QuerySet):
         yield from super().iterator()
 
 
-class ReverseGenericRelatedWithInheritanceObjectsDescriptor(
+class ReverseGenericRelatedObjectsWithInheritanceDescriptor(
     ReverseGenericRelatedObjectsDescriptor
 ):
     def __get__(self, instance, instance_type=None):

--- a/src/ralph/lib/custom_fields/fields.py
+++ b/src/ralph/lib/custom_fields/fields.py
@@ -29,6 +29,17 @@ class CustomFieldsWithInheritanceRelation(GenericRelation):
 
         custom_fields = CustomFieldsWithInheritanceRelation(CustomFieldValue)
         custom_fields_inheritance = ['city', 'city__country']
+
+    The priority of inheritance is as follows:
+    * the `CustomFieldValue`s (CFVs) set directyl on object has the highest
+      priority
+    * then CFVs set on first field on `custom_fields_inheritance` list,
+      then on second field on that list and so on
+
+    For the example above the priority is as follows:
+    * restaurant (highest)
+    * restaurant.city
+    * restaurant.city.country (lowest)
     """
     def contribute_to_class(self, cls, name, **kwargs):
         super().contribute_to_class(cls, name, **kwargs)
@@ -65,16 +76,12 @@ def _prioritize_custom_field_values(objects, model, content_type):
         ct_id: index for (index, ct_id) in enumerate(ct_priority)
     }
     custom_fields_seen = set()
-    custom_fields_values_ids = set()
-    result = []
     for cfv in sorted(
         objects, key=lambda cfv: ct_priority[cfv.content_type_id]
     ):
         if cfv.custom_field_id in custom_fields_seen:
             continue
         custom_fields_seen.add(cfv.custom_field_id)
-        custom_fields_values_ids.add(cfv.id)
-        result.append(cfv)
         yield cfv.id, cfv
 
 

--- a/src/ralph/lib/custom_fields/models.py
+++ b/src/ralph/lib/custom_fields/models.py
@@ -1,24 +1,17 @@
-import operator
 import six
-from collections import defaultdict
-from functools import reduce
 
 from dj.choices import Choices
 from django import forms
 from django.contrib.contenttypes import generic
-from django.contrib.contenttypes.fields import (
-    create_generic_related_manager,
-    GenericRelation,
-    ReverseGenericRelatedObjectsDescriptor
-)
+
 from django.contrib.contenttypes.models import ContentType
 from django.core.exceptions import ValidationError
-from django.db import connection, models
+from django.db import models
 from django.utils.text import capfirst, slugify
 from django.utils.translation import ugettext_lazy as _
 
-from ralph.admin.helpers import get_field_by_relation_path, getattr_dunder
 from ralph.lib.mixins.models import AdminAbsoluteUrlMixin, TimeStampMixin
+from .fields import CustomFieldsWithInheritanceRelation
 
 CUSTOM_FIELD_VALUE_MAX_LENGTH = 1000
 
@@ -171,164 +164,6 @@ class CustomFieldValue(TimeStampMixin, models.Model):
         if self.custom_field_id:
             self.custom_field.get_form_field().clean(self.value)
         super().clean()
-
-
-class CustomFieldsWithInheritanceRelation(GenericRelation):
-    def contribute_to_class(self, cls, name, **kwargs):
-        super(GenericRelation, self).contribute_to_class(cls, name, **kwargs)
-        setattr(
-            cls,
-            self.name,
-            ReverseGenericRelatedWithInheritanceObjectsDescriptor(
-                self,
-                self.for_concrete_model
-            )
-        )
-
-
-class ReverseGenericRelatedWithInheritanceObjectsDescriptor(
-    ReverseGenericRelatedObjectsDescriptor
-):
-    def __get__(self, instance, instance_type=None):
-        if instance is None:
-            return self
-
-        # Dynamically create a class that subclasses the related model's
-        # default manager.
-        rel_model = self.field.rel.to
-        superclass = rel_model._default_manager.__class__
-        # diff!
-        RelatedManager = create_generic_related_manager_with_iheritance(
-            superclass
-        )
-
-        qn = connection.ops.quote_name
-        content_type = ContentType.objects.db_manager(instance._state.db).get_for_model(
-            instance, for_concrete_model=self.for_concrete_model)
-
-        join_cols = self.field.get_joining_columns(reverse_join=True)[0]
-        manager = RelatedManager(
-            model=rel_model,
-            instance=instance,
-            source_col_name=qn(join_cols[0]),
-            target_col_name=qn(join_cols[1]),
-            content_type=content_type,
-            content_type_field_name=self.field.content_type_field_name,
-            object_id_field_name=self.field.object_id_field_name,
-            prefetch_cache_name=self.field.attname,
-        )
-
-        return manager
-
-
-def create_generic_related_manager_with_iheritance(superclass):
-    manager = create_generic_related_manager(superclass)
-
-    class GenericRelatedObjectWithInheritanceManager(manager):
-        def __init__(self, *args, **kwargs):
-            super().__init__(*args, **kwargs)
-            self.core_filters = {}
-            self.inheritance_filters = [self._get_inheritance_filters()]
-
-        def _get_inheritance_filters(self):
-            inheritance_filters = [
-                models.Q(**{
-                    self.content_type_field_name: self.content_type.id
-                }) &
-                models.Q(**{
-                    self.object_id_field_name: self.instance.id
-                })
-            ]
-            for field_path in self.instance.custom_fields_inheritance:
-                # assume that field is foreign key
-                # TODO: add some validator for it
-                field = get_field_by_relation_path(self.instance, field_path)
-                content_type = ContentType.objects.get_for_model(field.rel.to)
-                value = getattr_dunder(self.instance, field_path)
-                if value:
-                    inheritance_filters.append(
-                        models.Q(**{
-                            self.content_type_field_name: content_type.id
-                        }) &
-                        models.Q(**{
-                            self.object_id_field_name: value.pk
-                        })
-                    )
-            return reduce(operator.or_, inheritance_filters)
-
-        def get_queryset(self):
-            try:
-                return self.instance._prefetched_objects_cache[
-                    self.prefetch_cache_name
-                ]
-            except (AttributeError, KeyError):
-                return super().get_queryset().filter(
-                    *self.inheritance_filters
-                )
-
-        def get_prefetch_queryset(self, instances, queryset=None):
-            if queryset is None:
-                queryset = super().get_queryset()
-
-            queryset._add_hints(instance=instances[0])
-            queryset = queryset.using(queryset._db or self._db)
-            content_type = ContentType.objects.get_for_model(
-                instances[0]
-            )
-            content_types = set([content_type])
-            values = set()
-            instances_cfs = defaultdict(set)
-            for instance in instances:
-                values.add(instance.pk)
-                instances_cfs[instance.pk].add((content_type.pk, instance.pk))
-            for field_path in self.instance.custom_fields_inheritance:
-                # assume that field is foreign key
-                # TODO: add some validator for it
-                field = get_field_by_relation_path(self.instance, field_path)
-                content_type = ContentType.objects.get_for_model(field.rel.to)
-                content_types.add(content_type)
-                for instance in instances:
-                    value = getattr_dunder(instance, field_path)
-                    if value:
-                        values.add(value.pk)
-                        instances_cfs[instance.pk].add(
-                            (content_type.pk, value.pk)
-                        )
-
-            # not perfect
-            query = {
-                '%s__in' % self.content_type_field_name: content_types,
-                '%s__in' % self.object_id_field_name: set(values)
-            }
-
-            qs = list(queryset.filter(**query))
-            rel_obj_cache = {}
-            for rel_obj in qs:
-                rel_obj_cache[(rel_obj.content_type_id, rel_obj.object_id)] = rel_obj
-
-            for obj in instances:
-                vals = []
-                for rel_obj_ct_id, rel_obj_id in instances_cfs[obj.id]:
-                    try:
-                        vals.append(rel_obj_cache[(rel_obj_ct_id, rel_obj_id)])
-                    except KeyError:
-                        pass
-
-                obj_qs = getattr(obj, 'custom_fields').all()
-                obj_qs._result_cache = vals
-                # We don't want the individual obj_qs doing prefetch_related now,
-                # since we have merged this into the current work.
-                obj_qs._prefetch_done = True
-                obj._prefetched_objects_cache[self.prefetch_cache_name] = obj_qs
-            return (
-                qs,
-                lambda relobj: None,
-                lambda obj: -1,
-                True,
-                self.prefetch_cache_name + '__empty'
-            )
-
-    return GenericRelatedObjectWithInheritanceManager
 
 
 class WithCustomFieldsMixin(models.Model):

--- a/src/ralph/lib/custom_fields/models.py
+++ b/src/ralph/lib/custom_fields/models.py
@@ -11,7 +11,10 @@ from django.utils.text import capfirst, slugify
 from django.utils.translation import ugettext_lazy as _
 
 from ralph.lib.mixins.models import AdminAbsoluteUrlMixin, TimeStampMixin
-from .fields import CustomFieldsWithInheritanceRelation
+from .fields import (
+    CustomFieldsWithInheritanceRelation,
+    CustomFieldValueQuerySet
+)
 
 CUSTOM_FIELD_VALUE_MAX_LENGTH = 1000
 
@@ -117,6 +120,11 @@ class CustomFieldValue(TimeStampMixin, models.Model):
     content_type = models.ForeignKey(ContentType)
     object_id = models.PositiveIntegerField(db_index=True)
     object = generic.GenericForeignKey('content_type', 'object_id')
+
+    objects = models.Manager()
+    # generic relation has to use specific manager (queryset)
+    # which handle inheritance
+    inherited_objects = CustomFieldValueQuerySet.as_manager()
 
     class Meta:
         unique_together = ('custom_field', 'content_type', 'object_id')

--- a/src/ralph/lib/custom_fields/models.py
+++ b/src/ralph/lib/custom_fields/models.py
@@ -1,15 +1,23 @@
+import operator
 import six
+from collections import defaultdict
+from functools import reduce
 
 from dj.choices import Choices
 from django import forms
 from django.contrib.contenttypes import generic
-from django.contrib.contenttypes.fields import GenericRelation
+from django.contrib.contenttypes.fields import (
+    create_generic_related_manager,
+    GenericRelation,
+    ReverseGenericRelatedObjectsDescriptor
+)
 from django.contrib.contenttypes.models import ContentType
 from django.core.exceptions import ValidationError
-from django.db import models
+from django.db import connection, models
 from django.utils.text import capfirst, slugify
 from django.utils.translation import ugettext_lazy as _
 
+from ralph.admin.helpers import get_field_by_relation_path, getattr_dunder
 from ralph.lib.mixins.models import AdminAbsoluteUrlMixin, TimeStampMixin
 
 CUSTOM_FIELD_VALUE_MAX_LENGTH = 1000
@@ -165,9 +173,168 @@ class CustomFieldValue(TimeStampMixin, models.Model):
         super().clean()
 
 
+class CustomFieldsWithInheritanceRelation(GenericRelation):
+    def contribute_to_class(self, cls, name, **kwargs):
+        super(GenericRelation, self).contribute_to_class(cls, name, **kwargs)
+        setattr(
+            cls,
+            self.name,
+            ReverseGenericRelatedWithInheritanceObjectsDescriptor(
+                self,
+                self.for_concrete_model
+            )
+        )
+
+
+class ReverseGenericRelatedWithInheritanceObjectsDescriptor(
+    ReverseGenericRelatedObjectsDescriptor
+):
+    def __get__(self, instance, instance_type=None):
+        if instance is None:
+            return self
+
+        # Dynamically create a class that subclasses the related model's
+        # default manager.
+        rel_model = self.field.rel.to
+        superclass = rel_model._default_manager.__class__
+        # diff!
+        RelatedManager = create_generic_related_manager_with_iheritance(
+            superclass
+        )
+
+        qn = connection.ops.quote_name
+        content_type = ContentType.objects.db_manager(instance._state.db).get_for_model(
+            instance, for_concrete_model=self.for_concrete_model)
+
+        join_cols = self.field.get_joining_columns(reverse_join=True)[0]
+        manager = RelatedManager(
+            model=rel_model,
+            instance=instance,
+            source_col_name=qn(join_cols[0]),
+            target_col_name=qn(join_cols[1]),
+            content_type=content_type,
+            content_type_field_name=self.field.content_type_field_name,
+            object_id_field_name=self.field.object_id_field_name,
+            prefetch_cache_name=self.field.attname,
+        )
+
+        return manager
+
+
+def create_generic_related_manager_with_iheritance(superclass):
+    manager = create_generic_related_manager(superclass)
+
+    class GenericRelatedObjectWithInheritanceManager(manager):
+        def __init__(self, *args, **kwargs):
+            super().__init__(*args, **kwargs)
+            self.core_filters = {}
+            self.inheritance_filters = [self._get_inheritance_filters()]
+
+        def _get_inheritance_filters(self):
+            inheritance_filters = [
+                models.Q(**{
+                    self.content_type_field_name: self.content_type.id
+                }) &
+                models.Q(**{
+                    self.object_id_field_name: self.instance.id
+                })
+            ]
+            for field_path in self.instance.custom_fields_inheritance:
+                # assume that field is foreign key
+                # TODO: add some validator for it
+                field = get_field_by_relation_path(self.instance, field_path)
+                content_type = ContentType.objects.get_for_model(field.rel.to)
+                value = getattr_dunder(self.instance, field_path)
+                if value:
+                    inheritance_filters.append(
+                        models.Q(**{
+                            self.content_type_field_name: content_type.id
+                        }) &
+                        models.Q(**{
+                            self.object_id_field_name: value.pk
+                        })
+                    )
+            return reduce(operator.or_, inheritance_filters)
+
+        def get_queryset(self):
+            try:
+                return self.instance._prefetched_objects_cache[
+                    self.prefetch_cache_name
+                ]
+            except (AttributeError, KeyError):
+                return super().get_queryset().filter(
+                    *self.inheritance_filters
+                )
+
+        def get_prefetch_queryset(self, instances, queryset=None):
+            if queryset is None:
+                queryset = super().get_queryset()
+
+            queryset._add_hints(instance=instances[0])
+            queryset = queryset.using(queryset._db or self._db)
+            content_type = ContentType.objects.get_for_model(
+                instances[0]
+            )
+            content_types = set([content_type])
+            values = set()
+            instances_cfs = defaultdict(set)
+            for instance in instances:
+                values.add(instance.pk)
+                instances_cfs[instance.pk].add((content_type.pk, instance.pk))
+            for field_path in self.instance.custom_fields_inheritance:
+                # assume that field is foreign key
+                # TODO: add some validator for it
+                field = get_field_by_relation_path(self.instance, field_path)
+                content_type = ContentType.objects.get_for_model(field.rel.to)
+                content_types.add(content_type)
+                for instance in instances:
+                    value = getattr_dunder(instance, field_path)
+                    if value:
+                        values.add(value.pk)
+                        instances_cfs[instance.pk].add(
+                            (content_type.pk, value.pk)
+                        )
+
+            # not perfect
+            query = {
+                '%s__in' % self.content_type_field_name: content_types,
+                '%s__in' % self.object_id_field_name: set(values)
+            }
+
+            qs = list(queryset.filter(**query))
+            rel_obj_cache = {}
+            for rel_obj in qs:
+                rel_obj_cache[(rel_obj.content_type_id, rel_obj.object_id)] = rel_obj
+
+            for obj in instances:
+                vals = []
+                for rel_obj_ct_id, rel_obj_id in instances_cfs[obj.id]:
+                    try:
+                        vals.append(rel_obj_cache[(rel_obj_ct_id, rel_obj_id)])
+                    except KeyError:
+                        pass
+
+                obj_qs = getattr(obj, 'custom_fields').all()
+                obj_qs._result_cache = vals
+                # We don't want the individual obj_qs doing prefetch_related now,
+                # since we have merged this into the current work.
+                obj_qs._prefetch_done = True
+                obj._prefetched_objects_cache[self.prefetch_cache_name] = obj_qs
+            return (
+                qs,
+                lambda relobj: None,
+                lambda obj: -1,
+                True,
+                self.prefetch_cache_name + '__empty'
+            )
+
+    return GenericRelatedObjectWithInheritanceManager
+
+
 class WithCustomFieldsMixin(models.Model):
     # TODO: handle polymorphic in filters
-    custom_fields = GenericRelation(CustomFieldValue)
+    custom_fields = CustomFieldsWithInheritanceRelation(CustomFieldValue)
+    custom_fields_inheritance = []
 
     class Meta:
         abstract = True

--- a/src/ralph/lib/custom_fields/tests/api.py
+++ b/src/ralph/lib/custom_fields/tests/api.py
@@ -14,10 +14,11 @@ class SomeModelSerializer(
 ):
     class Meta:
         model = SomeModel
+        fields = ('id', 'custom_fields', 'configuration_variables')
 
 
 class SomeModelViewset(viewsets.ModelViewSet):
-    queryset = SomeModel.objects.all()
+    queryset = SomeModel.objects.prefetch_related('custom_fields')
     serializer_class = SomeModelSerializer
     filter_backends = (
         viewsets.ModelViewSet.filter_backends + [CustomFieldsFilterBackend]

--- a/src/ralph/lib/custom_fields/tests/migrations/0002_auto_20170113_1019.py
+++ b/src/ralph/lib/custom_fields/tests/migrations/0002_auto_20170113_1019.py
@@ -1,0 +1,38 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('custom_fields_tests', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='ModelA',
+            fields=[
+                ('id', models.AutoField(verbose_name='ID', serialize=False, primary_key=True, auto_created=True)),
+            ],
+            options={
+                'abstract': False,
+            },
+        ),
+        migrations.CreateModel(
+            name='ModelB',
+            fields=[
+                ('id', models.AutoField(verbose_name='ID', serialize=False, primary_key=True, auto_created=True)),
+                ('a', models.ForeignKey(to='custom_fields_tests.ModelA')),
+            ],
+            options={
+                'abstract': False,
+            },
+        ),
+        migrations.AddField(
+            model_name='somemodel',
+            name='b',
+            field=models.ForeignKey(to='custom_fields_tests.ModelB', null=True, blank=True),
+        ),
+    ]

--- a/src/ralph/lib/custom_fields/tests/models.py
+++ b/src/ralph/lib/custom_fields/tests/models.py
@@ -5,8 +5,18 @@ from django.db import models
 from ..models import WithCustomFieldsMixin
 
 
+class ModelA(WithCustomFieldsMixin, models.Model):
+    pass
+
+
+class ModelB(WithCustomFieldsMixin, models.Model):
+    a = models.ForeignKey(ModelA, null=False)
+
+
 class SomeModel(WithCustomFieldsMixin, models.Model):
     name = models.CharField(max_length=20)
+    b = models.ForeignKey(ModelB, null=True, blank=True)
+    custom_fields_inheritance = ['b', 'b__a']
 
     def get_absolute_url(self):
         return reverse(

--- a/src/ralph/lib/custom_fields/tests/test_admin.py
+++ b/src/ralph/lib/custom_fields/tests/test_admin.py
@@ -108,8 +108,8 @@ class CustomFieldValueAdminMaxinTestCase(TestCase):
         }
         data.update(self._prepare_inline_data(data_custom_fields))
         response = self.client.post(SomeModel.get_add_url(), data)
-        sm = SomeModel.objects.get(name='qwerty')
         self.assertEqual(response.status_code, 302)
+        sm = SomeModel.objects.get(name='qwerty')
         self.assertEqual(CustomFieldValue.objects.filter(
             object_id=sm.id,
             content_type=ContentType.objects.get_for_model(SomeModel),

--- a/src/ralph/lib/custom_fields/tests/test_models.py
+++ b/src/ralph/lib/custom_fields/tests/test_models.py
@@ -60,10 +60,10 @@ class CustomFieldModelsTestCase(TestCase):
             {field_name: new_value}, self.sm1.custom_fields_as_dict
         )
 
-    def test_should_custom_fields_as_dict_run_2_queries(self):
+    def test_should_custom_fields_as_dict_run_1_query(self):
         self.sm1.update_custom_field(name='test_str', value='new_value')
         self.sm1.update_custom_field(name='test_choices', value='qwerty')
-        with self.assertNumQueries(2):
+        with self.assertNumQueries(1):
             self.sm1.custom_fields_as_dict
 
 


### PR DESCRIPTION
First version of inheritance for custom fields.

How it works? Just specify `custom_fields_inheritance` on your model (which is using custom fields) with path to fields (foreign keys) from which you want to inherit custom fields values. This path supports Django dunder (__) convention.

Example:
```
custom_fields_inheritance = [
    'configuration_path',
    'configuration_path__module',
    'service_env',
]
```

Priority of custom fields is defined as follows:
* the biggest priority has custom field defined directly for instance
* then next priority has CFV from first field on `custom_fields_inheritance` list, then second from this list and so on

This is first (simple) version of inheritance - it's visible only in API. In the next version (PR) I'll make it visible in GUI as well.