### PR TITLE
XSS flaw bugfix

### DIFF
--- a/src/ralph/accounts/templates/ralphuser/inventory_tag_confirmation.html
+++ b/src/ralph/accounts/templates/ralphuser/inventory_tag_confirmation.html
@@ -16,8 +16,8 @@
     {% table asset_details.get_table_content %}
     <form action={% url 'inventory_tag' %} method="POST">
       {% csrf_token %}
-      <input type="hidden" name="asset_id" value={{ asset_id }} />
-      <input type="hidden" name="answer" value={{ answer }} />
+      <input type="hidden" name="asset_id" value="{{ asset_id }}" />
+      <input type="hidden" name="answer" value="{{ answer }}" />
       <a href={% url 'current_user_info' %} class= "button small alert left">
           Cancel</a>
       <input type="submit" name="confirm_button" value="Yes"


### PR DESCRIPTION
Inserting Django-autosanitized values to unquoted HTML attribute values is unsecure, because the attacker can append other HTML attributes including JavaScript events. This flaw is exploitable by the following technique:
http://blog.portswigger.net/2015/11/xss-in-hidden-input-fields.html