### PR TITLE
Custom field force inheritance

### DIFF
--- a/src/ralph/assets/models/assets.py
+++ b/src/ralph/assets/models/assets.py
@@ -8,7 +8,6 @@ from django.core.exceptions import ValidationError
 from django.core.validators import MinValueValidator
 from django.db import models
 from django.utils.translation import ugettext_lazy as _
-
 from mptt.models import MPTTModel, TreeForeignKey
 
 from ralph.accounts.models import Team
@@ -18,7 +17,10 @@ from ralph.assets.models.choices import (
     ModelVisualizationLayout,
     ObjectModelType
 )
-from ralph.lib.custom_fields.models import CustomFieldMeta, WithCustomFieldsMixin
+from ralph.lib.custom_fields.models import (
+    CustomFieldMeta,
+    WithCustomFieldsMixin
+)
 from ralph.lib.mixins.fields import NullableCharField
 from ralph.lib.mixins.models import (
     AdminAbsoluteUrlMixin,

--- a/src/ralph/assets/models/assets.py
+++ b/src/ralph/assets/models/assets.py
@@ -18,7 +18,7 @@ from ralph.assets.models.choices import (
     ModelVisualizationLayout,
     ObjectModelType
 )
-from ralph.lib.custom_fields.models import WithCustomFieldsMixin
+from ralph.lib.custom_fields.models import CustomFieldMeta, WithCustomFieldsMixin
 from ralph.lib.mixins.fields import NullableCharField
 from ralph.lib.mixins.models import (
     AdminAbsoluteUrlMixin,
@@ -26,6 +26,7 @@ from ralph.lib.mixins.models import (
     TimeStampMixin
 )
 from ralph.lib.permissions import PermByFieldMixin
+from ralph.lib.permissions.models import PermissionsBase
 
 logger = logging.getLogger(__name__)
 
@@ -139,13 +140,17 @@ class Manufacturer(
     _allow_in_dashboard = True
 
 
+AssetModelMeta = type('AssetModelMeta', (CustomFieldMeta, PermissionsBase), {})
+
+
 class AssetModel(
     PermByFieldMixin,
     NamedMixin.NonUnique,
     TimeStampMixin,
     AdminAbsoluteUrlMixin,
     WithCustomFieldsMixin,
-    models.Model
+    models.Model,
+    metaclass=AssetModelMeta
 ):
     # TODO: should type be determined based on category?
     _allow_in_dashboard = True

--- a/src/ralph/assets/models/base.py
+++ b/src/ralph/assets/models/base.py
@@ -6,7 +6,10 @@ from django.db import models
 from django.utils.translation import ugettext_lazy as _
 
 from ralph.attachments.models import AttachmentItem
-from ralph.lib.custom_fields.models import CustomFieldMeta, WithCustomFieldsMixin
+from ralph.lib.custom_fields.models import (
+    CustomFieldMeta,
+    WithCustomFieldsMixin
+)
 from ralph.lib.mixins.models import TaggableMixin, TimeStampMixin
 from ralph.lib.permissions import PermByFieldMixin
 from ralph.lib.permissions.models import PermissionsBase

--- a/src/ralph/assets/models/base.py
+++ b/src/ralph/assets/models/base.py
@@ -6,7 +6,7 @@ from django.db import models
 from django.utils.translation import ugettext_lazy as _
 
 from ralph.attachments.models import AttachmentItem
-from ralph.lib.custom_fields.models import WithCustomFieldsMixin
+from ralph.lib.custom_fields.models import CustomFieldMeta, WithCustomFieldsMixin
 from ralph.lib.mixins.models import TaggableMixin, TimeStampMixin
 from ralph.lib.permissions import PermByFieldMixin
 from ralph.lib.permissions.models import PermissionsBase
@@ -21,6 +21,7 @@ BaseObjectMeta = type(
     'BaseObjectMeta', (
         PolymorphicBase,
         PermissionsBase,
+        CustomFieldMeta,
         TransitionWorkflowBase
     ), {}
 )

--- a/src/ralph/assets/models/configuration.py
+++ b/src/ralph/assets/models/configuration.py
@@ -3,16 +3,29 @@
 from django.core.validators import RegexValidator
 from django.db import models
 from django.utils.translation import ugettext_lazy as _
-from mptt.models import MPTTModel, TreeForeignKey
+from mptt.models import MPTTModel, MPTTModelBase, TreeForeignKey
 
 from ralph.assets.models.base import BaseObject
+from ralph.lib.custom_fields.models import (
+    CustomFieldMeta,
+    WithCustomFieldsMixin
+)
 from ralph.lib.mixins.models import AdminAbsoluteUrlMixin, TimeStampMixin
 
 dir_file_name_validator = RegexValidator(regex='\w+')
 
+ConfigurationModuleBase = type(
+    'ConfigurationModuleBase', (MPTTModelBase, CustomFieldMeta), {}
+)
+
 
 class ConfigurationModule(
-    AdminAbsoluteUrlMixin, MPTTModel, TimeStampMixin, models.Model
+    WithCustomFieldsMixin,
+    AdminAbsoluteUrlMixin,
+    MPTTModel,
+    TimeStampMixin,
+    models.Model,
+    metaclass=ConfigurationModuleBase
 ):
     name = models.CharField(
         verbose_name=_('name'),

--- a/src/ralph/data_center/models/physical.py
+++ b/src/ralph/data_center/models/physical.py
@@ -36,7 +36,6 @@ from ralph.data_center.models.choices import (
 )
 from ralph.data_center.models.mixins import WithManagementIPMixin
 from ralph.data_center.publishers import publish_host_update
-from ralph.lib.custom_fields.models import CustomFieldsInheritance
 from ralph.lib.mixins.models import AdminAbsoluteUrlMixin, PreviousStateMixin
 from ralph.lib.transitions.decorators import transition_action
 from ralph.lib.transitions.fields import TransitionField
@@ -303,11 +302,11 @@ class Rack(AdminAbsoluteUrlMixin, NamedMixin.NonUnique, models.Model):
 
 class NetworkableBaseObject(models.Model):
     # TODO: hostname field and not-abstract cls
-    custom_fields_inheritance = CustomFieldsInheritance({
+    custom_fields_inheritance = {
         'configuration_path': 'assets.ConfigurationClass',
         'configuration_path__module': 'assets.ConfigurationModule',
         'service_env': 'assets.ServiceEnvironment',
-    })
+    }
 
     @cached_property
     def network_environment(self):

--- a/src/ralph/data_center/models/physical.py
+++ b/src/ralph/data_center/models/physical.py
@@ -15,7 +15,6 @@ from django.core.validators import (
 )
 from django.db import models, transaction
 from django.db.models import Q
-from django.db.models.fields.related import add_lazy_relation
 from django.utils.functional import cached_property
 from django.utils.safestring import mark_safe
 from django.utils.translation import ugettext_lazy as _
@@ -37,6 +36,7 @@ from ralph.data_center.models.choices import (
 )
 from ralph.data_center.models.mixins import WithManagementIPMixin
 from ralph.data_center.publishers import publish_host_update
+from ralph.lib.custom_fields.models import CustomFieldsInheritance
 from ralph.lib.mixins.models import AdminAbsoluteUrlMixin, PreviousStateMixin
 from ralph.lib.transitions.decorators import transition_action
 from ralph.lib.transitions.fields import TransitionField
@@ -301,25 +301,6 @@ class Rack(AdminAbsoluteUrlMixin, NamedMixin.NonUnique, models.Model):
         )
 
 
-def add_custom_field_inheritance(field, model, cls):
-    pass
-    # TODO: zapisać info w meta i nadpisać metaklasę - analogicznie do base.py:276 - iteracja po bazowych klasach i wywołanie add_to_class z tym polem
-
-class CustomFieldsInheritance(dict):
-    def contribute_to_class(self, cls, name, virtual_only=False):
-        print('Contributing!!!')
-        for field_path, model in self.items():
-            add_lazy_relation(
-                cls, field_path, model, add_custom_field_inheritance
-            )
-
-
-class MyFK(models.ForeignKey):
-    def contribute_to_class(self, cls, name, virtual_only=False):
-        import ipdb; ipdb.set_trace()
-        return super().contribute_to_class(cls, name, virtual_only)
-
-
 class NetworkableBaseObject(models.Model):
     # TODO: hostname field and not-abstract cls
     custom_fields_inheritance = CustomFieldsInheritance({
@@ -327,7 +308,6 @@ class NetworkableBaseObject(models.Model):
         'configuration_path__module': 'assets.ConfigurationModule',
         'service_env': 'assets.ServiceEnvironment',
     })
-    tmp = MyFK('data_center.ServerRoom')
 
     @cached_property
     def network_environment(self):

--- a/src/ralph/data_center/models/physical.py
+++ b/src/ralph/data_center/models/physical.py
@@ -15,6 +15,7 @@ from django.core.validators import (
 )
 from django.db import models, transaction
 from django.db.models import Q
+from django.db.models.fields.related import add_lazy_relation
 from django.utils.functional import cached_property
 from django.utils.safestring import mark_safe
 from django.utils.translation import ugettext_lazy as _
@@ -300,13 +301,33 @@ class Rack(AdminAbsoluteUrlMixin, NamedMixin.NonUnique, models.Model):
         )
 
 
+def add_custom_field_inheritance(field, model, cls):
+    pass
+    # TODO: zapisać info w meta i nadpisać metaklasę - analogicznie do base.py:276 - iteracja po bazowych klasach i wywołanie add_to_class z tym polem
+
+class CustomFieldsInheritance(dict):
+    def contribute_to_class(self, cls, name, virtual_only=False):
+        print('Contributing!!!')
+        for field_path, model in self.items():
+            add_lazy_relation(
+                cls, field_path, model, add_custom_field_inheritance
+            )
+
+
+class MyFK(models.ForeignKey):
+    def contribute_to_class(self, cls, name, virtual_only=False):
+        import ipdb; ipdb.set_trace()
+        return super().contribute_to_class(cls, name, virtual_only)
+
+
 class NetworkableBaseObject(models.Model):
     # TODO: hostname field and not-abstract cls
-    custom_fields_inheritance = [
-        'configuration_path',
-        'configuration_path__module',
-        'service_env',
-    ]
+    custom_fields_inheritance = CustomFieldsInheritance({
+        'configuration_path': 'assets.ConfigurationClass',
+        'configuration_path__module': 'assets.ConfigurationModule',
+        'service_env': 'assets.ServiceEnvironment',
+    })
+    tmp = MyFK('data_center.ServerRoom')
 
     @cached_property
     def network_environment(self):

--- a/src/ralph/lib/custom_fields/admin.py
+++ b/src/ralph/lib/custom_fields/admin.py
@@ -7,7 +7,8 @@ from ralph.admin import RalphAdmin, register
 from ralph.admin.mixins import RalphGenericTabularInline
 from ralph.lib.custom_fields.forms import (
     CustomFieldValueForm,
-    CustomFieldValueFormSet
+    CustomFieldValueFormSet,
+    CustomFieldValueWithClearChildrenForm
 )
 from ralph.lib.custom_fields.models import CustomField, CustomFieldValue
 from ralph.lib.custom_fields.views import CustomFieldFormfieldView
@@ -51,6 +52,10 @@ class CustomFieldValueInline(RalphGenericTabularInline):
     template = 'custom_fields/edit_inline/tabular.html'
 
 
+class CustomFieldValueWithClearChildrenInline(CustomFieldValueInline):
+    form = CustomFieldValueWithClearChildrenForm
+
+
 class CustomFieldValueAdminMixin(object):
     # set to True if custom field values summary should be visible
     # if set to False, inline form with custom fields will be shown with 100%
@@ -59,7 +64,14 @@ class CustomFieldValueAdminMixin(object):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.inlines = list(self.inlines) + [CustomFieldValueInline]
+        self.inlines = list(self.inlines) + [
+            self._get_custom_field_value_inline()
+        ]
+
+    def _get_custom_field_value_inline(self):
+        if self.model._meta.custom_fields_inheritance_by_model:
+                return CustomFieldValueWithClearChildrenInline
+        return CustomFieldValueInline
 
     @staticmethod
     def _get_custom_fields_values(obj):

--- a/src/ralph/lib/custom_fields/admin.py
+++ b/src/ralph/lib/custom_fields/admin.py
@@ -69,8 +69,11 @@ class CustomFieldValueAdminMixin(object):
         ]
 
     def _get_custom_field_value_inline(self):
+        # check if any model is inheriting custom fields from current model
         if self.model._meta.custom_fields_inheritance_by_model:
-                return CustomFieldValueWithClearChildrenInline
+            # if yes, allow for clearing custom fields values of children
+            # objects
+            return CustomFieldValueWithClearChildrenInline
         return CustomFieldValueInline
 
     @staticmethod

--- a/src/ralph/lib/custom_fields/fields.py
+++ b/src/ralph/lib/custom_fields/fields.py
@@ -132,6 +132,18 @@ class CustomFieldValueQuerySet(models.QuerySet):
             return
         yield from super().iterator()
 
+    def values(self, *fields):
+        # TODO: handle values and values_list (need to overwrite `iterator`
+        # using prioritizing)
+        raise NotImplementedError(
+            'CustomField queryset does not support values queryset'
+        )
+
+    def values_list(self, *fields):
+        raise NotImplementedError(
+            'CustomField queryset does not support values list queryset'
+        )
+
 
 class ReverseGenericRelatedObjectsWithInheritanceDescriptor(
     ReverseGenericRelatedObjectsDescriptor

--- a/src/ralph/lib/custom_fields/forms.py
+++ b/src/ralph/lib/custom_fields/forms.py
@@ -29,6 +29,8 @@ class CustomFieldValueWithClearChildrenForm(CustomFieldValueForm):
 
     def save(self, *args, **kwargs):
         result = super().save(*args, **kwargs)
+        # clear custom fields values for particular custom field if
+        # clear_children is checked
         if self.cleaned_data['clear_children']:
             self.instance.object.clear_children_custom_field_value(
                 self.instance.custom_field,

--- a/src/ralph/lib/custom_fields/forms.py
+++ b/src/ralph/lib/custom_fields/forms.py
@@ -1,18 +1,35 @@
 from django import forms
 from django.contrib.contenttypes.forms import BaseGenericInlineFormSet
 from django.contrib.contenttypes.models import ContentType
-from django.utils.translation import ugettext
+from django.utils.translation import ugettext, ugettext_lazy as _
 
 
 class CustomFieldValueForm(forms.ModelForm):
+    clear_children = forms.BooleanField(
+        initial=False, required=False, label=_('Clear children values?'),
+    )
+
+    class Meta:
+        fields = ['custom_field', 'value', 'clear_children']
+
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self._replace_value_field()
+        # TODO: add this, if sth
+        self.fields['clear_children']
 
     def _replace_value_field(self):
         # replace custom field value field with proper one (ex. select)
         if self.instance and self.instance.custom_field_id:
             self.fields['value'] = self.instance.custom_field.get_form_field()
+
+    def save(self, *args, **kwargs):
+        result = super().save(*args, **kwargs)
+        if self.cleaned_data['clear_children']:
+            self.instance.object.clear_children_custom_field_value(
+                self.instance.custom_field,
+            )
+        return result
 
 
 class CustomFieldValueFormSet(BaseGenericInlineFormSet):

--- a/src/ralph/lib/custom_fields/forms.py
+++ b/src/ralph/lib/custom_fields/forms.py
@@ -1,27 +1,31 @@
 from django import forms
 from django.contrib.contenttypes.forms import BaseGenericInlineFormSet
 from django.contrib.contenttypes.models import ContentType
-from django.utils.translation import ugettext, ugettext_lazy as _
+from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import ugettext
 
 
 class CustomFieldValueForm(forms.ModelForm):
-    clear_children = forms.BooleanField(
-        initial=False, required=False, label=_('Clear children values?'),
-    )
-
     class Meta:
-        fields = ['custom_field', 'value', 'clear_children']
+        fields = ['custom_field', 'value']
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self._replace_value_field()
-        # TODO: add this, if sth
-        self.fields['clear_children']
 
     def _replace_value_field(self):
         # replace custom field value field with proper one (ex. select)
         if self.instance and self.instance.custom_field_id:
             self.fields['value'] = self.instance.custom_field.get_form_field()
+
+
+class CustomFieldValueWithClearChildrenForm(CustomFieldValueForm):
+    clear_children = forms.BooleanField(
+        initial=False, required=False, label=_('Clear children values?'),
+    )
+
+    class Meta(CustomFieldValueForm.Meta):
+        fields = CustomFieldValueForm.Meta.fields + ['clear_children']
 
     def save(self, *args, **kwargs):
         result = super().save(*args, **kwargs)

--- a/src/ralph/lib/custom_fields/models.py
+++ b/src/ralph/lib/custom_fields/models.py
@@ -201,6 +201,8 @@ def add_custom_field_inheritance(field_path, model, cls):
 class WithCustomFieldsMixin(models.Model, metaclass=CustomFieldMeta):
     # TODO: handle polymorphic in filters
     custom_fields = CustomFieldsWithInheritanceRelation(CustomFieldValue)
+    # mapping from field path (using Django __ convention) to model (provided
+    # as string location of app_label and model name)
     custom_fields_inheritance = {}
 
     class Meta:
@@ -229,6 +231,11 @@ class WithCustomFieldsMixin(models.Model, metaclass=CustomFieldMeta):
         cfv.save(update_fields=['value'])
 
     def clear_children_custom_field_value(self, custom_field):
+        """
+        For each model inheriting `custom_field` from self (in practice
+        for each model inheriting, which have this custom_field set to any
+        value), delete their `CustomFieldValue`s.
+        """
         for model, field_path in self._meta.custom_fields_inheritance_by_model.items():  # noqa: E501
             custom_fields_values_to_delete = CustomFieldValue.objects.filter(
                 custom_field=custom_field,

--- a/src/ralph/lib/custom_fields/models.py
+++ b/src/ralph/lib/custom_fields/models.py
@@ -201,3 +201,6 @@ class WithCustomFieldsMixin(models.Model):
         cfv, _ = self.custom_fields.get_or_create(custom_field=cf)
         cfv.value = value
         cfv.save(update_fields=['value'])
+
+    def clear_children_custom_field_value(self, custom_field):
+        print('Clearing')

--- a/src/ralph/lib/custom_fields/tests/models.py
+++ b/src/ralph/lib/custom_fields/tests/models.py
@@ -2,7 +2,7 @@
 from django.core.urlresolvers import reverse
 from django.db import models
 
-from ..models import WithCustomFieldsMixin, CustomFieldsInheritance
+from ..models import WithCustomFieldsMixin
 
 
 class CustomFieldAdminAbsoluteUrlMixin(object):
@@ -37,7 +37,7 @@ class SomeModel(
 ):
     name = models.CharField(max_length=20)
     b = models.ForeignKey(ModelB, null=True, blank=True)
-    custom_fields_inheritance = CustomFieldsInheritance({
+    custom_fields_inheritance = {
         'b': 'ModelB',
         'b__a': 'ModelA',
-    })
+    }

--- a/src/ralph/lib/custom_fields/tests/models.py
+++ b/src/ralph/lib/custom_fields/tests/models.py
@@ -2,7 +2,7 @@
 from django.core.urlresolvers import reverse
 from django.db import models
 
-from ..models import WithCustomFieldsMixin
+from ..models import WithCustomFieldsMixin, CustomFieldsInheritance
 
 
 class CustomFieldAdminAbsoluteUrlMixin(object):
@@ -37,4 +37,7 @@ class SomeModel(
 ):
     name = models.CharField(max_length=20)
     b = models.ForeignKey(ModelB, null=True, blank=True)
-    custom_fields_inheritance = ['b', 'b__a']
+    custom_fields_inheritance = CustomFieldsInheritance({
+        'b': 'ModelB',
+        'b__a': 'ModelA',
+    })

--- a/src/ralph/lib/custom_fields/tests/test_models.py
+++ b/src/ralph/lib/custom_fields/tests/test_models.py
@@ -164,9 +164,20 @@ class CustomFieldInheritanceModelsTestCase(TestCase):
 
     def test_cleaning_children_custom_field_values(self):
         self.assertIn(
-            self.custom_field_str2.name, self.a1.custom_fields_as_dict
+            self.cfv1, list(self.sm1.custom_fields.all())
         )
+        self.a1.clear_children_custom_field_value(self.custom_field_str)
+        self.assertNotIn(self.cfv1, self.sm1.custom_fields.all())
+
+    def test_cleaning_children_custom_field_values_with_overwrite_from_ancestor(
+        self
+    ):
+        cfv4 = CustomFieldValue.objects.create(
+            object=self.sm1,
+            custom_field=self.custom_field_str2,
+            value='12345',
+        )
+        self.assertIn(cfv4, list(self.sm1.custom_fields.all()))
         self.a1.clear_children_custom_field_value(self.custom_field_str2)
-        self.assertNotIn(
-            self.custom_field_str2.name, self.a1.custom_fields_as_dict
-        )
+        self.assertIn(self.cfv3, self.sm1.custom_fields.all())
+        self.assertNotIn(cfv4, self.sm1.custom_fields.all())

--- a/src/ralph/lib/custom_fields/tests/test_models.py
+++ b/src/ralph/lib/custom_fields/tests/test_models.py
@@ -161,3 +161,12 @@ class CustomFieldInheritanceModelsTestCase(TestCase):
                 'value': 'sample_value11'
             }
         ])
+
+    def test_cleaning_children_custom_field_values(self):
+        self.assertIn(
+            self.custom_field_str2.name, self.a1.custom_fields_as_dict
+        )
+        self.a1.clear_children_custom_field_value(self.custom_field_str2)
+        self.assertNotIn(
+            self.custom_field_str2.name, self.a1.custom_fields_as_dict
+        )

--- a/src/ralph/virtual/models.py
+++ b/src/ralph/virtual/models.py
@@ -134,9 +134,9 @@ class CloudFlavor(AdminAbsoluteUrlMixin, BaseObject):
 class CloudProject(PreviousStateMixin, AdminAbsoluteUrlMixin, BaseObject):
     cloudprovider = models.ForeignKey(CloudProvider)
     cloudprovider._autocomplete = False
-    custom_fields_inheritance = [
-        'service_env',
-    ]
+    custom_fields_inheritance = {
+        'service_env': 'assets.ServiceEnvironment',
+    }
 
     project_id = models.CharField(
         verbose_name=_('project ID'),
@@ -158,12 +158,12 @@ def update_service_env_on_cloudproject_save(sender, instance, **kwargs):
 
 class CloudHost(PreviousStateMixin, AdminAbsoluteUrlMixin, BaseObject):
     previous_dc_host_update_fields = ['hostname']
-    custom_fields_inheritance = [
-        'parent__cloudproject',
-        'configuration_path',
-        'configuration_path__module',
-        'service_env',
-    ]
+    custom_fields_inheritance = {
+        'parent__cloudproject': 'virtual.CloudProject',
+        'configuration_path': 'assets.ConfigurationClass',
+        'configuration_path__module': 'assets.ConfigurationModule',
+        'service_env': 'assets.ServiceEnvironment',
+    }
 
     def save(self, *args, **kwargs):
         try:


### PR DESCRIPTION
Allow ancestors (of hosts, like `ServiceEnvironment` or `ConfigurationModule`) to overwrite value of particular custom field in their children. It's done by removing `CustomFieldValue` assigned to this child object and letting custom fields inheritance do rest.