### PR TITLE
Refactor operation status

### DIFF
--- a/src/ralph/admin/sitetrees.py
+++ b/src/ralph/admin/sitetrees.py
@@ -263,6 +263,7 @@ sitetrees = [
                 section(_('Failures'), 'operations', 'Failure'),
                 section(_('All'), 'operations', 'Operation'),
                 section(_('Types'), 'operations', 'OperationType'),
+                section(_('Statuses'), 'operations', 'OperationStatus'),
             ]
         ),
         ralph_item(

--- a/src/ralph/admin/tests/tests_views.py
+++ b/src/ralph/admin/tests/tests_views.py
@@ -74,6 +74,7 @@ FACTORY_MAP = {
     'ralph.operations.models.Operation': 'ralph.operations.tests.factories.OperationFactory',  # noqa
     'ralph.operations.models.OperationType': 'ralph.operations.tests.factories.OperationTypeFactory',  # noqa
     'ralph.operations.models.Problem': 'ralph.operations.tests.factories.ProblemFactory',  # noqa
+    'ralph.operations.models.OperationStatus': 'ralph.operations.tests.factories.OperationStatusFactory',  # noqa
     'ralph.reports.models.Report': 'ralph.reports.factories.ReportFactory',
     'ralph.reports.models.ReportLanguage': 'ralph.reports.factories.ReportLanguageFactory',  # noqa
     'ralph.supports.models.BaseObjectsSupport': 'ralph.supports.tests.factories.BaseObjectsSupportFactory',  # noqa

--- a/src/ralph/operations/admin.py
+++ b/src/ralph/operations/admin.py
@@ -5,11 +5,13 @@ from ralph.admin import RalphAdmin, RalphMPTTAdmin, register
 from ralph.admin.mixins import RalphAdminForm
 from ralph.attachments.admin import AttachmentsMixin
 from ralph.data_importer import resources
+from ralph.operations.filters import StatusFilter
 from ralph.operations.models import (
     Change,
     Failure,
     Incident,
     Operation,
+    OperationStatus,
     OperationType,
     Problem
 )
@@ -26,6 +28,12 @@ class OperationTypeAdmin(RalphMPTTAdmin):
         return False
 
 
+@register(OperationStatus)
+class OperationStatusAdmin(RalphAdmin):
+    list_display = ('name',)
+    search_fields = ['name']
+
+
 class OperationAdminForm(RalphAdminForm):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -40,10 +48,12 @@ class OperationAdminForm(RalphAdminForm):
 @register(Operation)
 class OperationAdmin(AttachmentsMixin, RalphAdmin):
     search_fields = ['title', 'description', 'ticket_id']
-    list_filter = ['type', 'status', 'assignee', 'ticket_id', 'base_objects',
-                   'created_date', 'update_date', 'resolved_date']
+    list_filter = ['type', ('status', StatusFilter), 'assignee', 'ticket_id',
+                   'base_objects', 'created_date', 'update_date',
+                   'resolved_date']
     list_display = ['title', 'type', 'created_date', 'status', 'assignee',
                     'get_ticket_url']
+    list_select_related = ('assignee', 'type', 'status')
     raw_id_fields = ['assignee', 'base_objects']
     resource_class = resources.OperationResource
     form = OperationAdminForm

--- a/src/ralph/operations/api.py
+++ b/src/ralph/operations/api.py
@@ -3,7 +3,7 @@ from django.db.models import Prefetch
 from ralph.accounts.api_simple import SimpleRalphUserSerializer
 from ralph.api import RalphAPISerializer, RalphAPIViewSet, router
 from ralph.assets.models import BaseObject
-from ralph.operations.models import Operation, OperationType
+from ralph.operations.models import Operation, OperationStatus, OperationType
 
 
 class OperationTypeSerializer(RalphAPISerializer):
@@ -13,9 +13,17 @@ class OperationTypeSerializer(RalphAPISerializer):
         depth = 1
 
 
+class OperationStatusSerializer(RalphAPISerializer):
+
+    class Meta:
+        model = OperationStatus
+        depth = 1
+
+
 class OperationSerializer(RalphAPISerializer):
     type = OperationTypeSerializer()
     assignee = SimpleRalphUserSerializer()
+    status = OperationStatusSerializer()
 
     class Meta:
         model = Operation
@@ -30,7 +38,7 @@ class OperationViewSet(RalphAPIViewSet):
         )
     )
     serializer_class = OperationSerializer
