### PR TITLE
Event processing for change management

### DIFF
--- a/src/ralph/admin/apps.py
+++ b/src/ralph/admin/apps.py
@@ -11,4 +11,3 @@ class RalphAdminConfig(RalphAppConfig):
     def ready(self):
         register_custom_filters()
         super().ready()
-        from ralph.operations.changemanagement.subscribtions import receive_chm_event  # noqa

--- a/src/ralph/admin/apps.py
+++ b/src/ralph/admin/apps.py
@@ -11,3 +11,4 @@ class RalphAdminConfig(RalphAppConfig):
     def ready(self):
         register_custom_filters()
         super().ready()
+        from ralph.operations.changemanagement.subscribtions import receive_chm_event  # noqa

--- a/src/ralph/lib/mixins/fields.py
+++ b/src/ralph/lib/mixins/fields.py
@@ -76,6 +76,7 @@ class TicketIdField(NullableCharField):
         null=True,
         blank=True,
         max_length=200,
+        unique=True,
         *args, **kwargs
     ):
         super().__init__(
@@ -84,6 +85,7 @@ class TicketIdField(NullableCharField):
             null=null,
             blank=blank,
             max_length=max_length,
+            unique=unique,
             *args, **kwargs
         )
 

--- a/src/ralph/operations/__init__.py
+++ b/src/ralph/operations/__init__.py
@@ -1,0 +1,1 @@
+default_app_config = 'ralph.operations.apps.RalphOperationsConfig'

--- a/src/ralph/operations/admin.py
+++ b/src/ralph/operations/admin.py
@@ -40,7 +40,7 @@ class OperationAdminForm(RalphAdminForm):
 @register(Operation)
 class OperationAdmin(AttachmentsMixin, RalphAdmin):
     search_fields = ['title', 'description', 'ticket_id']
-    list_filter = ['type', 'status']
+    list_filter = ['type', 'status', 'asignee', 'ticket_id', 'base_objects']
     list_display = ['title', 'type', 'status', 'asignee', 'get_ticket_url']
     raw_id_fields = ['asignee', 'base_objects']
     resource_class = resources.OperationResource

--- a/src/ralph/operations/admin.py
+++ b/src/ralph/operations/admin.py
@@ -40,7 +40,8 @@ class OperationAdminForm(RalphAdminForm):
 @register(Operation)
 class OperationAdmin(AttachmentsMixin, RalphAdmin):
     search_fields = ['title', 'description', 'ticket_id']
-    list_filter = ['type', 'status', 'asignee', 'ticket_id', 'base_objects']
+    list_filter = ['type', 'status', 'asignee', 'ticket_id', 'base_objects',
+                   'created_date', 'update_date', 'resolved_date']
     list_display = ['title', 'type', 'status', 'asignee', 'get_ticket_url']
     raw_id_fields = ['asignee', 'base_objects']
     resource_class = resources.OperationResource

--- a/src/ralph/operations/apps.py
+++ b/src/ralph/operations/apps.py
@@ -1,0 +1,11 @@
+from ralph.apps import RalphAppConfig
+
+
+class RalphOperationsConfig(RalphAppConfig):
+    name = 'ralph.operations'
+    label = 'operations'
+    verbose_name = 'Ralph Operations'
+
+    def ready(self):
+        from ralph.operations.changemanagement.subscribtions import receive_chm_event  # noqa
+        super().ready()

--- a/src/ralph/operations/changemanagement/jira.py
+++ b/src/ralph/operations/changemanagement/jira.py
@@ -1,9 +1,13 @@
+import logging
 from datetime import timezone
 
 from dateutil.parser import parse as parse_datetime
 from django.conf import settings
 
 from ralph.operations.models import OperationStatus
+
+
+logger = logging.getLogger(__name__)
 
 
 def get_title(event_data):
@@ -30,7 +34,15 @@ def get_operation_status(event_data):
         status_conf['BLOCKED']: OperationStatus.blocked
     }
 
-    return status_map[event_data['issue']['fields']['status']['name']]
+    try:
+        status_str = event_data['issue']['fields']['status']['name']
+        return status_map[status_str]
+    except KeyError:
+        logger.error(
+            'Received an operation with unexpected '
+            'status: {}. Please check the settings.'.format(status_str)
+        )
+        raise
 
 
 def get_operation_name(event_data):

