### PR TITLE
Use DRF ValidationError in mac serializer

### DIFF
--- a/src/ralph/lib/mixins/fields.py
+++ b/src/ralph/lib/mixins/fields.py
@@ -5,13 +5,13 @@ from django import forms
 from django.conf import settings
 from django.contrib.admin.widgets import AdminTextInputWidget
 from django.contrib.contenttypes.models import ContentType
-from rest_framework.exceptions import ValidationError
 from django.db import models
 from django.db.models.loading import get_model
 from django.forms.utils import flatatt
 from django.utils import six
 from django.utils.html import format_html, smart_urlquote
 from django.utils.translation import ugettext_lazy as _
+from rest_framework.exceptions import ValidationError
 from taggit.forms import TagField
 
 

--- a/src/ralph/lib/mixins/fields.py
+++ b/src/ralph/lib/mixins/fields.py
@@ -5,7 +5,7 @@ from django import forms
 from django.conf import settings
 from django.contrib.admin.widgets import AdminTextInputWidget
 from django.contrib.contenttypes.models import ContentType
-from django.core.exceptions import ValidationError
+from rest_framework.exceptions import ValidationError
 from django.db import models
 from django.db.models.loading import get_model
 from django.forms.utils import flatatt
@@ -239,9 +239,7 @@ class MACAddressField(NullableCharField):
             return self.normalize(value)
         except ValueError:
             raise ValidationError(
-                self.error_messages['invalid'],
-                code='invalid',
-                params={'value': value},
+                self.error_messages['invalid'] % {'value': value},
             )
 
     @classmethod

--- a/src/ralph/networks/tests/test_api.py
+++ b/src/ralph/networks/tests/test_api.py
@@ -39,6 +39,13 @@ class IPAddressAPITests(RalphAPITestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data['count'], 1)
 
+    def test_get_ip_list_filter_by_invalid_mac_400(self):
+        url = '{}?ethernet__mac={}'.format(
+            reverse('ipaddress-list'), '(none)'
+        )
+        response = self.client.get(url, format='json')
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
     def test_get_ip_details(self):
         url = reverse('ipaddress-detail', args=(self.ip1.id,))
         response = self.client.get(url, format='json')


### PR DESCRIPTION
In order to make validation error for mac address return 400 instead of
500, ValidationError from DRF must be userd. The one from Django causes
a 500.