-    select_related = ['type', 'assignee']
+    select_related = ['type', 'assignee', 'status']
     filter_fields = [
         'id', 'title', 'description', 'status', 'ticket_id', 'created_date',
         'update_date', 'resolved_date', 'type__name'
@@ -42,6 +50,12 @@ class OperationTypeViewSet(RalphAPIViewSet):
     serializer_class = OperationTypeSerializer
 
 
+class OperationStatusViewSet(RalphAPIViewSet):
+    queryset = OperationStatus.objects.all()
+    serializer_class = OperationStatusSerializer
+
+
 router.register(r'operation', OperationViewSet)
 router.register(r'operationtype', OperationTypeViewSet)
+router.register(r'operationstatus', OperationStatusViewSet)
 urlpatterns = []

--- a/src/ralph/operations/api.py
+++ b/src/ralph/operations/api.py
@@ -1,6 +1,7 @@
 from django.db.models import Prefetch
+from rest_framework.serializers import SlugRelatedField
 
-from ralph.accounts.api_simple import SimpleRalphUserSerializer
+from ralph.accounts.models import RalphUser
 from ralph.api import RalphAPISerializer, RalphAPIViewSet, router
 from ralph.assets.models import BaseObject
 from ralph.operations.models import Operation, OperationStatus, OperationType
@@ -21,9 +22,24 @@ class OperationStatusSerializer(RalphAPISerializer):
 
 
 class OperationSerializer(RalphAPISerializer):
-    type = OperationTypeSerializer()
-    assignee = SimpleRalphUserSerializer()
-    status = OperationStatusSerializer()
+    type = SlugRelatedField(
+        many=False,
+        read_only=False,
+        slug_field='name',
+        queryset=OperationType.objects.all()
+    )
+    assignee = SlugRelatedField(
+        many=False,
+        read_only=False,
+        slug_field='username',
+        queryset=RalphUser.objects.all()
+    )
+    status = SlugRelatedField(
+        many=False,
+        read_only=False,
+        slug_field='name',
+        queryset=OperationStatus.objects.all()
+    )
 
     class Meta:
         model = Operation
@@ -38,10 +54,12 @@ class OperationViewSet(RalphAPIViewSet):
         )
     )
     serializer_class = OperationSerializer
+    save_serializer_class = OperationSerializer
     select_related = ['type', 'assignee', 'status']
     filter_fields = [
-        'id', 'title', 'description', 'status', 'ticket_id', 'created_date',
-        'update_date', 'resolved_date', 'type__name'
+        'id', 'title', 'description', 'status', 'status', 'ticket_id',
+        'created_date', 'update_date', 'resolved_date', 'type',
+        'assignee'
     ]
 
 

--- a/src/ralph/operations/changemanagement/jira.py
+++ b/src/ralph/operations/changemanagement/jira.py
@@ -2,10 +2,6 @@ import logging
 from datetime import timezone
 
 from dateutil.parser import parse as parse_datetime
-from django.conf import settings
-
-from ralph.operations.changemanagement.exceptions import IgnoreOperation
-from ralph.operations.models import OperationStatus
 
 
 logger = logging.getLogger(__name__)
@@ -24,26 +20,7 @@ def get_ticket_id(event_data):
 
 
 def get_operation_status(event_data):
-    status_conf = settings.CHANGE_MGMT_OPERATION_STATUSES
-    status_map = {
-        status_conf['OPENED']: OperationStatus.opened,
-        status_conf['IN_PROGRESS']: OperationStatus.in_progress,
-        status_conf['RESOLVED']: OperationStatus.resolved,
-        status_conf['CLOSED']: OperationStatus.closed,
-        status_conf['REOPENED']: OperationStatus.reopened,
-        status_conf['TODO']: OperationStatus.todo,
-        status_conf['BLOCKED']: OperationStatus.blocked
-    }
-
-    try:
-        status_str = event_data['issue']['fields']['status']['name']
-        return status_map[status_str]
-    except KeyError:
-        logger.error(
-            'Received an operation with unexpected '
-            'status: {}. Please check the settings.'.format(status_str)
-        )
-        raise IgnoreOperation()
+    return event_data['issue']['fields']['status']['name']
 
 
 def get_operation_name(event_data):