--- a/src/ralph/operations/changemanagement/jira.py
+++ b/src/ralph/operations/changemanagement/jira.py
@@ -1,0 +1,69 @@
+from datetime import timezone
+
+from dateutil.parser import parse as parse_datetime
+from django.conf import settings
+
+
+def get_title(event_data):
+    return event_data['issue']['fields']['summary']
+
+
+def get_description(event_data):
+    return event_data['issue']['fields']['description']
+
+
+def get_ticket_id(event_data):
+    return event_data['issue']['key']
+
+
+def get_operation_status(event_data):
+    from ralph.operations.models import OperationStatus
+
+    status_conf = settings.CHANGE_MGMT_OPERATION_STATUSES
+    status_map = {
+        status_conf['OPENED']: OperationStatus.opened,
+        status_conf['IN_PROGRESS']: OperationStatus.in_progress,
+        status_conf['RESOLVED']: OperationStatus.resolved,
+        status_conf['CLOSED']: OperationStatus.closed,
+        status_conf['REOPENED']: OperationStatus.reopened,
+        status_conf['TODO']: OperationStatus.todo,
+        status_conf['BLOCKED']: OperationStatus.blocked
+    }
+
+    return status_map[event_data['issue']['fields']['status']['name']]
+
+
+def get_operation_name(event_data):
+    return event_data['issue']['fields']['issuetype']['name']
+
+
+def get_assignee_username(event_data):
+    try:
+        return event_data['issue']['fields']['assignee']['key']
+    except TypeError:
+        # NOTE(romcheg): This means there is no assignee.
+        return None
+
+
+def get_creation_date(event_data):
+    return _safe_load_datetime(event_data, 'created')
+
+
+def get_last_update_date(event_data):
+    return _safe_load_datetime(event_data, 'updated')
+
+
+def get_resolution_date(event_data):
+    return _safe_load_datetime(event_data, 'resolutiondate')
+
+
+def _safe_load_datetime(event_data, field):
+    """Safely serialize an ISO 8601 datetime string into a datetime object."""
+
+    try:
+        datetime_str = event_data['issue']['fields'][field]
+        return parse_datetime(
+            datetime_str
+        ).astimezone(timezone.utc).replace(tzinfo=None)
+    except:
+        return None

--- a/src/ralph/operations/changemanagement/jira.py
+++ b/src/ralph/operations/changemanagement/jira.py
@@ -3,6 +3,8 @@ from datetime import timezone
 from dateutil.parser import parse as parse_datetime
 from django.conf import settings
 
+from ralph.operations.models import OperationStatus
+
 
 def get_title(event_data):
     return event_data['issue']['fields']['summary']
@@ -17,8 +19,6 @@ def get_ticket_id(event_data):
 
 
 def get_operation_status(event_data):
