### PR TITLE
Fix `Assets Supports` export

### DIFF
--- a/src/ralph/data_importer/resources.py
+++ b/src/ralph/data_importer/resources.py
@@ -582,7 +582,7 @@ class BaseObjectsSupportRichResource(RalphModelResource):
         support = bo_support.support
         return str(
             bo_support.objects_count / support.price
-            if support.price > 0 else 0
+            if support.price else 0
         )
 
 

--- a/src/ralph/data_importer/tests/test_export.py
+++ b/src/ralph/data_importer/tests/test_export.py
@@ -14,11 +14,12 @@ from ralph.licences.tests.factories import (
     LicenceFactory,
     LicenceUserFactory
 )
-from ralph.supports.models import Support
+from ralph.supports.models import BaseObjectsSupport, Support
 from ralph.supports.tests.factories import (
     BackOfficeAssetSupportFactory,
+    BaseObjectsSupportFactory,
     DataCenterAssetSupportFactory,
-    SupportFactory
+    SupportFactory,
 )
 
 
@@ -103,3 +104,13 @@ class DataCenterAssetExporterTestCase(SimulateAdminExportTestCase):
         export_data = self._export(DataCenterAsset)
         # check if management ip is properly exported
         self.assertNotEqual(export_data.dict[0]['management_ip'], '')
+
+
+class BaseObjectsSupportExporterTestCase(SimulateAdminExportTestCase):
+
+    def test_support_export_works_with_support_without_price(self):
+        support = SupportFactory(price=None)
+        BaseObjectsSupportFactory(support=support)
+        export_data = self._export(BaseObjectsSupport)
+        self.assertEqual(export_data.dict[0]['support__price'], '')
+        self.assertEqual(export_data.dict[0]['support__price_per_object'], '0')

--- a/src/ralph/data_importer/tests/test_export.py
+++ b/src/ralph/data_importer/tests/test_export.py
@@ -19,7 +19,7 @@ from ralph.supports.tests.factories import (
     BackOfficeAssetSupportFactory,
     BaseObjectsSupportFactory,
     DataCenterAssetSupportFactory,
-    SupportFactory,
+    SupportFactory
 )
 
 

--- a/src/ralph/settings/test.py
+++ b/src/ralph/settings/test.py
@@ -7,26 +7,13 @@ sys.path.append(os.path.join(BASE_DIR, '..', '..', 'contrib', 'dhcp_agent'))
 
 DEBUG = False
 
-TEST_DB_ENGINE = os.environ.get('TEST_DB_ENGINE', 'sqlite')
-
-if TEST_DB_ENGINE == 'mysql':
-    # use default mysql settings
-    if not os.environ.get('DATABASE_PASSWORD'):
-        DATABASES['default']['PASSWORD'] = None
-elif TEST_DB_ENGINE == 'psql':
+TEST_DB_ENGINE = os.environ.get('TEST_DB_ENGINE', 'mysql')
+if TEST_DB_ENGINE == 'psql':
     DATABASES['default'].update({
         'ENGINE': 'transaction_hooks.backends.postgresql_psycopg2',
         'PORT': os.environ.get('DATABASE_PORT', 5432),
         'OPTIONS': {},
     })
-else:  # use sqlite as default
-    DATABASES = {
-        'default': {
-            'ENGINE': 'transaction_hooks.backends.sqlite3',
-            'NAME': ':memory:',
-            'ATOMIC_REQUESTS': True,
-        }
-    }
 
 INSTALLED_APPS += (
     'ralph.lib.mixins',


### PR DESCRIPTION
Now export works even when exists support without price.

Also:
* Use MySQL as default DB in tests (SQLite is not supported anymore)