### PR TITLE
Signals on commit

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -11,6 +11,7 @@ django-rq==0.9.0
 django-taggit==0.17.1
 django-taggit-serializer==0.1.5
 django-threadlocals==0.8
+django-transaction-hooks==0.2  # it's merged to Django 1.9 - remove this when Django version will be bumped to 1.9
 djangorestframework==3.2.2
 djangorestframework_xml==1.2.0
 drf-nested-routers==0.11.1

--- a/src/ralph/data_center/forms.py
+++ b/src/ralph/data_center/forms.py
@@ -28,12 +28,7 @@ class DataCenterAssetForm(RalphAdminForm):
         obj = super().save(*args, **kwargs)
         # save object to enable creating ethernet (and link it to
         # DataCenterAsset)
-
-        # stop post save signal (especially hermes sync with ralph2)
-        # TODO: remove this when ralph2 sync will be removed
-        obj._handle_post_save = False
         obj.save()
-        del obj._handle_post_save
 
         if (
             not self.cleaned_data['management_hostname'] and

--- a/src/ralph/data_center/models/physical.py
+++ b/src/ralph/data_center/models/physical.py
@@ -5,6 +5,7 @@ from collections import namedtuple
 from itertools import chain
 
 from django import forms
+from django.conf import settings
 from django.core.exceptions import ValidationError
 from django.core.urlresolvers import reverse
 from django.core.validators import (

--- a/src/ralph/data_center/models/physical.py
+++ b/src/ralph/data_center/models/physical.py
@@ -5,7 +5,6 @@ from collections import namedtuple
 from itertools import chain
 
 from django import forms
-from django.conf import settings
 from django.core.exceptions import ValidationError
 from django.core.urlresolvers import reverse
 from django.core.validators import (
@@ -13,7 +12,7 @@ from django.core.validators import (
     MinValueValidator,
     RegexValidator
 )
-from django.db import models, transaction
+from django.db import connection, models, transaction
 from django.db.models import Q
 from django.db.models.signals import post_save
 from django.dispatch import receiver
@@ -37,6 +36,7 @@ from ralph.data_center.models.choices import (
     RackOrientation
 )
 from ralph.data_center.models.mixins import WithManagementIPMixin
+from ralph.data_center.publishers import publish_host_update
 from ralph.lib.mixins.models import AdminAbsoluteUrlMixin, PreviousStateMixin
 from ralph.lib.transitions.decorators import transition_action
 from ralph.lib.transitions.fields import TransitionField
@@ -763,12 +763,11 @@ class Connection(AdminAbsoluteUrlMixin, models.Model):
         )
 
 
-if settings.HERMES_HOST_UPDATE_TOPIC_NAME:
-    from ralph.data_center.publishers import publish_host_update
-
-    @receiver(post_save, sender=DataCenterAsset)
-    def post_save_dc_asset(sender, instance, **kwargs):
-        # temporary, until Ralph2 sync is turned on
-        # see ralph.ralph2_sync.admin for details
-        if getattr(instance, '_handle_post_save', True):
-            return publish_host_update(instance)
+@receiver(post_save, sender=DataCenterAsset)
+def post_save_dc_asset(sender, instance, **kwargs):
+    def publish_host_update_call():
+        publish_host_update(instance)
+    # subscribe to on_commit hook, then call publishing host update (when
+    # all M2M relations will be updated)
+    # TODO: replace connection by transaction after upgrading to Django 1.9
+    connection.on_commit(publish_host_update_call)

--- a/src/ralph/data_center/publishers.py
+++ b/src/ralph/data_center/publishers.py
@@ -25,10 +25,9 @@ def _get_host_data(instance):
     auto_publish_result=False
 )
 def publish_host_update(instance):
-    if (
-        settings.HERMES_HOST_UPDATE_TOPIC_NAME and
-        not getattr(instance, '_host_update_published', False)
-    ):
+    """
+    Publish TOOD
+    """
+    if settings.HERMES_HOST_UPDATE_TOPIC_NAME:
         host_data = _get_host_data(instance)
         publish(settings.HERMES_HOST_UPDATE_TOPIC_NAME, host_data)
-        instance._host_update_published = True

--- a/src/ralph/data_center/publishers.py
+++ b/src/ralph/data_center/publishers.py
@@ -1,9 +1,12 @@
 # -*- coding: utf-8 -*-
+import logging
 from copy import deepcopy
 
 import pyhermes
 from django.conf import settings
 from pyhermes.publishing import publish
+
+logger = logging.getLogger(__name__)
 
 
 def _get_host_data(instance):
@@ -29,6 +32,14 @@ def publish_host_update(instance):
     Publish information about DC Host updates using DCHost API serializer.
     """
     if settings.HERMES_HOST_UPDATE_TOPIC_NAME:
+        logger.info(
+            'Publishing host update for {}'.format(instance),
+            extra={
+                'type': 'PUBLISH_HOST_UPDATE',
+                'instance_id': instance.id,
+                'content_type': instance.content_type.name,
+            }
+        )
         host_data = _get_host_data(instance)
         # call publish directly to make testing easier
         publish(settings.HERMES_HOST_UPDATE_TOPIC_NAME, host_data)

--- a/src/ralph/data_center/publishers.py
+++ b/src/ralph/data_center/publishers.py
@@ -26,8 +26,9 @@ def _get_host_data(instance):
 )
 def publish_host_update(instance):
     """
-    Publish TOOD
+    Publish information about DC Host updates using DCHost API serializer.
     """
     if settings.HERMES_HOST_UPDATE_TOPIC_NAME:
         host_data = _get_host_data(instance)
+        # call publish directly to make testing easier
         publish(settings.HERMES_HOST_UPDATE_TOPIC_NAME, host_data)

--- a/src/ralph/data_center/tests/test_admin.py
+++ b/src/ralph/data_center/tests/test_admin.py
@@ -73,7 +73,7 @@ class DataCenterAssetAdminTest(TransactionTestCase):
             for (k, v) in d.items()
         }
 
-    def test_update_data_center_asset_check_mail_notifications(self):
+    def test_if_mail_notification_is_send_when_dca_is_updated_through_gui(self):
         old_service = ServiceFactory(name='test')
         new_service = ServiceFactory(name='prod')
         old_service.business_owners.add(UserFactory(email='test1@test.pl'))
@@ -110,7 +110,7 @@ class DataCenterAssetAdminTest(TransactionTestCase):
 
     @override_settings(HERMES_HOST_UPDATE_TOPIC_NAME='ralph.host_update')
     @mock.patch('ralph.data_center.publishers.publish')
-    def test_update_data_center_asset_check_publish_host_update(
+    def test_if_host_update_is_published_to_hermes_when_dca_is_updated_through_gui(  # noqa: E501
         self, publish_mock
     ):
         self.cfv1 = CustomFieldValue.objects.create(

--- a/src/ralph/data_center/tests/test_admin.py
+++ b/src/ralph/data_center/tests/test_admin.py
@@ -1,0 +1,199 @@
+from unittest import mock
+
+from django.contrib.auth import get_user_model
+from django.core import mail
+from django.db import connection, transaction
+from django.test import (
+    override_settings,
+    RequestFactory,
+    TestCase,
+    TransactionTestCase
+)
+
+from ralph.accounts.tests.factories import UserFactory
+from ralph.assets.tests.factories import (
+    ServiceEnvironmentFactory,
+    ServiceFactory
+)
+from ralph.data_center.models import DataCenterAsset
+from ralph.data_center.tests.factories import DataCenterAssetFactory
+from ralph.lib.custom_fields.models import (
+    CustomField,
+    CustomFieldTypes,
+    CustomFieldValue
+)
+
+
+class DataCenterAssetAdminTestCaseMixin(object):
+    def setUp(self):
+        self.user = get_user_model().objects.create_superuser(
+            username='root',
+            password='password',
+            email='email@email.pl'
+        )
+        result = self.client.login(username='root', password='password')
+        self.assertEqual(result, True)
+        self.factory = RequestFactory()
+        self.dca = DataCenterAssetFactory(hostname='ralph1.allegro.pl')
+        self.custom_fields_inline_prefix = 'custom_fields-customfieldvalue-content_type-object_id-'  # noqa
+
+    def _update_dca(self, dca_data=None, inline_data=None):
+        data = {
+            'id': self.dca.id,
+            'sn': self.dca.sn,
+            'barcode': self.dca.barcode,
+            'hostname': self.dca.hostname,
+            'model': self.dca.model_id,
+            'orientation': self.dca.orientation,
+            'service_env': self.dca.service_env_id,
+            'status': self.dca.status,
+            'depreciation_rate': self.dca.depreciation_rate,
+        }
+        data.update(dca_data or {})
+        if inline_data:
+            data.update(self._prepare_inline_data(inline_data))
+        response = self.client.post(self.dca.get_absolute_url(), data)
+        self.assertEqual(
+            response.status_code,
+            302,
+            (
+                repr(response.context['form'].errors)
+                if response.context and 'form' in response.context else ''
+            )
+        )
+
+    def _prepare_inline_data(self, d):
+        return {
+            '{}{}'.format(self.custom_fields_inline_prefix, k): v
+            for (k, v) in d.items()
+        }
+
+
+class DataCenterAssetAdminMailNotificationsTestCase(
+    DataCenterAssetAdminTestCaseMixin, TestCase
+):
+    def test_update_data_center_asset_check_mail_notifications(self):
+        old_service = ServiceFactory(name='test')
+        new_service = ServiceFactory(name='prod')
+        old_service.business_owners.add(UserFactory(email='test1@test.pl'))
+        new_service.business_owners.add(UserFactory(email='test2@test.pl'))
+        old_service_env = ServiceEnvironmentFactory(service=old_service)
+        new_service_env = ServiceEnvironmentFactory(service=new_service)
+        # update without triggering signals
+        DataCenterAsset.objects.filter(
+            pk=self.dca.pk
+        ).update(service_env=old_service_env)
+
+        data_custom_fields = {
+            'TOTAL_FORMS': 3,
+            'INITIAL_FORMS': 0,
+        }
+        self._update_dca(
+            dca_data={'service_env': new_service_env.id},
+            inline_data=data_custom_fields
+        )
+
+        self.dca.refresh_from_db()
+
+        self.assertEqual(
+            'Device has been assigned to Service: {} ({})'.format(
+                new_service, self.dca
+            ),
+            mail.outbox[0].subject
+        )
+        self.assertCountEqual(
+            mail.outbox[0].to,
+            ['test1@test.pl', 'test2@test.pl']
+        )
+
+
+# TransactionTestCase has to be used here, since request to admin is wrapped
+# in transaction (to test publishing dc host update data to hermes)
+class DataCenterAssetAdminDCHostPublishUpdateTestCase(
+    DataCenterAssetAdminTestCaseMixin, TransactionTestCase
+):
+    def setUp(self):
+        super().setUp()
+        self.custom_field_str = CustomField.objects.create(
+            name='test_str', type=CustomFieldTypes.STRING, default_value='xyz'
+        )
+        self.custom_field_choices = CustomField.objects.create(
+            name='test_choice', type=CustomFieldTypes.CHOICE,
+            choices='qwerty|asdfgh|zxcvbn', default_value='zxcvbn',
+            use_as_configuration_variable=True,
+        )
+
+    @override_settings(HERMES_HOST_UPDATE_TOPIC_NAME='ralph.host_update')
+    @mock.patch('ralph.data_center.publishers.publish')
+    def test_update_data_center_asset_check_publish_host_update(
+        self, publish_mock
+    ):
+        self.cfv1 = CustomFieldValue.objects.create(
+            object=self.dca,
+            custom_field=self.custom_field_str,
+            value='sample_value',
+        )
+        new_service = ServiceFactory(name='service1', uid='sc-44444')
+        new_service_env = ServiceEnvironmentFactory(
+            service=new_service, environment__name='dev'
+        )
+
+        data_custom_fields = {
+            'TOTAL_FORMS': 3,
+            'INITIAL_FORMS': 1,
+            '0-id': self.cfv1.id,
+            '0-custom_field': self.custom_field_str.id,
+            '0-value': 'sample_value22',
+            '1-id': '',
+            '1-custom_field': self.custom_field_choices.id,
+            '1-value': 'qwerty',
+        }
+        with transaction.atomic():
+            self._update_dca(
+                dca_data={
+                    'service_env': new_service_env.id,
+                    'hostname': 'my-host.mydc.net',
+                },
+                inline_data=data_custom_fields
+            )
+            # DCA is saved twice
+            self.assertEqual(len(connection.run_on_commit), 2)
+
+        self.dca.refresh_from_db()
+        publish_data = publish_mock.call_args[0][1]
+        publish_data.pop('modified')
+        publish_data.pop('created')
+        self.assertEqual(publish_data, {
+            '__str__': 'data center asset: ' + str(self.dca),
+            'configuration_path': None,
+            'configuration_variables': {
+                'test_choice': 'qwerty',
+            },
+            'custom_fields': {
+                'test_str': 'sample_value22',
+                'test_choice': 'qwerty'
+            },
+            'ethernet': [],
+            'hostname': 'my-host.mydc.net',
+            'id': self.dca.id,
+            'ipaddresses': [],
+            'object_type': 'datacenterasset',
+            'parent': None,
+            'remarks': '',
+            'service_env': {
+                'id': new_service_env.id,
+                'service': 'service1',
+                'environment': 'dev',
+                'service_uid': 'sc-44444',
+                'ui_url': ''
+            },
+            'tags': [],
+            '_previous_state': {
+                'hostname': 'ralph1.allegro.pl'
+            },
+        })
+        # Despite `save` is called twice, publish update data is called only
+        # once
+        self.assertEqual(publish_mock.call_count, 1)
+        # check if on_commit callbacks are removed from current db connections
+        self.assertEqual(connection.run_on_commit, [])

--- a/src/ralph/dns/publishers.py
+++ b/src/ralph/dns/publishers.py
@@ -1,16 +1,20 @@
 # -*- coding: utf-8 -*-
+import logging
+
 import pyhermes
+from pyhermes import publish
 from django.conf import settings
-from django.db.models.signals import post_save
-from django.dispatch import receiver
 from threadlocals.threadlocals import get_current_user
 
 from ralph.data_center.models.physical import DataCenterAsset
 from ralph.data_center.models.virtual import Cluster
 from ralph.virtual.models import VirtualServer
+from ralph.signals import post_commit
+
+logger = logging.getLogger(__name__)
 
 
-def _publish_data_to_dnsaaas(obj):
+def _get_txt_data_to_publish_to_dnsaas(obj):
     publish_data = []
     current_user = get_current_user()
     username = current_user.username if current_user else ''
@@ -21,27 +25,20 @@ def _publish_data_to_dnsaaas(obj):
     return publish_data
 
 
-def _send_once(instance):
-    publish_data_to_dnsaaas(instance)
+@pyhermes.publisher(
+    topic=settings.DNSAAS_AUTO_TXT_RECORD_TOPIC_NAME or '',
+    # call publish directly to make testing (overriding settings) easier
+    auto_publish_result=False,
+)
+def publish_data_to_dnsaaas(obj):
+    if settings.DNSAAS_AUTO_TXT_RECORD_TOPIC_NAME:
+        logger.info('Publishing DNS TXT records update for {}'.format(obj))
+        publish(
+            settings.DNSAAS_AUTO_TXT_RECORD_TOPIC_NAME,
+            _get_txt_data_to_publish_to_dnsaas(obj)
+        )
 
 
-if settings.DNSAAS_AUTO_TXT_RECORD_TOPIC_NAME:
-    @pyhermes.publisher(
-        topic=settings.DNSAAS_AUTO_TXT_RECORD_TOPIC_NAME,
-        auto_publish_result=True
-    )
-    def publish_data_to_dnsaaas(obj):
-        return _publish_data_to_dnsaaas(obj)
-
-    # TODO(mkurek): consider changing it to `ralph.signals.post_commit`
-    @receiver(post_save, sender=DataCenterAsset)
-    def post_save_dc_asset(sender, instance, **kwargs):
-        _send_once(instance)
-
-    @receiver(post_save, sender=Cluster)
-    def post_save_cluster(sender, instance, **kwargs):
-        _send_once(instance)
-
-    @receiver(post_save, sender=VirtualServer)
-    def post_save_virtual_server(sender, instance, **kwargs):
-        _send_once(instance)
+post_commit(publish_data_to_dnsaaas, DataCenterAsset)
+post_commit(publish_data_to_dnsaaas, Cluster)
+post_commit(publish_data_to_dnsaaas, VirtualServer)

--- a/src/ralph/dns/publishers.py
+++ b/src/ralph/dns/publishers.py
@@ -2,14 +2,14 @@
 import logging
 
 import pyhermes
-from pyhermes import publish
 from django.conf import settings
+from pyhermes import publish
 from threadlocals.threadlocals import get_current_user
 
 from ralph.data_center.models.physical import DataCenterAsset
 from ralph.data_center.models.virtual import Cluster
-from ralph.virtual.models import VirtualServer
 from ralph.signals import post_commit
+from ralph.virtual.models import VirtualServer
 
 logger = logging.getLogger(__name__)
 

--- a/src/ralph/dns/publishers.py
+++ b/src/ralph/dns/publishers.py
@@ -33,6 +33,7 @@ if settings.DNSAAS_AUTO_TXT_RECORD_TOPIC_NAME:
     def publish_data_to_dnsaaas(obj):
         return _publish_data_to_dnsaaas(obj)
 
+    # TODO: consider changing it to `ralph.signals.post_commit`
     @receiver(post_save, sender=DataCenterAsset)
     def post_save_dc_asset(sender, instance, **kwargs):
         _send_once(instance)

--- a/src/ralph/dns/publishers.py
+++ b/src/ralph/dns/publishers.py
@@ -22,9 +22,7 @@ def _publish_data_to_dnsaaas(obj):
 
 
 def _send_once(instance):
-    # run without condition when ralph2 sync is killed
-    if getattr(instance, '_handle_post_save', True):
-        publish_data_to_dnsaaas(instance)
+    publish_data_to_dnsaaas(instance)
 
 
 if settings.DNSAAS_AUTO_TXT_RECORD_TOPIC_NAME:

--- a/src/ralph/dns/publishers.py
+++ b/src/ralph/dns/publishers.py
@@ -33,7 +33,7 @@ if settings.DNSAAS_AUTO_TXT_RECORD_TOPIC_NAME:
     def publish_data_to_dnsaaas(obj):
         return _publish_data_to_dnsaaas(obj)
 
-    # TODO: consider changing it to `ralph.signals.post_commit`
+    # TODO(mkurek): consider changing it to `ralph.signals.post_commit`
     @receiver(post_save, sender=DataCenterAsset)
     def post_save_dc_asset(sender, instance, **kwargs):
         _send_once(instance)

--- a/src/ralph/dns/tests.py
+++ b/src/ralph/dns/tests.py
@@ -1,17 +1,18 @@
 # -*- coding: utf-8 -*-
 from unittest.mock import patch
 
-from django.test import override_settings, TestCase
+from django.db import transaction
+from django.test import override_settings, TestCase, TransactionTestCase
 from django.utils.translation import ugettext_lazy as _
 
 from ralph.assets.tests.factories import (
     ConfigurationClassFactory,
     EthernetFactory
 )
-from ralph.data_center.models.virtual import BaseObjectCluster
+from ralph.data_center.models import BaseObjectCluster, DataCenterAsset
 from ralph.dns.dnsaas import DNSaaS
 from ralph.dns.forms import DNSRecordForm, RecordType
-from ralph.dns.publishers import _publish_data_to_dnsaaas
+from ralph.dns.publishers import _get_txt_data_to_publish_to_dnsaas
 from ralph.dns.views import (
     add_errors,
     DNSaaSIntegrationNotEnabledError,
@@ -102,15 +103,17 @@ class TestDNSView(TestCase):
         DNSView()
 
 
-class TestPublisher(TestCase):
+class TestGetTXTDataToPublishToDNSaaS(TestCase):
 
-    def setUp(self):
+    @classmethod
+    def setUpClass(cls):
         from ralph.data_center.tests.factories import (
             ClusterFactory,
             DataCenterAssetFactory,
             RackFactory,
         )
-        self.dc_asset = DataCenterAssetFactory(
+        super().setUpClass()
+        cls.dc_asset = DataCenterAssetFactory(
             hostname='ralph0.allegro.pl',
             service_env__service__name='service',
             service_env__environment__name='test',
@@ -127,16 +130,16 @@ class TestPublisher(TestCase):
             configuration_path__class_name='www',
             configuration_path__module__name='ralph',
         )
-        self.dc_ip = IPAddressFactory(
-            base_object=self.dc_asset,
-            ethernet=EthernetFactory(base_object=self.dc_asset),
+        cls.dc_ip = IPAddressFactory(
+            base_object=cls.dc_asset,
+            ethernet=EthernetFactory(base_object=cls.dc_asset),
         )
         IPAddressFactory(
-            base_object=self.dc_asset,
-            ethernet=EthernetFactory(base_object=self.dc_asset),
+            base_object=cls.dc_asset,
+            ethernet=EthernetFactory(base_object=cls.dc_asset),
             is_management=True,
         )
-        self.virtual_server = VirtualServerFactory(
+        cls.virtual_server = VirtualServerFactory(
             hostname='s000.local',
             configuration_path=ConfigurationClassFactory(
                 class_name='worker',
@@ -160,12 +163,12 @@ class TestPublisher(TestCase):
         )
         # refresh virtual server to get parent as BaseObject, not
         # DataCenterAsset
-        self.vs_ip = IPAddressFactory(
-            base_object=self.virtual_server,
-            ethernet=EthernetFactory(base_object=self.virtual_server),
+        cls.vs_ip = IPAddressFactory(
+            base_object=cls.virtual_server,
+            ethernet=EthernetFactory(base_object=cls.virtual_server),
         )
-        self.virtual_server = VirtualServer.objects.get(
-            pk=self.virtual_server.id
+        cls.virtual_server = VirtualServer.objects.get(
+            pk=cls.virtual_server.id
         )
 
         cluster = ClusterFactory(
@@ -176,13 +179,13 @@ class TestPublisher(TestCase):
             service_env__service__name='service',
             service_env__environment__name='preprod',
         )
-        self.boc_1 = BaseObjectCluster.objects.create(
+        cls.boc_1 = BaseObjectCluster.objects.create(
             cluster=cluster,
             base_object=DataCenterAssetFactory(
                 rack=RackFactory(), position=1,
             )
         )
-        self.boc_2 = BaseObjectCluster.objects.create(
+        cls.boc_2 = BaseObjectCluster.objects.create(
             cluster=cluster,
             base_object=DataCenterAssetFactory(
                 rack=RackFactory(
@@ -195,14 +198,14 @@ class TestPublisher(TestCase):
             is_master=True
         )
 
-        self.cluster = ClusterFactory._meta.model.objects.get(pk=cluster)
-        self.cluster_ip = IPAddressFactory(
-            base_object=self.cluster,
-            ethernet=EthernetFactory(base_object=self.cluster),
+        cls.cluster = ClusterFactory._meta.model.objects.get(pk=cluster)
+        cls.cluster_ip = IPAddressFactory(
+            base_object=cls.cluster,
+            ethernet=EthernetFactory(base_object=cls.cluster),
         )
 
     def test_dc_asset_gets_data_ok(self):
-        data = _publish_data_to_dnsaaas(self.dc_asset)
+        data = _get_txt_data_to_publish_to_dnsaas(self.dc_asset)
         self.assertEqual(data, [{
             'content': 'www',
             'ips': [self.dc_ip.address],
@@ -242,7 +245,7 @@ class TestPublisher(TestCase):
         }])
 
     def test_virtual_server_gets_data_ok(self):
-        data = _publish_data_to_dnsaaas(self.virtual_server)
+        data = _get_txt_data_to_publish_to_dnsaas(self.virtual_server)
         self.assertEqual(data, [{
             'content': 'worker',
             'ips': [self.vs_ip.address],
@@ -282,7 +285,7 @@ class TestPublisher(TestCase):
         }])
 
     def test_cluster_gets_data_ok(self):
-        data = _publish_data_to_dnsaaas(self.cluster)
+        data = _get_txt_data_to_publish_to_dnsaas(self.cluster)
         self.assertEqual(data, [{
             'content': 'www',
             'ips': [self.cluster_ip.address],
@@ -320,6 +323,95 @@ class TestPublisher(TestCase):
             'target_owner': 'ralph',
             'purpose': 'LOCATION'
         }])
+
+
+class TestPublishAutoTXTToDNSaaS(TransactionTestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        from ralph.data_center.tests.factories import (
+            DataCenterAssetFactory,
+            RackFactory,
+        )
+        super().setUpClass()
+        cls.dc_asset = DataCenterAssetFactory(
+            hostname='ralph0.allegro.pl',
+            service_env__service__name='service',
+            service_env__environment__name='test',
+            model__name='DL360',
+            model__manufacturer__name='Asus',
+            model__category__name='ATS',
+            rack=RackFactory(
+                name='Rack #100',
+                server_room__name='Server Room A',
+                server_room__data_center__name='DC1',
+            ),
+            position=1,
+            slot_no='1',
+            configuration_path__class_name='www',
+            configuration_path__module__name='ralph',
+        )
+        cls.dc_ip = IPAddressFactory(
+            base_object=cls.dc_asset,
+            ethernet=EthernetFactory(base_object=cls.dc_asset),
+        )
+        IPAddressFactory(
+            base_object=cls.dc_asset,
+            ethernet=EthernetFactory(base_object=cls.dc_asset),
+            is_management=True,
+        )
+
+    @override_settings(
+        DNSAAS_AUTO_TXT_RECORD_TOPIC_NAME='dnsaas_auto_txt_record'
+    )
+    @patch('ralph.dns.publishers.publish')
+    def test_publishing_auto_txt_data_when_dc_asset_updated(self, publish_mock):
+        # fetch clean instance
+        dc_asset = DataCenterAsset.objects.get(pk=self.dc_asset)
+        with transaction.atomic():
+            dc_asset.save()
+
+        self.assertEqual(publish_mock.call_count, 1)
+        # publish_data = publish_mock.call_args[0][1]
+        publish_mock.assert_called_once_with('dnsaas_auto_txt_record', [
+            {
+                'content': 'www',
+                'ips': [self.dc_ip.address],
+                'owner': '',
+                'target_owner': 'ralph',
+                'purpose': 'VENTURE'
+            }, {
+                'content': 'ralph',
+                'ips': [self.dc_ip.address],
+                'owner': '',
+                'target_owner': 'ralph',
+                'purpose': 'ROLE',
+            }, {
+                'content': 'ralph/www',
+                'ips': [self.dc_ip.address],
+                'owner': '',
+                'target_owner': 'ralph',
+                'purpose': 'CONFIGURATION_PATH',
+            }, {
+                'content': 'service - test',
+                'ips': [self.dc_ip.address],
+                'owner': '',
+                'target_owner': 'ralph',
+                'purpose': 'SERVICE_ENV',
+            }, {
+                'content': '[ATS] Asus DL360',
+                'ips': [self.dc_ip.address],
+                'owner': '',
+                'target_owner': 'ralph',
+                'purpose': 'MODEL'
+            }, {
+                'content': 'DC1 / Server Room A / Rack #100 / 1 / 1',
+                'ips': [self.dc_ip.address],
+                'owner': '',
+                'target_owner': 'ralph',
+                'purpose': 'LOCATION'
+            }
+        ])
 
 
 class TestDNSaaS(TestCase):

--- a/src/ralph/dns/tests.py
+++ b/src/ralph/dns/tests.py
@@ -372,8 +372,8 @@ class TestPublishAutoTXTToDNSaaS(TransactionTestCase):
             dc_asset.save()
 
         self.assertEqual(publish_mock.call_count, 1)
-        # publish_data = publish_mock.call_args[0][1]
-        publish_mock.assert_called_once_with('dnsaas_auto_txt_record', [
+        publish_data = publish_mock.call_args[0][1]
+        self.assertCountEqual(publish_data, [
             {
                 'content': 'www',
                 'ips': [self.dc_ip.address],

--- a/src/ralph/dns/tests.py
+++ b/src/ralph/dns/tests.py
@@ -361,6 +361,9 @@ class TestPublishAutoTXTToDNSaaS(TransactionTestCase):
             is_management=True,
         )
 
+    def setUp(self):
+        self.maxDiff = None
+
     @override_settings(
         DNSAAS_AUTO_TXT_RECORD_TOPIC_NAME='dnsaas_auto_txt_record'
     )

--- a/src/ralph/dns/tests.py
+++ b/src/ralph/dns/tests.py
@@ -361,9 +361,6 @@ class TestPublishAutoTXTToDNSaaS(TransactionTestCase):
             is_management=True,
         )
 
-    def setUp(self):
-        self.maxDiff = None
-
     @override_settings(
         DNSAAS_AUTO_TXT_RECORD_TOPIC_NAME='dnsaas_auto_txt_record'
     )
@@ -376,41 +373,39 @@ class TestPublishAutoTXTToDNSaaS(TransactionTestCase):
 
         self.assertEqual(publish_mock.call_count, 1)
         publish_data = publish_mock.call_args[0][1]
+        # owner could be non-deterministic, depending on order of tests
+        # and it's not part of this test to check its correctness
+        for data_dict in publish_data:
+            data_dict.pop('owner')
         self.assertCountEqual(publish_data, [
             {
                 'content': 'www',
                 'ips': [self.dc_ip.address],
-                'owner': '',
                 'target_owner': 'ralph',
                 'purpose': 'VENTURE'
             }, {
                 'content': 'ralph',
                 'ips': [self.dc_ip.address],
-                'owner': '',
                 'target_owner': 'ralph',
                 'purpose': 'ROLE',
             }, {
                 'content': 'ralph/www',
                 'ips': [self.dc_ip.address],
-                'owner': '',
                 'target_owner': 'ralph',
                 'purpose': 'CONFIGURATION_PATH',
             }, {
                 'content': 'service - test',
                 'ips': [self.dc_ip.address],
-                'owner': '',
                 'target_owner': 'ralph',
                 'purpose': 'SERVICE_ENV',
             }, {
                 'content': '[ATS] Asus DL360',
                 'ips': [self.dc_ip.address],
-                'owner': '',
                 'target_owner': 'ralph',
                 'purpose': 'MODEL'
             }, {
                 'content': 'DC1 / Server Room A / Rack #100 / 1 / 1',
                 'ips': [self.dc_ip.address],
-                'owner': '',
                 'target_owner': 'ralph',
                 'purpose': 'LOCATION'
             }

--- a/src/ralph/domains/publishers.py
+++ b/src/ralph/domains/publishers.py
@@ -46,5 +46,4 @@ if settings.DOMAIN_DATA_UPDATE_TOPIC:
 
     @receiver(post_save, sender=Domain)
     def post_save_domain(sender, instance, **kwargs):
-        if getattr(instance, '_handle_post_save', True):
-            publish_domain_data(instance)
+        publish_domain_data(instance)

--- a/src/ralph/notifications/apps.py
+++ b/src/ralph/notifications/apps.py
@@ -20,8 +20,4 @@ class NotificationConfig(RalphAppConfig):
             'virtual.CloudProject',
         ]
         for model in models:
-            # post_save.connect(
-            #     receiver=send_notification_for_model,
-            #     sender=model
-            # )
             post_commit(send_notification_for_model, model)

--- a/src/ralph/notifications/apps.py
+++ b/src/ralph/notifications/apps.py
@@ -1,8 +1,9 @@
 # -*- coding: utf-8 -*-
 from django.conf import settings
-from django.db.models.signals import post_save
+
 from ralph.apps import RalphAppConfig
 from ralph.notifications.sender import send_notification_for_model
+from ralph.signals import post_commit
 
 
 class NotificationConfig(RalphAppConfig):
@@ -19,7 +20,8 @@ class NotificationConfig(RalphAppConfig):
             'virtual.CloudProject',
         ]
         for model in models:
-            post_save.connect(
-                receiver=send_notification_for_model,
-                sender=model
-            )
+            # post_save.connect(
+            #     receiver=send_notification_for_model,
+            #     sender=model
+            # )
+            post_commit(send_notification_for_model, model)

--- a/src/ralph/notifications/sender.py
+++ b/src/ralph/notifications/sender.py
@@ -9,8 +9,8 @@ from threadlocals.threadlocals import get_current_user
 
 
 @Metrology.timer('notification')
-def send_notification_for_model(sender, instance, **kwargs):
-    ServiceEnvironment = sender.service_env.field.related_model
+def send_notification_for_model(instance):
+    ServiceEnvironment = instance._meta.get_field('service_env').related_model
     old_service_env_id = instance._previous_state['service_env_id']
     new_service_env_id = instance.service_env_id
     if old_service_env_id and old_service_env_id != new_service_env_id:

--- a/src/ralph/notifications/sender.py
+++ b/src/ralph/notifications/sender.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+import logging
 from urllib.parse import urljoin
 
 from django.conf import settings
@@ -7,6 +8,8 @@ from django.template.loader import render_to_string
 from metrology import Metrology
 from threadlocals.threadlocals import get_current_user
 
+logger = logging.getLogger(__name__)
+
 
 @Metrology.timer('notification')
 def send_notification_for_model(instance):
@@ -14,6 +17,15 @@ def send_notification_for_model(instance):
     old_service_env_id = instance._previous_state['service_env_id']
     new_service_env_id = instance.service_env_id
     if old_service_env_id and old_service_env_id != new_service_env_id:
+        logger.info(
+            'Sending mail notification for {}'.format(instance),
+            extra={
+                'type': 'SEND_MAIL_NOTIFICATION_FOR_MODEL',
+                'instance_id': instance.id,
+                'content_type': instance.content_type.name,
+                'notification_type': 'service_change',
+            }
+        )
         old_service_env = ServiceEnvironment.objects.get(
             pk=old_service_env_id
         )

--- a/src/ralph/notifications/sender.py
+++ b/src/ralph/notifications/sender.py
@@ -10,8 +10,6 @@ from threadlocals.threadlocals import get_current_user
 
 @Metrology.timer('notification')
 def send_notification_for_model(sender, instance, **kwargs):
-    if not getattr(instance, '_handle_post_save', False):
-        return
     ServiceEnvironment = sender.service_env.field.related_model
     old_service_env_id = instance._previous_state['service_env_id']
     new_service_env_id = instance.service_env_id

--- a/src/ralph/notifications/test_notification.py
+++ b/src/ralph/notifications/test_notification.py
@@ -8,6 +8,7 @@ from ralph.assets.tests.factories import (
     ServiceEnvironmentFactory,
     ServiceFactory
 )
+from ralph.data_center.models import DataCenterAsset
 from ralph.data_center.tests.factories import DataCenterAssetFactory
 
 
@@ -23,6 +24,10 @@ class NotificationTest(TransactionTestCase):
                 service=old_service
             )
         )
+
+        # fetch DCA to start with clean state in post_commit signals
+        # (ex. invalidate call to notification handler during creating of DCA)
+        self.dca = DataCenterAsset.objects.get(pk=self.dca.pk)
         self.dca.service_env = ServiceEnvironmentFactory(
             service=new_service
         )

--- a/src/ralph/notifications/test_notification.py
+++ b/src/ralph/notifications/test_notification.py
@@ -25,7 +25,6 @@ class NotificationTest(RalphTestCase):
         self.dca.service_env = ServiceEnvironmentFactory(
             service=new_service
         )
-        self.dca._handle_post_save = True
         self.dca.save()
 
         self.assertEqual(
@@ -38,3 +37,9 @@ class NotificationTest(RalphTestCase):
             mail.outbox[0].to,
             ['test1@test.pl', 'test2@test.pl']
         )
+
+    def test_notificaiton_change_service_in_datacenterasset_through_admin(self):
+        assert False  # TODO
+
+    def test_notificaiton_change_service_in_datacenterasset_through_api(self):
+        assert False  # TODO

--- a/src/ralph/notifications/test_notification.py
+++ b/src/ralph/notifications/test_notification.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 from django.core import mail
+from django.test import TransactionTestCase
 
 from ralph.accounts.tests.factories import UserFactory
 from ralph.assets.tests.factories import (
@@ -7,10 +8,9 @@ from ralph.assets.tests.factories import (
     ServiceFactory
 )
 from ralph.data_center.tests.factories import DataCenterAssetFactory
-from ralph.tests import RalphTestCase
 
 
-class NotificationTest(RalphTestCase):
+class NotificationTest(TransactionTestCase):
 
     def test_notificaiton_change_service_in_datacenterasset(self):
         old_service = ServiceFactory(name='test')

--- a/src/ralph/notifications/test_notification.py
+++ b/src/ralph/notifications/test_notification.py
@@ -37,9 +37,3 @@ class NotificationTest(RalphTestCase):
             mail.outbox[0].to,
             ['test1@test.pl', 'test2@test.pl']
         )
-
-    def test_notificaiton_change_service_in_datacenterasset_through_admin(self):
-        assert False  # TODO
-
-    def test_notificaiton_change_service_in_datacenterasset_through_api(self):
-        assert False  # TODO

--- a/src/ralph/settings/base.py
+++ b/src/ralph/settings/base.py
@@ -128,7 +128,6 @@ MYSQL_OPTIONS = {
 }
 DATABASES = {
     'default': {
-        # 'ENGINE': 'django.db.backends.mysql',
         'ENGINE': 'transaction_hooks.backends.mysql',
         'NAME': os.environ.get('DATABASE_NAME', 'ralph_ng'),
         'USER': os.environ.get('DATABASE_USER', 'ralph_ng'),

--- a/src/ralph/settings/base.py
+++ b/src/ralph/settings/base.py
@@ -128,7 +128,8 @@ MYSQL_OPTIONS = {
 }
 DATABASES = {
     'default': {
-        'ENGINE': 'django.db.backends.mysql',
+        # 'ENGINE': 'django.db.backends.mysql',
+        'ENGINE': 'transaction_hooks.backends.mysql',
         'NAME': os.environ.get('DATABASE_NAME', 'ralph_ng'),
         'USER': os.environ.get('DATABASE_USER', 'ralph_ng'),
         'PASSWORD': os.environ.get('DATABASE_PASSWORD', 'ralph_ng') or None,

--- a/src/ralph/settings/test.py
+++ b/src/ralph/settings/test.py
@@ -15,6 +15,7 @@ if TEST_DB_ENGINE == 'mysql':
         DATABASES['default']['PASSWORD'] = None
 elif TEST_DB_ENGINE == 'psql':
     DATABASES['default'].update({
+        # TODO: change backend
         'ENGINE': 'django.db.backends.postgresql_psycopg2',
         'PORT': os.environ.get('DATABASE_PORT', 5432),
         'OPTIONS': {},

--- a/src/ralph/settings/test.py
+++ b/src/ralph/settings/test.py
@@ -15,15 +15,14 @@ if TEST_DB_ENGINE == 'mysql':
         DATABASES['default']['PASSWORD'] = None
 elif TEST_DB_ENGINE == 'psql':
     DATABASES['default'].update({
-        # TODO: change backend
-        'ENGINE': 'django.db.backends.postgresql_psycopg2',
+        'ENGINE': 'transaction_hooks.backends.postgresql_psycopg2',
         'PORT': os.environ.get('DATABASE_PORT', 5432),
         'OPTIONS': {},
     })
 else:  # use sqlite as default
     DATABASES = {
         'default': {
-            'ENGINE': 'django.db.backends.sqlite3',
+            'ENGINE': 'transaction_hooks.backends.sqlite3',
             'NAME': ':memory:',
             'ATOMIC_REQUESTS': True,
         }

--- a/src/ralph/signals.py
+++ b/src/ralph/signals.py
@@ -7,7 +7,7 @@ from django.dispatch import receiver
 # @post_commit(MyModel)
 # def my_handler(instance):
 #    ...
-def post_commit(func, model, signal=post_save, prevent_multiple_calls=True):
+def post_commit(func, model, signal=post_save, single_call=True):
     """
     Post commit signal for specific model.
 
@@ -38,13 +38,13 @@ def post_commit(func, model, signal=post_save, prevent_multiple_calls=True):
         def wrapper():
             # prevent from calling the same func multiple times for single
             # instance
-            called_attr = '_' + func.__name__ + '_called'
+            called_already_attr = '_' + func.__name__ + '_called'
             if (
-                not getattr(instance, called_attr, False) or
-                not prevent_multiple_calls
+                not getattr(instance, called_already_attr, False) or
+                not single_call
             ):
                 func(instance)
-                setattr(instance, called_attr, True)
+                setattr(instance, called_already_attr, True)
 
         # TODO(mkurek): replace connection by transaction after upgrading to
         # Django 1.9

--- a/src/ralph/signals.py
+++ b/src/ralph/signals.py
@@ -1,0 +1,24 @@
+from django.db import connection
+from django.db.models.signals import post_save
+from django.dispatch import receiver
+
+
+def post_commit(func, model, prevent_multiple_calls=True):
+    """
+    TODO
+    """
+    @receiver(post_save, sender=model, weak=False)
+    def wrap(sender, instance, **kwargs):
+        def wrapper():
+            # prevent from calling the same func multiple times for single
+            # instance
+            called_attr = '_' + func.__name__ + '_called'
+            if (
+                not getattr(instance, called_attr, False) or
+                not prevent_multiple_calls
+            ):
+                func(instance)
+                setattr(instance, called_attr, True)
+
+        # TODO: replace connection by transaction after upgrading to Django 1.9
+        connection.on_commit(wrapper)

--- a/src/ralph/signals.py
+++ b/src/ralph/signals.py
@@ -3,7 +3,11 @@ from django.db.models.signals import post_save
 from django.dispatch import receiver
 
 
-def post_commit(func, model, prevent_multiple_calls=True):
+# TODO: make this working as a decorator, example:
+# @post_commit(MyModel)
+# def my_handler(instance):
+#    ...
+def post_commit(func, model, signal=post_save, prevent_multiple_calls=True):
     """
     Post commit signal for specific model.
 
@@ -29,7 +33,7 @@ def post_commit(func, model, prevent_multiple_calls=True):
     * if transaction is not started for current request, then this hook will
       behave as post_save (will be called immediately)
     """
-    @receiver(post_save, sender=model, weak=False)
+    @receiver(signal, sender=model, weak=False)
     def wrap(sender, instance, **kwargs):
         def wrapper():
             # prevent from calling the same func multiple times for single

--- a/src/ralph/signals.py
+++ b/src/ralph/signals.py
@@ -3,7 +3,7 @@ from django.db.models.signals import post_save
 from django.dispatch import receiver
 
 
-# TODO: make this working as a decorator, example:
+# TODO(mkurek): make this working as a decorator, example:
 # @post_commit(MyModel)
 # def my_handler(instance):
 #    ...
@@ -46,5 +46,6 @@ def post_commit(func, model, signal=post_save, prevent_multiple_calls=True):
                 func(instance)
                 setattr(instance, called_attr, True)
 
-        # TODO: replace connection by transaction after upgrading to Django 1.9
+        # TODO(mkurek): replace connection by transaction after upgrading to
+        # Django 1.9
         connection.on_commit(wrapper)

--- a/src/ralph/signals.py
+++ b/src/ralph/signals.py
@@ -5,7 +5,29 @@ from django.dispatch import receiver
 
 def post_commit(func, model, prevent_multiple_calls=True):
     """
-    TODO
+    Post commit signal for specific model.
+
+    It's better than Django's post_save, because:
+    * it handles transaction rollback (transaction could be rolled back
+      after calling post_save)
+    * it handles M2M relations (post_save is (usually) called when main model
+      is saved, before related M2M instances are saved)
+
+    Requirements:
+    * you have to use database supporting transactions (ex. MySQL)
+    * you have to use django-transaction-hooks
+      (https://github.com/carljm/django-transaction-hooks) for Django<=1.8
+      (it was merged into Django 1.9)
+
+    Notice that this feature will work whether or not you're using transactions
+    in your code. Possible scenarios are as follows:
+    * `ATOMIC_REQUESTS` is set to True in settings - then every request is
+      wrapped in transaction - at the end of processing each (saving) request,
+      this hook will be processed (for models which were saved)
+    * view is decorated using `transaction.atomic` - at the end of processing
+      the view, this hook will be called (if any of registered models was saved)
+    * if transaction is not started for current request, then this hook will
+      behave as post_save (will be called immediately)
     """
     @receiver(post_save, sender=model, weak=False)
     def wrap(sender, instance, **kwargs):

--- a/src/ralph/signals.py
+++ b/src/ralph/signals.py
@@ -39,9 +39,9 @@ def post_commit(func, model, signal=post_save, single_call=True):
             # prevent from calling the same func multiple times for single
             # instance
             called_already_attr = '_' + func.__name__ + '_called'
-            if (
-                not getattr(instance, called_already_attr, False) or
-                not single_call
+            if not (
+                getattr(instance, called_already_attr, False) and
+                single_call
             ):
                 func(instance)
                 setattr(instance, called_already_attr, True)


### PR DESCRIPTION
Multiple fixes in this PR:
* remove `_handle_post_save` variable - previously it was used to mark signals to NOT be executed before M2M relations were saved - the logic which set this field was removed in cbb2486603b0f0c847e4089e7d07ec4fb25bd298, but some code (ex. mail notifications) still relies on it
* fix notifications and publishing dc host update to be done after transaction is committed (and, especially, after M2M relations are saved)

To call some function after committing the transaction, just use:
```
from ralph.signals import post_commit

post_commit(my_handler, MyModel)
```

for example:
```
post_commit(publish_host_update, DataCenterAsset)
```