### PR TITLE
Set RU order direction per rack on rack diagrams

### DIFF
--- a/src/ralph/data_center/admin.py
+++ b/src/ralph/data_center/admin.py
@@ -454,7 +454,12 @@ class RackAccessoryInline(RalphTabularInline):
 class RackAdmin(RalphAdmin):
 
     exclude = ['accessories']
-    list_display = ['name', 'server_room_name', 'data_center_name', 'reverse_ordering']
+    list_display = [
+        'name',
+        'server_room_name',
+        'data_center_name',
+        'reverse_ordering',
+    ]
     list_filter = ['server_room__data_center']  # TODO use fk field in filter
     list_select_related = ['server_room', 'server_room__data_center']
     search_fields = ['name']

--- a/src/ralph/data_center/admin.py
+++ b/src/ralph/data_center/admin.py
@@ -454,7 +454,7 @@ class RackAccessoryInline(RalphTabularInline):
 class RackAdmin(RalphAdmin):
 
     exclude = ['accessories']
-    list_display = ['name', 'server_room_name', 'data_center_name']
+    list_display = ['name', 'server_room_name', 'data_center_name', 'reverse_ordering']
     list_filter = ['server_room__data_center']  # TODO use fk field in filter
     list_select_related = ['server_room', 'server_room__data_center']
     search_fields = ['name']

--- a/src/ralph/data_center/migrations/0023_rack_reverse_ordering.py
+++ b/src/ralph/data_center/migrations/0023_rack_reverse_ordering.py
@@ -2,7 +2,6 @@
 from __future__ import unicode_literals
 
 from django.db import migrations, models
-from django.conf import settings
 
 
 class Migration(migrations.Migration):
@@ -15,6 +14,14 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name='rack',
             name='reverse_ordering',
-            field=models.BooleanField(help_text='Check if RU starts counting from top to bottom. Unchecked rack diagrams will start counting with 1 at the bottom', verbose_name='RU order top to bottom', default=settings.RACK_LISTING_NUMBERING_TOP_TO_BOTTOM),
+            field=models.BooleanField(
+                help_text=(
+                    'Check if RU numbers count from top to bottom with '
+                    'position 1 starting at the top of the rack. If '
+                    'unchecked position 1is at the bottom of the rack'
+                ),
+                default=False,
+                verbose_name='RU order top to bottom',
+            ),
         ),
     ]

--- a/src/ralph/data_center/migrations/0023_rack_reverse_ordering.py
+++ b/src/ralph/data_center/migrations/0023_rack_reverse_ordering.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+from django.conf import settings
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('data_center', '0022_auto_20161206_1521'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='rack',
+            name='reverse_ordering',
+            field=models.BooleanField(help_text='Check if RU starts counting from top to bottom. Unchecked rack diagrams will start counting with 1 at the bottom', verbose_name='RU order top to bottom', default=settings.RACK_LISTING_NUMBERING_TOP_TO_BOTTOM),
+        ),
+    ]

--- a/src/ralph/data_center/migrations/0023_rack_reverse_ordering.py
+++ b/src/ralph/data_center/migrations/0023_rack_reverse_ordering.py
@@ -2,6 +2,7 @@
 from __future__ import unicode_literals
 
 from django.db import migrations, models
+from django.conf import settings
 
 
 class Migration(migrations.Migration):
@@ -15,12 +16,11 @@ class Migration(migrations.Migration):
             model_name='rack',
             name='reverse_ordering',
             field=models.BooleanField(
-                help_text=(
-                    'Check if RU numbers count from top to bottom with '
-                    'position 1 starting at the top of the rack. If '
-                    'unchecked position 1is at the bottom of the rack'
+                help_text=('Check if RU numbers count from top to bottom with '
+                           'position 1 starting at the top of the rack. If '
+                           'unchecked position 1 is at the bottom of the rack'
                 ),
-                default=False,
+                default=settings.RACK_LISTING_NUMBERING_TOP_TO_BOTTOM,
                 verbose_name='RU order top to bottom',
             ),
         ),

--- a/src/ralph/data_center/models/physical.py
+++ b/src/ralph/data_center/models/physical.py
@@ -224,7 +224,7 @@ class Rack(AdminAbsoluteUrlMixin, NamedMixin.NonUnique, models.Model):
         )
     )
     reverse_ordering = models.BooleanField(
-        default=False,
+        default=settings.RACK_LISTING_NUMBERING_TOP_TO_BOTTOM,
         help_text=_('Check if RU starts counting from top to bottom. Unchecked rack diagrams will start counting with 1 at the bottom'),
         verbose_name=_('RU order top to bottom'),
     )

--- a/src/ralph/data_center/models/physical.py
+++ b/src/ralph/data_center/models/physical.py
@@ -223,6 +223,11 @@ class Rack(AdminAbsoluteUrlMixin, NamedMixin.NonUnique, models.Model):
             'has warehouse-kind role'
         )
     )
