### PR TITLE
Disable editing of configuration module and class details

### DIFF
--- a/src/ralph/assets/admin.py
+++ b/src/ralph/assets/admin.py
@@ -59,6 +59,11 @@ class ConfigurationClassAdmin(CustomFieldValueAdminMixin, RalphAdmin):
     objects_count.short_description = _('Objects count')
     objects_count.admin_order_field = 'objects_count'
 
+    def get_readonly_fields(self, request, obj=None):
+        if obj:
+            return self.readonly_fields + ['class_name', 'module']
+        return self.readonly_fields
+
 
 @register(ConfigurationModule)
 class ConfigurationModuleAdmin(CustomFieldValueAdminMixin, RalphMPTTAdmin):
@@ -103,6 +108,11 @@ class ConfigurationModuleAdmin(CustomFieldValueAdminMixin, RalphMPTTAdmin):
         ).render()
     show_children_classes.allow_tags = True
     show_children_classes.short_description = _('Children classes')
+
+    def get_readonly_fields(self, request, obj=None):
+        if obj:
+            return self.readonly_fields + ['name', 'parent']
+        return self.readonly_fields
 
 
 @register(ServiceEnvironment)

--- a/src/ralph/assets/api/views.py
+++ b/src/ralph/assets/api/views.py
@@ -198,6 +198,9 @@ class ConfigurationModuleViewSet(RalphAPIViewSet):
     serializer_class = serializers.ConfigurationModuleSerializer
     save_serializer_class = serializers.ConfigurationModuleSimpleSerializer
     filter_fields = ('parent', 'name')
+    # don't allow for ConfigurationModule updating or deleting as it might
+    # dissrupt configuration of many hosts!
+    http_method_names = ['get', 'post', 'options', 'head']
 
 
 class ConfigurationClassViewSet(RalphAPIViewSet):
@@ -206,6 +209,9 @@ class ConfigurationClassViewSet(RalphAPIViewSet):
     filter_fields = ('module', 'module__name', 'class_name', 'path')
     select_related = ['module']
     prefetch_related = ['tags']
+    # don't allow for ConfigurationClass updating or deleting as it might
+    # dissrupt configuration of many hosts!
+    http_method_names = ['get', 'post', 'options', 'head']
 
 
 class BaseObjectViewSetMixin(object):

--- a/src/ralph/assets/tests/test_api.py
+++ b/src/ralph/assets/tests/test_api.py
@@ -1039,9 +1039,9 @@ class ConfigurationModuleAPITests(RalphAPITestCase):
             'name': 'test_2'
         }
         response = self.client.patch(url, data, format='json')
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.conf_module_2.refresh_from_db()
-        self.assertEqual(self.conf_module_2.name, 'test_2')
+        self.assertEqual(
+            response.status_code, status.HTTP_405_METHOD_NOT_ALLOWED
+        )
 
 
 class ConfigurationClassAPITests(RalphAPITestCase):
@@ -1104,9 +1104,9 @@ class ConfigurationClassAPITests(RalphAPITestCase):
             'class_name': 'test_2'
         }
         response = self.client.patch(url, data, format='json')
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.conf_class_1.refresh_from_db()
-        self.assertEqual(self.conf_class_1.class_name, 'test_2')
+        self.assertEqual(
+            response.status_code, status.HTTP_405_METHOD_NOT_ALLOWED
+        )
 
 
 class EthernetAPITests(RalphAPITestCase):


### PR DESCRIPTION
* ConfigurationModule - disable name and parent
* ConfigurationClass - disable module and class_name

Changing these fields could be dissruptive for configuration of hosts.