--- a/src/ralph/operations/filters.py
+++ b/src/ralph/operations/filters.py
@@ -1,0 +1,22 @@
+from ralph.admin.filters import ChoicesListFilter
+from ralph.operations.models import OperationStatus
+
+
+class StatusFilter(ChoicesListFilter):
+
+    def __init__(self, *args, **kwargs):
+        super(StatusFilter, self).__init__(*args, **kwargs)
+
+        statuses = OperationStatus.objects.order_by('name')
+
+        self._choices_list = [
+            (status.id, status.name) for status in statuses
+        ]
+
+    def queryset(self, request, queryset):
+        if not self.value():
+            return queryset
+
+        return queryset.filter(
+            status__id=int(self.value())
+        )

--- a/src/ralph/operations/filters.py
+++ b/src/ralph/operations/filters.py
@@ -18,5 +18,5 @@ class StatusFilter(ChoicesListFilter):
             return queryset
 
         return queryset.filter(
-            status__id=int(self.value())
+            status_id=int(self.value())
         )

--- a/src/ralph/operations/fixtures/operation_statuses.json
+++ b/src/ralph/operations/fixtures/operation_statuses.json
@@ -1,0 +1,51 @@
+[
+{
+    "fields": {
+        "name": "Open"
+    },
+    "pk": 1,
+    "model": "operations.operationstatus"
+},
+{
+    "fields": {
+        "name": "In Progress"
+    },
+    "pk": 2,
+    "model": "operations.operationstatus"
+},
+{
+    "fields": {
+        "name": "Resolved"
+    },
+    "pk": 3,
+    "model": "operations.operationstatus"
+},
+{
+    "fields": {
+        "name": "Closed"
+    },
+    "pk": 4,
+    "model": "operations.operationstatus"
+},
+{
+    "fields": {
+        "name": "Reopened"
+    },
+    "pk": 5,
+    "model": "operations.operationstatus"
+},
+{
+    "fields": {
+        "name": "Todo"
+    },
+    "pk": 6,
+    "model": "operations.operationstatus"
+},
+{
+    "fields": {
+        "name": "Blocked"
+    },
+    "pk": 7,
+    "model": "operations.operationstatus"
+}
+]

--- a/src/ralph/operations/migrations/0010_auto_20170410_1031.py
+++ b/src/ralph/operations/migrations/0010_auto_20170410_1031.py
@@ -63,13 +63,19 @@ class Migration(migrations.Migration):
                     'id',
                     models.AutoField(
                         serialize=False, primary_key=True,
-                        auto_created=True, verbose_name='ID')
+                        auto_created=True, verbose_name='ID'
+                    )
                 ),
                 (
                     'name',
-                    models.CharField(max_length=255)
+                    models.CharField(
+                        verbose_name='name',
+                        max_length=255,
+                        unique=True
+                    )
                 ),
             ],