-    from ralph.operations.models import OperationStatus
-
     status_conf = settings.CHANGE_MGMT_OPERATION_STATUSES
     status_map = {
         status_conf['OPENED']: OperationStatus.opened,

--- a/src/ralph/operations/changemanagement/subscribtions.py
+++ b/src/ralph/operations/changemanagement/subscribtions.py
@@ -1,0 +1,99 @@
+import pyhermes
+from django.db import transaction
+from django.contrib.auth import get_user_model
+from django.conf import settings
+from importlib import import_module
+
+
+def _safe_load_user(username):
+    """Loads an existing user or creates a new one."""
+
+    if username is None:
+        return
+
+    model = get_user_model()
+
+    user, created = model.objects.get_or_create(username=username)
+
+    if created:
+        user.is_active = False
+        user.save()
+
+    return user
+
+
+def _safe_load_operation_type(operation_name):
+    """Load operation type by its name. None, if not found."""
+    from ralph.operations.models import OperationType
+
+    try:
+        return OperationType.objects.get(name=operation_name)
+    except OperationType.DoesNotExits:
+        return None
+
+
+def _load_base_objects(object_ids):
+    """Load base objects with the specified ids. [] if none is found."""
+
+    from ralph.assets.models import BaseObject
+
+    return BaseObject.objects.filter(id__in=object_ids)
+
+
+@transaction.atomic
+def record_operation(title, status, description, operation_name, ticket_id,
+                     assignee_username=None, created_date=None,
+                     update_date=None, resolution_date=None, bo_ids=None):
+
+    from ralph.operations.models import Operation
+
+    operation_type = _safe_load_operation_type(operation_name)
+
+    operation, _ = Operation.objects.update_or_create(
+        ticket_id=ticket_id,
+        defaults=dict(
+            title=title,
+            description=description,
+            status=status,
+            type=operation_type,
+            asignee=_safe_load_user(assignee_username),
+            created_date=created_date,
+            update_date=update_date,
+            resolved_date=resolution_date
+        )
+    )
+
+    if bo_ids:
+        operation.base_objects = _load_base_objects(bo_ids)
+        operation.save()
+
+
+@pyhermes.subscriber(topic=settings.HERMES_CHANGE_MGMT_TOPICS['CHANGES'])
+def receive_chm_event(event_data):
+    """Process messages from the change management system."""
+    try:
+        change_processor = import_module(settings.CHANGE_MGMT_PROCESSOR)
+
+        bo_ids = None
+        if settings.CHANGE_MGMT_BO_LOADER:
+            bo_loader = import_module(settings.CHANGE_MGMT_BO_LOADER)
+            bo_ids = bo_loader.get_baseobjects_ids(event_data)
+
+        record_operation(
+            title=change_processor.get_title(event_data),
+            description=change_processor.get_description(event_data),
+            ticket_id=change_processor.get_ticket_id(event_data),
+            status=change_processor.get_operation_status(event_data),
+            operation_name=change_processor.get_operation_name(event_data),
+            assignee_username=change_processor.get_assignee_username(
+                event_data
+            ),
+            created_date=change_processor.get_creation_date(event_data),
+            update_date=change_processor.get_last_update_date(event_data),
+            resolution_date=change_processor.get_resolution_date(event_data),
+            bo_ids=bo_ids
+        )
+
+    except Exception as e:
+        # TODO(romcheg): Change this for something sensible
+        raise

--- a/src/ralph/operations/changemanagement/subscribtions.py
+++ b/src/ralph/operations/changemanagement/subscribtions.py
@@ -31,7 +31,7 @@ def _safe_load_operation_type(operation_name):
 
     try:
         return OperationType.objects.get(name=operation_name)
-    except OperationType.DoesNotExits:
+    except OperationType.DoesNotExist:
         return None
 
 
@@ -47,6 +47,10 @@ def record_operation(title, status, description, operation_name, ticket_id,
                      update_date=None, resolution_date=None, bo_ids=None):
 
     operation_type = _safe_load_operation_type(operation_name)
+
+    # NOTE(romcheg): Changes of an unknown type should not be recorded.
+    if operation_type is None:
+        return
 
     operation, _ = Operation.objects.update_or_create(
         ticket_id=ticket_id,

--- a/src/ralph/operations/changemanagement/subscribtions.py
+++ b/src/ralph/operations/changemanagement/subscribtions.py
@@ -5,6 +5,9 @@ from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.db import transaction
 
+from ralph.assets.models import BaseObject
+from ralph.operations.models import Operation, OperationType
+
 
 def _safe_load_user(username):
     """Loads an existing user or creates a new one."""
@@ -25,7 +28,6 @@ def _safe_load_user(username):
 
 def _safe_load_operation_type(operation_name):
     """Load operation type by its name. None, if not found."""
-    from ralph.operations.models import OperationType
 
     try:
         return OperationType.objects.get(name=operation_name)
@@ -36,8 +38,6 @@ def _safe_load_operation_type(operation_name):
 def _load_base_objects(object_ids):
     """Load base objects with the specified ids. [] if none is found."""
 
-    from ralph.assets.models import BaseObject
-
     return BaseObject.objects.filter(id__in=object_ids)
 
 
@@ -45,8 +45,6 @@ def _load_base_objects(object_ids):
 def record_operation(title, status, description, operation_name, ticket_id,
                      assignee_username=None, created_date=None,
                      update_date=None, resolution_date=None, bo_ids=None):
-
-    from ralph.operations.models import Operation
 
     operation_type = _safe_load_operation_type(operation_name)
 

--- a/src/ralph/operations/changemanagement/subscribtions.py
+++ b/src/ralph/operations/changemanagement/subscribtions.py
@@ -1,8 +1,9 @@
-import pyhermes
-from django.db import transaction
-from django.contrib.auth import get_user_model
-from django.conf import settings
 from importlib import import_module
+
+import pyhermes
+from django.conf import settings
+from django.contrib.auth import get_user_model
+from django.db import transaction
 
 
 def _safe_load_user(username):

--- a/src/ralph/operations/migrations/0005_auto_20170323_1425.py
+++ b/src/ralph/operations/migrations/0005_auto_20170323_1425.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+import ralph.lib.mixins.fields
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('operations', '0004_auto_20160307_1138'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='operation',
+            name='ticket_id',
+            field=ralph.lib.mixins.fields.TicketIdField(null=True, unique=True, max_length=200, verbose_name='ticket id', blank=True, help_text='External system ticket identifier'),
+        ),
+    ]

--- a/src/ralph/operations/migrations/0006_auto_20170323_1530.py
+++ b/src/ralph/operations/migrations/0006_auto_20170323_1530.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('operations', '0005_auto_20170323_1425'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='operation',
+            name='status',
+            field=models.PositiveIntegerField(verbose_name='status', choices=[(1, 'open'), (2, 'in progress'), (3, 'resolved'), (4, 'closed'), (5, 'reopened'), (6, 'todo'), (7, 'blocked')], default=1),
+        ),
+    ]

--- a/src/ralph/operations/models.py
+++ b/src/ralph/operations/models.py
@@ -24,6 +24,9 @@ class OperationStatus(Choices):
     in_progress = _('in progress')
     resolved = _('resolved')
     closed = _('closed')
+    reopened = _('reopened')
+    todo = _('todo')
+    blocked = _('blocked')
 
 
 class OperationType(

--- a/src/ralph/operations/models.py
+++ b/src/ralph/operations/models.py
@@ -77,7 +77,7 @@ class Operation(AdminAbsoluteUrlMixin, TaggableMixin, models.Model):
         blank=True,
         on_delete=models.PROTECT,
     )
-    ticket_id = TicketIdField()
+    ticket_id = TicketIdField(unique=True, verbose_name=_('ticket id'))
     created_date = models.DateTimeField(
         null=True, blank=True, verbose_name=_('created date'),
     )

