### PR TITLE
Fix infinite redirect loop on domain details view

### DIFF
--- a/src/ralph/domains/models/domains.py
+++ b/src/ralph/domains/models/domains.py
@@ -44,7 +44,7 @@ class WebsiteType(Choices):
     direct = _('Direct')
 
 
-class Domain(BaseObject, AdminAbsoluteUrlMixin):
+class Domain(AdminAbsoluteUrlMixin, BaseObject):
     name = models.CharField(
         verbose_name=_('domain name'),
         help_text=_('Full domain name'),


### PR DESCRIPTION
Fix infinite redirect loop when user click on Basic info tab on domain details view