+            options={'ordering': ['name']}
         ),
         migrations.RunPython(load_old_operation_status, atomic=True),
         migrations.AlterField(

--- a/src/ralph/operations/migrations/0010_auto_20170410_1031.py
+++ b/src/ralph/operations/migrations/0010_auto_20170410_1031.py
@@ -1,0 +1,83 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+from dj.choices import Choices
+from django.conf import settings
+import django.db.models.deletion
+
+from ralph.operations.models import OperationStatus
+
+
+class OldOperationStatus(Choices):
+    _ = Choices.Choice
+
+    opened = _('open')
+    in_progress = _('in progress')
+    resolved = _('resolved')
+    closed = _('closed')
+    reopened = _('reopened')
+    todo = _('todo')
+    blocked = _('blocked')
+
+
+def safe_convert_status(status_name):
+    try:
+        status_conf = settings.CHANGE_MGMT_OPERATION_STATUSES
+
+        status_map = {
+            OldOperationStatus.opened.raw: status_conf['OPENED'],
+            OldOperationStatus.in_progress.raw: status_conf['IN_PROGRESS'],
+            OldOperationStatus.resolved.raw: status_conf['RESOLVED'],
+            OldOperationStatus.closed.raw: status_conf['CLOSED'],
+            OldOperationStatus.reopened.raw: status_conf['REOPENED'],
+            OldOperationStatus.todo.raw: status_conf['TODO'],
+            OldOperationStatus.blocked.raw: status_conf['BLOCKED']
+        }
+
+        return status_map[status_name]
+    except (TypeError, KeyError):
+        return status_name
+
+
+def load_old_operation_status(foo, bar):
+
+    for st_id, st_name in OldOperationStatus():
+        OperationStatus.objects.create(
+            id=st_id,
+            name=safe_convert_status(st_name)
+        )
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('operations', '0009_auto_20170403_1112'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='OperationStatus',
+            fields=[
+                (
+                    'id',
+                    models.AutoField(
+                        serialize=False, primary_key=True,
+                        auto_created=True, verbose_name='ID')
+                ),
+                (
+                    'name',
+                    models.CharField(max_length=255)
+                ),
+            ],
+        ),
+        migrations.RunPython(load_old_operation_status, atomic=True),
+        migrations.AlterField(
+            model_name='operation',
+            name='status',
+            field=models.ForeignKey(
+                on_delete=django.db.models.deletion.PROTECT,
+                to='operations.OperationStatus', verbose_name='status'
+            ),
+        ),
+    ]

--- a/src/ralph/operations/models.py
+++ b/src/ralph/operations/models.py
@@ -17,16 +17,8 @@ from ralph.lib.mixins.models import (
 )
 
 