--- a/src/ralph/operations/tests/sample_jira_event.json
+++ b/src/ralph/operations/tests/sample_jira_event.json
@@ -149,7 +149,7 @@
             "customfield_10802": null,
             "issuetype": {
                 "self": "https://jira.example.com/rest/api/2/issuetype/20",
-                "name": "Change-OP",
+                "name": "Change",
                 "description": "Operational Change Issue Type for Support/Maintenance",
                 "id": "20",
                 "avatarId": 31010,

--- a/src/ralph/operations/tests/sample_jira_event.json
+++ b/src/ralph/operations/tests/sample_jira_event.json
@@ -1,0 +1,295 @@
+{
+    "issue_event_type_name": "issue_updated",
+    "webhookEvent": "jira:issue_updated",
+    "user": {
+        "self": "https://jira.example.com/rest/api/2/user?username=username.fortytwo",
+        "name": "username.fortytwo",
+        "key": "username.fortytwo",
+        "displayName": "Username Fortytwo",
+        "avatarUrls": {
+            "32x32": "https://jira.example.com/secure/useravatar?size=medium&ownerId=username.fortytwo&avatarId=44502",
+            "24x24": "https://jira.example.com/secure/useravatar?size=small&ownerId=username.fortytwo&avatarId=44502",
+            "48x48": "https://jira.example.com/secure/useravatar?ownerId=username.fortytwo&avatarId=44502",
+            "16x16": "https://jira.example.com/secure/useravatar?size=xsmall&ownerId=username.fortytwo&avatarId=44502"
+        },
+        "emailAddress": "username.fortytwo@example.com",
+        "timeZone": "Europe/Warsaw",
+        "active": true
+    },
+    "timestamp": 1490009623877,
+    "issue": {
+        "self": "https://jira.example.com/rest/api/2/issue/1960071",
+        "fields": {
+            "resolutiondate": null,
+            "customfield_11606": "Restoring previous configuration from backup (stored on rancid servers) ",
+            "timespent": null,
+            "customfield_11401": null,
+            "lastViewed": "2017-03-20T12:29:01.739+0100",
+            "customfield_11625": null,
+            "environment": null,
+            "project": {
+                "self": "https://jira.example.com/rest/api/2/project/35801",
+                "name": "LBaaS Technical Queue",
+                "key": "LBAASTQ",
+                "id": "35801",
+                "projectCategory": {
+                    "self": "https://jira.example.com/rest/api/2/projectCategory/10001",
+                    "name": "Projects",
+                    "description": "It is a space to conduct a project. ",
+                    "id": "10001"
+                },
+                "avatarUrls": {
+                    "32x32": "https://jira.example.com/secure/projectavatar?size=medium&pid=35801&avatarId=22305",
+                    "24x24": "https://jira.example.com/secure/projectavatar?size=small&pid=35801&avatarId=22305",
+                    "48x48": "https://jira.example.com/secure/projectavatar?pid=35801&avatarId=22305",
+                    "16x16": "https://jira.example.com/secure/projectavatar?size=xsmall&pid=35801&avatarId=22305"
+                }
+            },
+            "customfield_14600": [],
+            "customfield_14300": null,
+            "comment": {
+                "total": 0,
+                "maxResults": 0,
+                "startAt": 0,
+                "comments": []
+            },
+            "timeestimate": null,
+            "customfield_10601": null,
+            "customfield_11618": null,
+            "customfield_13700": null,
+            "aggregatetimeestimate": null,
+            "timeoriginalestimate": null,
+            "customfield_10702": null,
+            "customfield_13300": {
+                "self": "https://jira.example.com/rest/api/2/customFieldOption/15605",
+                "id": "15605",
+                "value": "Low"
+            },
+            "customfield_10400": null,
+            "customfield_15100": null,
+            "aggregatetimespent": null,
+            "customfield_10500": null,
+            "customfield_15101": null,
+            "customfield_11603": null,
+            "worklog": {
+                "total": 0,
+                "maxResults": 20,
+                "startAt": 0,
+                "worklogs": []
+            },
+            "customfield_11602": "2017-03-20T10:10:00.000+0100",
+            "customfield_13403": null,
+            "versions": [],
+            "issuelinks": [],
+            "customfield_10513": [
+                {
+                    "self": "https://jira.example.com/rest/api/2/customFieldOption/21605",
+                    "id": "21605",
+                    "value": "Load balancing (F5)"
+                }
+            ],
+            "customfield_13404": null,
+            "customfield_11611": {
+                "self": "https://jira.example.com/rest/api/2/customFieldOption/10943",
+                "id": "10943",
+                "value": "Infrastructure/DB Servers"
+            },
+            "customfield_11607": null,
+            "customfield_10503": null,
+            "timetracking": {},
+            "customfield_11300": null,
+            "customfield_15000": null,
+            "summary": "THIS IS THE SUMMARY",
+            "customfield_11624": null,
+            "created": "2017-03-20T10:10:40.000+0100",
+            "customfield_10600": null,
+            "customfield_10003": null,
+            "customfield_13900": null,
+            "customfield_11400": null,
+            "resolution": null,
+            "aggregatetimeoriginalestimate": null,
+            "customfield_13803": null,
+            "assignee": {
+                "self": "https://jira.example.com/rest/api/2/user?username=username.fortytwo",
+                "name": "username.fortytwo",
+                "key": "username.fortytwo",
+                "displayName": "Username Fortytwo",
+                "avatarUrls": {
+                    "32x32": "https://jira.example.com/secure/useravatar?size=medium&ownerId=username.fortytwo&avatarId=44502",
+                    "24x24": "https://jira.example.com/secure/useravatar?size=small&ownerId=username.fortytwo&avatarId=44502",
+                    "48x48": "https://jira.example.com/secure/useravatar?ownerId=username.fortytwo&avatarId=44502",
+                    "16x16": "https://jira.example.com/secure/useravatar?size=xsmall&ownerId=username.fortytwo&avatarId=44502"
+                },
+                "emailAddress": "username.fortytwo@example.com",
+                "timeZone": "Europe/Warsaw",
+                "active": true
+            },
+            "customfield_13406": null,
+            "customfield_10300": null,
+            "customfield_14301": null,
+            "fixVersions": [],
+            "customfield_13405": null,
+            "customfield_10004": "9223372036854775807",
+            "customfield_13200": null,
+            "customfield_14800": null,
+            "customfield_10100": null,
+            "customfield_10002": null,
+            "customfield_15001": null,
+            "customfield_11619": null,
+            "customfield_10302": null,
+            "progress": {
+                "total": 0,
+                "progress": 0
+            },
+            "customfield_10800": null,
+            "customfield_13400": null,
+            "customfield_13603": null,
+            "customfield_10502": null,
+            "customfield_13602": null,
+            "customfield_10802": null,
+            "issuetype": {
+                "self": "https://jira.example.com/rest/api/2/issuetype/20",
+                "name": "Change-OP",
+                "description": "Operational Change Issue Type for Support/Maintenance",
+                "id": "20",
+                "avatarId": 31010,
+                "iconUrl": "https://jira.example.com/secure/viewavatar?size=xsmall&avatarId=31010&avatarType=issuetype",
+                "subtask": false
+            },
+            "customfield_11623": null,
+            "customfield_10510": null,
+            "components": [],
+            "customfield_14500": "2|i13fbr:",
+            "customfield_11621": "Tests are not possible due to lack of tests environment for services ",
+            "creator": {
+                "self": "https://jira.example.com/rest/api/2/user?username=username.fortytwo",
+                "name": "username.fortytwo",
+                "key": "username.fortytwo",
+                "displayName": "Username Fortytwo",
+                "avatarUrls": {
+                    "32x32": "https://jira.example.com/secure/useravatar?size=medium&ownerId=username.fortytwo&avatarId=44502",
+                    "24x24": "https://jira.example.com/secure/useravatar?size=small&ownerId=username.fortytwo&avatarId=44502",
+                    "48x48": "https://jira.example.com/secure/useravatar?ownerId=username.fortytwo&avatarId=44502",
+                    "16x16": "https://jira.example.com/secure/useravatar?size=xsmall&ownerId=username.fortytwo&avatarId=44502"
+                },
+                "emailAddress": "username.fortytwo@example.com",
+                "timeZone": "Europe/Warsaw",
+                "active": true
+            },
+            "customfield_12300": null,
+            "subtasks": [],
+            "customfield_10301": null,
+            "status": {
+                "self": "https://jira.example.com/rest/api/2/status/1",
+                "name": "Open",
+                "description": "The issue is open and ready for the assignee to start work on it.",
+                "id": "1",
+                "statusCategory": {
+                    "self": "https://jira.example.com/rest/api/2/statuscategory/2",
+                    "colorName": "blue-gray",
+                    "name": "To Do",
+                    "key": "new",
+                    "id": 2
+                },
+                "iconUrl": "https://jira.example.com/images/icons/statuses/open.png"
+            },
+            "priority": {
+                "self": "https://jira.example.com/rest/api/2/priority/4",
+                "name": "Minor",
+                "iconUrl": "https://jira.example.com/images/icons/priorities/minor.svg",
+                "id": "4"
+            },
+            "updated": "2017-03-20T12:33:44.000+0100",
+            "labels": [
+                "net",
+                "seba",
+                "small",
+                "test-label"
+            ],
+            "customfield_12601": [
+                {
+                    "self": "https://jira.example.com/rest/api/2/user?username=username.fortytwo",
+                    "name": "username.fortytwo",
+                    "key": "username.fortytwo",
+                    "displayName": "Username Fortytwo",
+                    "avatarUrls": {
+                        "32x32": "https://jira.example.com/secure/useravatar?size=medium&ownerId=username.fortytwo&avatarId=44502",
+                        "24x24": "https://jira.example.com/secure/useravatar?size=small&ownerId=username.fortytwo&avatarId=44502",
+                        "48x48": "https://jira.example.com/secure/useravatar?ownerId=username.fortytwo&avatarId=44502",
+                        "16x16": "https://jira.example.com/secure/useravatar?size=xsmall&ownerId=username.fortytwo&avatarId=44502"
+                    },
+                    "emailAddress": "username.fortytwo@example.com",
+                    "timeZone": "Europe/Warsaw",
+                    "active": true
+                }
+            ],
+            "attachment": [],
+            "customfield_12700": null,
+            "customfield_11600": null,
+            "customfield_13000": null,
+            "workratio": -1,
+            "votes": {
+                "self": "https://jira.example.com/rest/api/2/issue/SOMEPROJ-42/votes",
+                "hasVoted": false,
+                "votes": 0
+            },
+            "customfield_11601": "2017-03-31T10:10:00.000+0200",
+            "customfield_12100": null,
+            "customfield_10504": null,
+            "customfield_13100": "{hide-templates=[true]}",
+            "watches": {
+                "self": "https://jira.example.com/rest/api/2/issue/SOMEPROJ-42/watchers",
+                "isWatching": true,
+                "watchCount": 1
+            },
+            "customfield_11501": null,
+            "reporter": {
+                "self": "https://jira.example.com/rest/api/2/user?username=username.fortytwo",
+                "name": "username.fortytwo",
+                "key": "username.fortytwo",
+                "displayName": "Username Fortytwo",
+                "avatarUrls": {
+                    "32x32": "https://jira.example.com/secure/useravatar?size=medium&ownerId=username.fortytwo&avatarId=44502",
+                    "24x24": "https://jira.example.com/secure/useravatar?size=small&ownerId=username.fortytwo&avatarId=44502",
+                    "48x48": "https://jira.example.com/secure/useravatar?ownerId=username.fortytwo&avatarId=44502",
+                    "16x16": "https://jira.example.com/secure/useravatar?size=xsmall&ownerId=username.fortytwo&avatarId=44502"
+                },
+                "emailAddress": "username.fortytwo@example.com",
+                "timeZone": "Europe/Warsaw",
+                "active": true
+            },
+            "customfield_10000": null,
+            "customfield_15200": "com.atlassian.servicedesk.plugins.approvals.internal.customfield.ApprovalsCFValue@7f528b38",
+            "customfield_11622": null,
+            "customfield_11615": null,
+            "customfield_12801": {
+                "self": "https://jira.example.com/rest/api/2/customFieldOption/12101",
+                "id": "12101",
+                "value": "Low"
+            },
+            "description": "THAT IS A TEST TICKET",
+            "aggregateprogress": {
+                "total": 0,
+                "progress": 0
+            },
+            "duedate": null,
+            "customfield_10807": null,
+            "customfield_10001": null
+        },
+        "key": "SOMEPROJ-42",
+        "id": "1960071"
+    },
+    "changelog": {
+        "id": "11858052",
+        "items": [
+            {
+                "to": null,
+                "toString": "THAT IS A TEST TICKET",
+                "fromString": "PREVIOUS DESCRIPTION",
+                "field": "description",
+                "from": null,
+                "fieldtype": "jira"
+            }
+        ]
+    }
+}

--- a/src/ralph/operations/tests/test_event_receiver.py
+++ b/src/ralph/operations/tests/test_event_receiver.py
@@ -1,0 +1,50 @@
+import json
+from os import path
+
+from ralph.tests import RalphTestCase
+from ralph.operations.models import Operation, OperationStatus
+from ralph.operations.changemanagement.subscribtions import receive_chm_event
+
+
+class ChangesReceiverTestCase(RalphTestCase):
+
+    def setUp(self):
+        with open(
+            path.join(path.dirname(__file__), 'sample_jira_event.json'), 'r'
+        ) as f:
+            self.jira_event = json.load(f)
+
+    def test_new_event_records_operation(self):
+        receive_chm_event(self.jira_event)
+
+        op = Operation.objects.get(ticket_id='SOMEPROJ-42')
+
+        self.assertEqual('username.fortytwo', op.asignee.username)
+        self.assertEqual(OperationStatus.opened, op.status)
+
+    def test_recorded_operation_gets_updated(self):
+        assignee_bak = self.jira_event['issue']['fields']['assignee']
+        self.jira_event['issue']['fields']['assignee'] = None
+
+        receive_chm_event(self.jira_event)
+
+        op = Operation.objects.get(ticket_id='SOMEPROJ-42')
+        self.assertEqual(OperationStatus.opened, op.status)
+        self.assertEqual(None, op.asignee)
+
+        self.jira_event['issue']['fields']['assignee'] = assignee_bak
+        self.jira_event['issue']['fields']['status']['name'] = 'Closed'
+
+        receive_chm_event(self.jira_event)
+
+        op = Operation.objects.get(ticket_id='SOMEPROJ-42')
+        self.assertEqual(OperationStatus.closed, op.status)
+        self.assertEqual('username.fortytwo', op.asignee.username)
+
+    def test_no_record_created_unknown_operation_type(self):
+        self.jira_event['issue']['fields']['issuetype']['name'] = 'DEADBEEF'
+
+        receive_chm_event(self.jira_event)
+
+        with self.assertRaises(Operation.DoesNotExist):
+            Operation.objects.get(ticket_id='SOMEPROJ-42')

--- a/src/ralph/operations/tests/test_event_receiver.py
+++ b/src/ralph/operations/tests/test_event_receiver.py
@@ -48,3 +48,11 @@ class ChangesReceiverTestCase(RalphTestCase):
 
         with self.assertRaises(Operation.DoesNotExist):
             Operation.objects.get(ticket_id='SOMEPROJ-42')
+
+    def test_no_record_created_unknown_operation_status(self):
+        self.jira_event['issue']['fields']['status']['name'] = 'DEADBEEF'
+
+        receive_chm_event(self.jira_event)
+
+        with self.assertRaises(Operation.DoesNotExist):
+            Operation.objects.get(ticket_id='SOMEPROJ-42')

--- a/src/ralph/operations/tests/test_event_receiver.py
+++ b/src/ralph/operations/tests/test_event_receiver.py
@@ -1,9 +1,9 @@
 import json
 from os import path
 
-from ralph.tests import RalphTestCase
-from ralph.operations.models import Operation, OperationStatus
 from ralph.operations.changemanagement.subscribtions import receive_chm_event
+from ralph.operations.models import Operation, OperationStatus
+from ralph.tests import RalphTestCase
 
 
 class ChangesReceiverTestCase(RalphTestCase):

--- a/src/ralph/operations/tests/test_jira_processor.py
+++ b/src/ralph/operations/tests/test_jira_processor.py
@@ -1,0 +1,75 @@
+from datetime import datetime
+import json
+from os import path
+
+from ralph.operations.changemanagement import jira
+from ralph.tests import RalphTestCase
+from ralph.operations.models import OperationStatus
+
+
+class JiraProcessorTestCase(RalphTestCase):
+
+    def setUp(self):
+        with open(
+            path.join(path.dirname(__file__), 'sample_jira_event.json'), 'r'
+        ) as f:
+            self.jira_event = json.load(f)
+
+    def test_get_assignee_username(self):
+        self.assertEqual(
+            'username.fortytwo',
+            jira.get_assignee_username(self.jira_event)
+        )
+
+    def test_get_assiignee_username_no_assignee_returns_none(self):
+        self.jira_event['issue']['fields']['assignee'] = None
+        self.assertIsNone(jira.get_assignee_username(self.jira_event))
+
+    def test_get_title(self):
+        self.assertEqual(
+            'THIS IS THE SUMMARY',
+            jira.get_title(self.jira_event)
+        )
+
+    def test_get_description(self):
+        self.assertEqual(
+            'THAT IS A TEST TICKET',
+            jira.get_description(self.jira_event)
+        )
+
+    def test_get_create_datetime(self):
+        self.assertEqual(
+            datetime(2017, 3, 20, 9, 10, 40, 0),
+            jira.get_creation_date(self.jira_event)
+        )
+
+    def test_get_last_update_datetime(self):
+        self.assertEqual(
+            datetime(2017, 3, 20, 11, 33, 44, 0),
+            jira.get_last_update_date(self.jira_event)
+        )
+
+    def test_get_resolution_datetime(self):
+        self.jira_event['issue']['fields']['resolutiondate'] = (
+            '2017-03-20T14:10:40.000+0100'
+        )
+
+        self.assertEqual(
+            datetime(2017, 3, 20, 13, 10, 40, 0),
+            jira.get_resolution_date(self.jira_event)
+        )
+
+    def test_get_resolution_datetime_no_time_returns_none(self):
+        self.assertIsNone(jira.get_resolution_date(self.jira_event))
+
+    def test_get_ticket_id(self):
+        self.assertEqual('SOMEPROJ-42', jira.get_ticket_id(self.jira_event))
+
+    def test_get_operation_name(self):
+        self.assertEqual('Change-OP', jira.get_operation_name(self.jira_event))
+
+    def test_get_operation_status(self):
+        self.assertEqual(
+            OperationStatus.opened,
+            jira.get_operation_status(self.jira_event)
+        )

--- a/src/ralph/operations/tests/test_jira_processor.py
+++ b/src/ralph/operations/tests/test_jira_processor.py
@@ -1,10 +1,10 @@
-from datetime import datetime
 import json
+from datetime import datetime
 from os import path
 
 from ralph.operations.changemanagement import jira
-from ralph.tests import RalphTestCase
 from ralph.operations.models import OperationStatus
+from ralph.tests import RalphTestCase
 
 
 class JiraProcessorTestCase(RalphTestCase):

--- a/src/ralph/operations/tests/test_jira_processor.py
+++ b/src/ralph/operations/tests/test_jira_processor.py
@@ -73,3 +73,9 @@ class JiraProcessorTestCase(RalphTestCase):
             OperationStatus.opened,
             jira.get_operation_status(self.jira_event)
         )
