### PR TITLE
Fix order of custom fields inheritance

### DIFF
--- a/src/ralph/data_center/models/physical.py
+++ b/src/ralph/data_center/models/physical.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 import logging
 import re
-from collections import namedtuple
+from collections import namedtuple, OrderedDict
 from itertools import chain
 
 from django import forms
@@ -302,11 +302,11 @@ class Rack(AdminAbsoluteUrlMixin, NamedMixin.NonUnique, models.Model):
 
 class NetworkableBaseObject(models.Model):
     # TODO: hostname field and not-abstract cls
-    custom_fields_inheritance = {
-        'configuration_path': 'assets.ConfigurationClass',
-        'configuration_path__module': 'assets.ConfigurationModule',
-        'service_env': 'assets.ServiceEnvironment',
-    }
+    custom_fields_inheritance = OrderedDict([
+        ('configuration_path', 'assets.ConfigurationClass'),
+        ('configuration_path__module', 'assets.ConfigurationModule'),
+        ('service_env', 'assets.ServiceEnvironment'),
+    ])
 
     @cached_property
     def network_environment(self):

--- a/src/ralph/lib/custom_fields/fields.py
+++ b/src/ralph/lib/custom_fields/fields.py
@@ -29,7 +29,10 @@ class CustomFieldsWithInheritanceRelation(GenericRelation):
         city = models.ForeignKey(City)
 
         custom_fields = CustomFieldsWithInheritanceRelation(CustomFieldValue)
-        custom_fields_inheritance = ['city', 'city__country']
+        custom_fields_inheritance = OrderedDict([
+            ('city', 'City'),
+            ('city__country', 'Country'),
+        ])
 
     The priority of inheritance is as follows:
     * the `CustomFieldValue`s (CFVs) set directyl on object has the highest

--- a/src/ralph/lib/custom_fields/tests/models.py
+++ b/src/ralph/lib/custom_fields/tests/models.py
@@ -1,4 +1,6 @@
 # -*- coding: utf-8 -*-
+from collections import OrderedDict
+
 from django.core.urlresolvers import reverse
 from django.db import models
 
@@ -37,7 +39,7 @@ class SomeModel(
 ):
     name = models.CharField(max_length=20)
     b = models.ForeignKey(ModelB, null=True, blank=True)
-    custom_fields_inheritance = {
-        'b': 'ModelB',
-        'b__a': 'ModelA',
-    }
+    custom_fields_inheritance = OrderedDict([
+        ('b', 'ModelB'),
+        ('b__a', 'ModelA'),
+    ])

--- a/src/ralph/virtual/models.py
+++ b/src/ralph/virtual/models.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 import logging
+from collections import OrderedDict
 
 from dj.choices import Choices
 from django.contrib.contenttypes.models import ContentType
@@ -134,9 +135,9 @@ class CloudFlavor(AdminAbsoluteUrlMixin, BaseObject):
 class CloudProject(PreviousStateMixin, AdminAbsoluteUrlMixin, BaseObject):
     cloudprovider = models.ForeignKey(CloudProvider)
     cloudprovider._autocomplete = False
-    custom_fields_inheritance = {
-        'service_env': 'assets.ServiceEnvironment',
-    }
+    custom_fields_inheritance = OrderedDict([
+        ('service_env', 'assets.ServiceEnvironment'),
+    ])
 
     project_id = models.CharField(
         verbose_name=_('project ID'),
@@ -158,12 +159,12 @@ def update_service_env_on_cloudproject_save(sender, instance, **kwargs):
 
 class CloudHost(PreviousStateMixin, AdminAbsoluteUrlMixin, BaseObject):
     previous_dc_host_update_fields = ['hostname']
-    custom_fields_inheritance = {
-        'parent__cloudproject': 'virtual.CloudProject',
-        'configuration_path': 'assets.ConfigurationClass',
-        'configuration_path__module': 'assets.ConfigurationModule',
-        'service_env': 'assets.ServiceEnvironment',
-    }
+    custom_fields_inheritance = OrderedDict([
+        ('parent__cloudproject', 'virtual.CloudProject'),
+        ('configuration_path', 'assets.ConfigurationClass'),
+        ('configuration_path__module', 'assets.ConfigurationModule'),
+        ('service_env', 'assets.ServiceEnvironment'),
+    ])
 
     def save(self, *args, **kwargs):
         try:

--- a/src/ralph/virtual/tests/test_models.py
+++ b/src/ralph/virtual/tests/test_models.py
@@ -20,7 +20,8 @@ from ralph.virtual.tests.factories import (
     CloudFlavorFactory,
     CloudHostFactory,
     CloudProjectFactory,
-    CloudProviderFactory
+    CloudProviderFactory,
+    VirtualServerFullFactory
 )
 
 
@@ -187,4 +188,31 @@ class CloudHostTestCase(RalphTestCase):
         self.assertEqual(
             self.cloud_host.custom_fields_as_dict,
             {'test str': 'sample_value22'}
+        )
+
+
+class VirtualServerTestCase(RalphTestCase):
+    def setUp(self):
+        self.vs = VirtualServerFullFactory()
+        self.custom_field_str = CustomField.objects.create(
+            name='test str', type=CustomFieldTypes.STRING, default_value='xyz'
+        )
+
+    def test_custom_fields_inheritance_proper_order(self):
+        # regression test for inheritance of custom field values: when switched
+        # from list to dict, the order of inheritance was lost
+        self.assertEqual(self.vs.custom_fields_as_dict, {})
+        CustomFieldValue.objects.create(
+            object=self.vs.configuration_path.module,
+            custom_field=self.custom_field_str,
+            value='sample_value22',
+        )
+        CustomFieldValue.objects.create(
+            object=self.vs.configuration_path,
+            custom_field=self.custom_field_str,
+            value='sample_value',
+        )
+        self.assertEqual(
+            self.vs.custom_fields_as_dict,
+            {'test str': 'sample_value'}
         )


### PR DESCRIPTION
When switched from list to dict, the order of inheritance was lost.
Using OrderedDict now to assure proper order of inheritance.