-class OperationStatus(Choices):
-    _ = Choices.Choice
-
-    opened = _('open')
-    in_progress = _('in progress')
-    resolved = _('resolved')
-    closed = _('closed')
-    reopened = _('reopened')
-    todo = _('todo')
-    blocked = _('blocked')
+class OperationStatus(AdminAbsoluteUrlMixin, NamedMixin, models.Model):
+    pass
 
 
 class OperationType(
@@ -69,9 +61,12 @@ class Operation(AdminAbsoluteUrlMixin, TaggableMixin, models.Model):
     description = models.TextField(
         verbose_name=_('description'), null=True, blank=True,
     )
-    status = models.PositiveIntegerField(
-        verbose_name=_('status'), choices=OperationStatus(),
-        default=OperationStatus.opened.id,
+    status = models.ForeignKey(
+        OperationStatus,
+        verbose_name=_('status'),
+        null=False,
+        blank=False,
+        on_delete=models.PROTECT
     )
     assignee = models.ForeignKey(
         settings.AUTH_USER_MODEL,

--- a/src/ralph/operations/tests/factories.py
+++ b/src/ralph/operations/tests/factories.py
@@ -17,6 +17,10 @@ def get_operation_type(name):
     return OperationType.objects.get(name=name)
 
 
+def get_operation_status(name):
+    return OperationStatus.objects.get(name=name)
+
+
 class OperationTypeFactory(DjangoModelFactory):
 
     name = factory.Iterator(['Problem', 'Incident', 'Failure', 'Change'])
@@ -26,10 +30,19 @@ class OperationTypeFactory(DjangoModelFactory):
         django_get_or_create = ['name']
 
 
+class OperationStatusFactory(DjangoModelFactory):
+
+    name = factory.Iterator(['Open', 'Closed', 'Resolved', 'In Progress'])
+
+    class Meta:
+        model = OperationStatus
+        django_get_or_create = ['name']
+
+
 class OperationFactory(DjangoModelFactory):
 
     title = factory.Sequence(lambda n: 'Operation #%d' % n)
-    status = OperationStatus.opened
+    status = factory.LazyAttribute(lambda obj: get_operation_status('Open'))
     type = factory.LazyAttribute(lambda obj: get_operation_type('Change'))
 
     class Meta:

--- a/src/ralph/operations/tests/factories.py
+++ b/src/ralph/operations/tests/factories.py
@@ -2,6 +2,7 @@
 import factory
 from factory.django import DjangoModelFactory
 
+from ralph.accounts.tests.factories import UserFactory
 from ralph.operations.models import (
     Change,
     Failure,
@@ -44,6 +45,7 @@ class OperationFactory(DjangoModelFactory):
     title = factory.Sequence(lambda n: 'Operation #%d' % n)
     status = factory.LazyAttribute(lambda obj: get_operation_status('Open'))
     type = factory.LazyAttribute(lambda obj: get_operation_type('Change'))
+    assignee = factory.SubFactory(UserFactory)
 
     class Meta:
         model = Operation

--- a/src/ralph/operations/tests/test_api.py
+++ b/src/ralph/operations/tests/test_api.py
@@ -6,7 +6,7 @@ from ralph.operations.tests.factories import OperationFactory
 
 
 class OperationsAPITestCase(RalphAPITestCase):
-    fixtures = ['operation_types']
+    fixtures = ['operation_types', 'operation_statuses']
 
     def test_list_operations(self):
         num_operations = 10
@@ -34,5 +34,5 @@ class OperationsAPITestCase(RalphAPITestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
         received_op = response.data
-        self.assertEqual(received_op['status'], op.status.raw)
+        self.assertEqual(received_op['status']['name'], op.status.name)
         self.assertEqual(received_op['title'], op.title)

--- a/src/ralph/operations/tests/test_api.py
+++ b/src/ralph/operations/tests/test_api.py
@@ -1,6 +1,7 @@
 from django.core.urlresolvers import reverse
 from rest_framework import status
 
+from ralph.accounts.tests.factories import UserFactory
 from ralph.api.tests._base import RalphAPITestCase
 from ralph.operations.tests.factories import OperationFactory
 
@@ -34,5 +35,23 @@ class OperationsAPITestCase(RalphAPITestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
         received_op = response.data
-        self.assertEqual(received_op['status']['name'], op.status.name)
+        self.assertEqual(received_op['status'], op.status.name)
         self.assertEqual(received_op['title'], op.title)
+
+    def test_operation_create(self):
+        user = UserFactory()
+        op_data = {
+             'title': 'deadbeef-title',
+             'description': 'deadbeef-description',
+             'status': 'Open',
+             'type': 'Change',
+             'assignee': user.username
+        }
+
+        resp = self.client.post(
+             reverse('operation-list'),
+             data=op_data,
+             format='json',
+         )
+
+        self.assertEqual(resp.status_code, 201)

--- a/src/ralph/operations/tests/test_jira_processor.py
+++ b/src/ralph/operations/tests/test_jira_processor.py
@@ -71,12 +71,6 @@ class JiraProcessorTestCase(RalphTestCase):
 
     def test_get_operation_status(self):
         self.assertEqual(
-            OperationStatus.opened,
+            'Open',
             jira.get_operation_status(self.jira_event)
         )
-
-    def test_get_operation_status_bad_status_raises_IgnoreOperation(self):
-        self.jira_event['issue']['fields']['status']['name'] = 'DEADBEEF'
-
-        with self.assertRaises(IgnoreOperation):
-            jira.get_operation_status(self.jira_event)

--- a/src/ralph/operations/views.py
+++ b/src/ralph/operations/views.py
@@ -47,8 +47,8 @@ class OperationInlineReadOnlyForExisting(OperationInline):
 
 class OperationInlineAddOnly(OperationInline):
     can_delete = False
-    verbose_name_plural = _('Add new Operations')
-    fields = ['title', 'description', 'type', 'ticket_id']
+    verbose_name_plural = _('Add new Operation')
+    fields = ['title', 'description', 'type', 'status', 'ticket_id']
 
     def has_change_permission(self, request, obj=None):
         return False


### PR DESCRIPTION
List of possible operation statuses along with their meaning is
a flexible matter, especially in cases, when an external change
management software is used. Given that, having to rewrite and
release a new version of Ralph in order to adapt to the changes
is not a way to go.

This patch removes a hard-coded list of statuses from Ralph and
replaces it with a reference to a manageable entity called
OperationStatus. Those entities are manageable botj over the API
and the UI.

The change management listener's behavior was also set to create
new operation types in responce to incomming messages instead of
ignoring operations that have an unknown status.