+
+    def test_get_operation_status_bad_status_raises_KeyError(self):
+        self.jira_event['issue']['fields']['status']['name'] = 'DEADBEEF'
+
+        with self.assertRaises(KeyError):
+            jira.get_operation_status(self.jira_event)

--- a/src/ralph/operations/tests/test_jira_processor.py
+++ b/src/ralph/operations/tests/test_jira_processor.py
@@ -66,7 +66,7 @@ class JiraProcessorTestCase(RalphTestCase):
         self.assertEqual('SOMEPROJ-42', jira.get_ticket_id(self.jira_event))
 
     def test_get_operation_name(self):
-        self.assertEqual('Change-OP', jira.get_operation_name(self.jira_event))
+        self.assertEqual('Change', jira.get_operation_name(self.jira_event))
 
     def test_get_operation_status(self):
         self.assertEqual(

--- a/src/ralph/operations/tests/test_models.py
+++ b/src/ralph/operations/tests/test_models.py
@@ -1,7 +1,8 @@
+from django.db import IntegrityError
 from django.forms import ValidationError
 
 from ralph.operations.models import OperationType
-from ralph.operations.tests.factories import FailureFactory
+from ralph.operations.tests.factories import ChangeFactory, FailureFactory
 from ralph.tests import RalphTestCase
 
 
@@ -16,3 +17,10 @@ class OperationModelsTestCase(RalphTestCase):
             msg='Invalid Operation type. Choose descendant of Failure'
         ):
             self.failure.clean()
