### PR TITLE
Extend the list of available operation statuses

### DIFF
--- a/src/ralph/operations/migrations/0006_auto_20170323_1530.py
+++ b/src/ralph/operations/migrations/0006_auto_20170323_1530.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('operations', '0005_auto_20170323_1425'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='operation',
+            name='status',
+            field=models.PositiveIntegerField(verbose_name='status', choices=[(1, 'open'), (2, 'in progress'), (3, 'resolved'), (4, 'closed'), (5, 'reopened'), (6, 'todo'), (7, 'blocked')], default=1),
+        ),
+    ]

--- a/src/ralph/operations/models.py
+++ b/src/ralph/operations/models.py
@@ -24,6 +24,9 @@ class OperationStatus(Choices):
     in_progress = _('in progress')
     resolved = _('resolved')
     closed = _('closed')
+    reopened = _('reopened')
+    todo = _('todo')
+    blocked = _('blocked')
 
 
 class OperationType(


### PR DESCRIPTION
This patch adds the following statuses:

 - reopened
 - todo
 - blocked