### PR TITLE
Make operations identifiable by ticket id

### DIFF
--- a/src/ralph/lib/mixins/fields.py
+++ b/src/ralph/lib/mixins/fields.py
@@ -76,6 +76,7 @@ class TicketIdField(NullableCharField):
         null=True,
         blank=True,
         max_length=200,
+        unique=True,
         *args, **kwargs
     ):
         super().__init__(
@@ -84,6 +85,7 @@ class TicketIdField(NullableCharField):
             null=null,
             blank=blank,
             max_length=max_length,
+            unique=unique,
             *args, **kwargs
         )
 

--- a/src/ralph/operations/migrations/0005_auto_20170323_1425.py
+++ b/src/ralph/operations/migrations/0005_auto_20170323_1425.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+import ralph.lib.mixins.fields
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('operations', '0004_auto_20160307_1138'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='operation',
+            name='ticket_id',
+            field=ralph.lib.mixins.fields.TicketIdField(null=True, unique=True, max_length=200, verbose_name='ticket id', blank=True, help_text='External system ticket identifier'),
+        ),
+    ]

--- a/src/ralph/operations/models.py
+++ b/src/ralph/operations/models.py
@@ -77,7 +77,7 @@ class Operation(AdminAbsoluteUrlMixin, TaggableMixin, models.Model):
         blank=True,
         on_delete=models.PROTECT,
     )
-    ticket_id = TicketIdField()
+    ticket_id = TicketIdField(unique=True, verbose_name=_('ticket id'))
     created_date = models.DateTimeField(
         null=True, blank=True, verbose_name=_('created date'),
     )

--- a/src/ralph/operations/tests/test_models.py
+++ b/src/ralph/operations/tests/test_models.py
@@ -1,7 +1,8 @@
+from django.db import IntegrityError
 from django.forms import ValidationError
 
 from ralph.operations.models import OperationType
-from ralph.operations.tests.factories import FailureFactory
+from ralph.operations.tests.factories import ChangeFactory, FailureFactory
 from ralph.tests import RalphTestCase
 
 
@@ -16,3 +17,10 @@ class OperationModelsTestCase(RalphTestCase):
             msg='Invalid Operation type. Choose descendant of Failure'
         ):
             self.failure.clean()
+
+    def test_ticket_id_unique(self):
+        ticket_id = 'FOO-42'
+        ChangeFactory(ticket_id=ticket_id)
+
+        with self.assertRaises(IntegrityError):
+            ChangeFactory(ticket_id=ticket_id)


### PR DESCRIPTION
Change management workflows that involve usage of an external ticket
systems allow to identify every single operation by its external ID.
In order to do that a single operation should be ralated to a single
ticket.

This patch sets a unique property for an operation's ticket_id
attribute so identifying tickets by their external identifiers is
possible.