### PR TITLE
update data_center api views to add filter on service environment name

### DIFF
--- a/src/ralph/data_center/api/views.py
+++ b/src/ralph/data_center/api/views.py
@@ -67,6 +67,7 @@ class DataCenterAssetViewSet(BaseObjectViewSetMixin, RalphAPIViewSet):
         'service_env__service__uid',
         'service_env__service__name',
         'service_env__service__id',
+        'service_env__environment__name',
         'firmware_version',
         'bios_version',
     ]


### PR DESCRIPTION
I have update the filter list to be able to filter data on environment name not only service_env name