+    reverse_ordering = models.BooleanField(
+        default=False,
+        help_text=_('Check if RU starts counting from top to bottom. Unchecked rack diagrams will start counting with 1 at the bottom'),
+        verbose_name=_('RU order top to bottom'),
+    )
 
     class Meta:
         unique_together = ('name', 'server_room')

--- a/src/ralph/data_center/models/physical.py
+++ b/src/ralph/data_center/models/physical.py
@@ -225,7 +225,11 @@ class Rack(AdminAbsoluteUrlMixin, NamedMixin.NonUnique, models.Model):
     )
     reverse_ordering = models.BooleanField(
         default=settings.RACK_LISTING_NUMBERING_TOP_TO_BOTTOM,
-        help_text=_('Check if RU starts counting from top to bottom. Unchecked rack diagrams will start counting with 1 at the bottom'),
+        help_text=_(
+            'Check if RU numbers count from top to bottom with position 1 '
+            'starting at the top of the rack. If unchecked position 1 is '
+            'at the bottom of the rack'
+        ),
         verbose_name=_('RU order top to bottom'),
     )
 

--- a/src/ralph/dc_view/serializers/models_serializer.py
+++ b/src/ralph/dc_view/serializers/models_serializer.py
@@ -138,7 +138,7 @@ class RackBaseSerializer(serializers.ModelSerializer):
         fields = (
             'id', 'name', 'server_room', 'max_u_height',
             'visualization_col', 'visualization_row', 'free_u', 'description',
-            'orientation'
+            'orientation', 'reverse_ordering'
         )
 
     def update(self, data):

--- a/src/ralph/dc_view/static/js/app/rack/directives.js
+++ b/src/ralph/dc_view/static/js/app/rack/directives.js
@@ -3,7 +3,7 @@
 
     angular
         .module('rack.directives', [])
-        .directive('rack', ['SETTINGS', function (SETTINGS) {
+        .directive('rack', function () {
             return {
                 restrict: 'E',
                 scope: {
@@ -14,7 +14,7 @@
                 },
                 templateUrl: '/static/partials/rack/rack.html',
             };
-        }])
+        })
         .directive('deviceItem', function () {
             return {
                 restrict: 'E',

--- a/src/ralph/dc_view/static/js/app/rack/directives.js
+++ b/src/ralph/dc_view/static/js/app/rack/directives.js
@@ -13,9 +13,6 @@
                     info: '='
                 },
                 templateUrl: '/static/partials/rack/rack.html',
-                link: function(scope) {
-                    scope.reverse_ordering = SETTINGS.RACK_LISTING_NUMBERING_TOP_TO_BOTTOM;
-                }
             };
         }])
         .directive('deviceItem', function () {

--- a/src/ralph/dc_view/static/partials/rack/rack.html
+++ b/src/ralph/dc_view/static/partials/rack/rack.html
@@ -3,16 +3,16 @@
         {{ info.name }}
     </div>
     <div class="wrapper">
-        <listing class="listing-u left" ng-class="{reverse: reverse_ordering}"></listing>
+        <listing class="listing-u left" ng-class="{reverse: info.reverse_ordering}"></listing>
         <div class="pdu left">
             <pdu-item pdu="item" ng-repeat="item in pdus|filter:{orientation:'left'}" style="order: {{ $index }}"></pdu-item>
         </div>
-        <div class="devices" ng-class="{reverse: reverse_ordering}">
+        <div class="devices" ng-class="{reverse: info.reverse_ordering}">
             <device-item device="item" side="side" ng-repeat="item in devices"></device-item>
         </div>
         <div class="pdu right">
             <pdu-item pdu="item" ng-repeat="item in pdus|filter:{orientation:'right'}" style="order: {{ $index }}"></pdu-item>
         </div>
-        <listing class="listing-u right" ng-class="{reverse: reverse_ordering}"></listing>
+        <listing class="listing-u right" ng-class="{reverse: info.reverse_ordering}"></listing>
     </div>
 </div>

--- a/src/ralph/dc_view/tests.py
+++ b/src/ralph/dc_view/tests.py
@@ -99,7 +99,8 @@ class TestRestAssetInfoPerRack(TestCase):
                 'free_u': self.rack_1.get_free_u(),
                 'description': '{}'.format(self.rack_1.description),
                 'orientation': '{}'.format(self.rack_1.get_orientation_desc()),
-                'rack_admin_url': self.rack_1.get_absolute_url()
+                'rack_admin_url': self.rack_1.get_absolute_url(),
+                'reverse_ordering': self.rack_1.reverse_ordering
             },
             'devices':
             [


### PR DESCRIPTION
This resolves #2930 and backwards compatible with instances using
SETTINGS.RACK_LISTING_NUMBERING_TOP_TO_BOTTOM