+
+    def test_ticket_id_unique(self):
+        ticket_id = 'FOO-42'
+        ChangeFactory(ticket_id=ticket_id)
+
+        with self.assertRaises(IntegrityError):
+            ChangeFactory(ticket_id=ticket_id)

--- a/src/ralph/settings/base.py
+++ b/src/ralph/settings/base.py
@@ -457,7 +457,9 @@ CHANGE_MGMT_OPERATION_STATUSES = {
     )
 }
 
-CHANGE_MGMT_BO_LOADER = os.getenv('CHANGE_MGMT_BO_LOADER', None)
+CHANGE_MGMT_BASE_OBJECT_LOADER = os.getenv(
+    'CHANGE_MGMT_BASE_OBJECT_LOADER', None
+)
 CHANGE_MGMT_PROCESSOR = os.getenv(
     'CHANGE_MGMT_PROCESSOR', 'ralph.operations.changemanagement.jira'
 )

--- a/src/ralph/settings/base.py
+++ b/src/ralph/settings/base.py
@@ -431,6 +431,45 @@ DOMAIN_OWNER_TYPE = {
     'TO': 'Technical Owner',
 }
 
+# Change management settings
+
+CHANGE_MGMT_OPERATION_STATUSES = {
+    'OPENED': os.getenv(
+        'CHANGE_MGMT_OPERATION_STATUS_OPENED', 'Open'
+    ),
+    'IN_PROGRESS': os.getenv(
+        'CHANGE_MGMT_OPERATION_STATUS_IN_PROGRESS', 'In Progress'
+    ),
+    'RESOLVED': os.getenv(
+        'CHANGE_MGMT_OPERATION_STATUS_RESOLVED', 'Resolved'
+    ),
+    'CLOSED': os.getenv(
+        'CHANGE_MGMT_OPERATION_STATUS_CLOSED', 'Closed'
+    ),
+    'REOPENED': os.getenv(
+        'CHANGE_MGMT_OPERATION_STATUS_REOPENED', 'Reopened'
+    ),
+    'TODO': os.getenv(
+        'CHANGE_MGMT_OPERATION_STATUS_TODO', 'Todo'
+    ),
+    'BLOCKED': os.getenv(
+        'CHANGE_MGMT_OPERATION_STATUS_BLOCKED', 'Blocked'
+    )
+}
+
+CHANGE_MGMT_BO_LOADER = os.getenv('CHANGE_MGMT_BO_LOADER', None)
+CHANGE_MGMT_PROCESSOR = os.getenv(
+    'CHANGE_MGMT_PROCESSOR', 'ralph.operations.changemanagement.jira'
+)
+
+HERMES_CHANGE_MGMT_TOPICS = {
+    'CHANGES': os.getenv(
+        'HERMES_CHANGE_MGMT_CHANGES_TOPIC', 'hermes.changemanagement.changes'
+    )
+}
+
+
+# Hermes settings
 
 ENABLE_HERMES_INTEGRATION = bool_from_env('ENABLE_HERMES_INTEGRATION')
 HERMES = json.loads(os.environ.get('HERMES', '{}'))


### PR DESCRIPTION
This patch adds a generic subscriber for receiving and recording
change management events and a Jira processor for it. Base object
loading logic should be implemented for every secific case so it
is not included.

It also makes operations identifiable by their thicket_ids and extends
the list of possible operation statuses.