### PR TITLE
Fix for custom fields summary with inherited values

### DIFF
--- a/src/ralph/lib/custom_fields/fields.py
+++ b/src/ralph/lib/custom_fields/fields.py
@@ -104,6 +104,13 @@ class CustomFieldValueQuerySet(models.QuerySet):
         self._prioritize = False
         self._prioritize_model_or_instance = None
 
+    def _clone(self, klass=None, setup=False, **kwargs):
+        kwargs.update({
+            '_prioritize': self._prioritize,
+            '_prioritize_model_or_instance': self._prioritize_model_or_instance,
+        })
+        return super()._clone(klass, setup, **kwargs)
+
     def prioritize(self, model_or_instance):
         self._prioritize = True
         self._prioritize_model_or_instance = model_or_instance

--- a/src/ralph/lib/custom_fields/tests/test_models.py
+++ b/src/ralph/lib/custom_fields/tests/test_models.py
@@ -137,3 +137,27 @@ class CustomFieldInheritanceModelsTestCase(TestCase):
                 'value': 'sample_value2'
             }
         ])
+
+    def test_admin_get_custom_fields_values_result_when_cfv_is_inherited(self):
+        CustomFieldValue.objects.create(
+            object=self.sm1,
+            custom_field=self.custom_field_str2,
+            value='sample_value11',
+        )
+        custom_fields_values = SomeModelAdmin._get_custom_fields_values(
+            self.sm1
+        )
+        self.assertEqual(custom_fields_values, [
+            {
+                'name': 'test str',
+                'object': '-',
+                'object_url': '',
+                'value': 'sample_value'
+            },
+            {
+                'name': 'test str 2',
+                'object': '-',
+                'object_url': '',
+                'value': 'sample_value11'
+            }
+        ])


### PR DESCRIPTION
When object has custom field assigned directly and inherited some value for this CF, it was duplicated in summary. There was missing rewriting of `_prioritize` and `_prioritize_model_or_instance` during queryset cloning (ex. during calling `select_related` or `order_by`).