### PR TITLE
Assign reporters to operations

### DIFF
--- a/src/ralph/operations/admin.py
+++ b/src/ralph/operations/admin.py
@@ -48,21 +48,22 @@ class OperationAdminForm(RalphAdminForm):
 @register(Operation)
 class OperationAdmin(AttachmentsMixin, RalphAdmin):
     search_fields = ['title', 'description', 'ticket_id']
-    list_filter = ['type', ('status', StatusFilter), 'assignee', 'ticket_id',
-                   'base_objects', 'created_date', 'update_date',
-                   'resolved_date']
-    list_display = ['title', 'type', 'created_date', 'status', 'assignee',
+    list_filter = ['type', ('status', StatusFilter), 'reporter',
+                   'assignee', 'ticket_id', 'base_objects', 'created_date',
+                   'update_date', 'resolved_date']
+    list_display = ['title', 'type', 'created_date', 'status', 'reporter',
                     'get_ticket_url']
-    list_select_related = ('assignee', 'type', 'status')
-    raw_id_fields = ['assignee', 'base_objects']
+    list_select_related = ('assignee', 'reporter', 'type', 'status')
+    raw_id_fields = ['assignee', 'reporter', 'base_objects']
     resource_class = resources.OperationResource
     form = OperationAdminForm
 
     fieldsets = (
         (_('Basic info'), {
             'fields': (
-                'type', 'title', 'status', 'assignee', 'description',
-                'ticket_id', 'created_date', 'update_date', 'resolved_date',
+                'type', 'title', 'status', 'reporter', 'assignee',
+                'description', 'ticket_id', 'created_date', 'update_date',
+                'resolved_date',
             )
         }),
         (_('Objects'), {

--- a/src/ralph/operations/api.py
+++ b/src/ralph/operations/api.py
@@ -34,6 +34,12 @@ class OperationSerializer(RalphAPISerializer):
         slug_field='username',
         queryset=RalphUser.objects.all()
     )
+    reporter = SlugRelatedField(
+        many=False,
+        read_only=False,
+        slug_field='username',
+        queryset=RalphUser.objects.all()
+    )
     status = SlugRelatedField(
         many=False,
         read_only=False,
@@ -55,11 +61,11 @@ class OperationViewSet(RalphAPIViewSet):
     )
     serializer_class = OperationSerializer
     save_serializer_class = OperationSerializer
-    select_related = ['type', 'assignee', 'status']
+    select_related = ['type', 'assignee', 'reporter', 'status']
     filter_fields = [
         'id', 'title', 'description', 'status', 'status', 'ticket_id',
         'created_date', 'update_date', 'resolved_date', 'type',
-        'assignee'
+        'assignee', 'reporter'
     ]
 
 

--- a/src/ralph/operations/changemanagement/jira.py
+++ b/src/ralph/operations/changemanagement/jira.py
@@ -35,6 +35,14 @@ def get_assignee_username(event_data):
         return None
 
 
+def get_reporter_username(event_data):
+    try:
+        return event_data['issue']['fields']['reporter']['key']
+    except TypeError:
+        # NOTE(romcheg): This means the reporter is not specified.
+        return None
+
+
 def get_creation_date(event_data):
     return _safe_load_datetime(event_data, 'created')
 

--- a/src/ralph/operations/changemanagement/subscribtions.py
+++ b/src/ralph/operations/changemanagement/subscribtions.py
@@ -66,8 +66,8 @@ def _load_base_objects(object_ids):
 
 @transaction.atomic
 def record_operation(title, status_name, description, operation_name, ticket_id,
-                     assignee_username=None, created_date=None,
-                     update_date=None, resolution_date=None,
+                     assignee_username=None, reporter_username=None,
+                     created_date=None, update_date=None, resolution_date=None,
                      base_object_ids=None):
 
     operation_type = _safe_load_operation_type(operation_name)
@@ -88,6 +88,7 @@ def record_operation(title, status_name, description, operation_name, ticket_id,
             status=_safe_load_status(status_name),
             type=operation_type,
             assignee=_safe_load_user(assignee_username),
+            reporter=_safe_load_user(reporter_username),
             created_date=created_date,
             update_date=update_date,
             resolved_date=resolution_date
@@ -110,6 +111,9 @@ def receive_chm_event(event_data):
             status_name=change_processor.get_operation_status(event_data),
             operation_name=change_processor.get_operation_name(event_data),
             assignee_username=change_processor.get_assignee_username(
+                event_data
+            ),
+            reporter_username=change_processor.get_reporter_username(
                 event_data
             ),
             created_date=change_processor.get_creation_date(event_data),

--- a/src/ralph/operations/migrations/0011_operation_reporter.py
+++ b/src/ralph/operations/migrations/0011_operation_reporter.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+from django.conf import settings
+import django.db.models.deletion
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        migrations.swappable_dependency(settings.AUTH_USER_MODEL),
+        ('operations', '0010_auto_20170410_1031'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='operation',
+            name='reporter',
+            field=models.ForeignKey(null=True, blank=True, verbose_name='reporter', to=settings.AUTH_USER_MODEL, on_delete=django.db.models.deletion.PROTECT, related_name='reported_operations'),
+        ),
+    ]

--- a/src/ralph/operations/models.py
+++ b/src/ralph/operations/models.py
@@ -76,6 +76,14 @@ class Operation(AdminAbsoluteUrlMixin, TaggableMixin, models.Model):
         blank=True,
         on_delete=models.PROTECT,
     )
+    reporter = models.ForeignKey(
+        settings.AUTH_USER_MODEL,
+        related_name='reported_operations',
+        verbose_name=_('reporter'),
+        null=True,
+        blank=True,
+        on_delete=models.PROTECT,
+    )
     ticket_id = TicketIdField(unique=True, verbose_name=_('ticket id'))
     created_date = models.DateTimeField(
         null=True, blank=True, verbose_name=_('created date'),

--- a/src/ralph/operations/tests/sample_jira_event.json
+++ b/src/ralph/operations/tests/sample_jira_event.json
@@ -245,16 +245,16 @@
             "customfield_11501": null,
             "reporter": {
                 "self": "https://jira.example.com/rest/api/2/user?username=username.fortytwo",
-                "name": "username.fortytwo",
-                "key": "username.fortytwo",
-                "displayName": "Username Fortytwo",
+                "name": "username.fourtwenty",
+                "key": "username.fourtwenty",
+                "displayName": "Username Fourtwenty",
                 "avatarUrls": {
-                    "32x32": "https://jira.example.com/secure/useravatar?size=medium&ownerId=username.fortytwo&avatarId=44502",
-                    "24x24": "https://jira.example.com/secure/useravatar?size=small&ownerId=username.fortytwo&avatarId=44502",
-                    "48x48": "https://jira.example.com/secure/useravatar?ownerId=username.fortytwo&avatarId=44502",
-                    "16x16": "https://jira.example.com/secure/useravatar?size=xsmall&ownerId=username.fortytwo&avatarId=44502"
+                    "32x32": "https://jira.example.com/secure/useravatar?size=medium&ownerId=username.fourtwenty&avatarId=44502",
+                    "24x24": "https://jira.example.com/secure/useravatar?size=small&ownerId=username.fourtwenty&avatarId=44502",
+                    "48x48": "https://jira.example.com/secure/useravatar?ownerId=username.fourtwenty&avatarId=44502",
+                    "16x16": "https://jira.example.com/secure/useravatar?size=xsmall&ownerId=username.fourtwenty&avatarId=44502"
                 },
-                "emailAddress": "username.fortytwo@example.com",
+                "emailAddress": "username.fourtwenty@example.com",
                 "timeZone": "Europe/Warsaw",
                 "active": true
             },

--- a/src/ralph/operations/tests/test_api.py
+++ b/src/ralph/operations/tests/test_api.py
@@ -3,6 +3,7 @@ from rest_framework import status
 
 from ralph.accounts.tests.factories import UserFactory
 from ralph.api.tests._base import RalphAPITestCase
+from ralph.operations.models import Operation
 from ralph.operations.tests.factories import OperationFactory
 
 
@@ -39,13 +40,17 @@ class OperationsAPITestCase(RalphAPITestCase):
         self.assertEqual(received_op['title'], op.title)
 
     def test_operation_create(self):
-        user = UserFactory()
+        assignee = UserFactory()
+        reporter = UserFactory()
+
         op_data = {
              'title': 'deadbeef-title',
              'description': 'deadbeef-description',
              'status': 'Open',
              'type': 'Change',
-             'assignee': user.username
+             'ticket_id': 'DEADBEEF-42',
+             'assignee': assignee.username,
+             'reporter': reporter.username
         }
 
         resp = self.client.post(
@@ -55,3 +60,12 @@ class OperationsAPITestCase(RalphAPITestCase):
          )
 
         self.assertEqual(resp.status_code, 201)
+
+        op = Operation.objects.get(ticket_id=op_data['ticket_id'])
+
+        self.assertEqual(op_data['title'], op.title)
+        self.assertEqual(op_data['description'], op.description)
+        self.assertEqual(op_data['assignee'], op.assignee.username)
+        self.assertEqual(op_data['reporter'], op.reporter.username)
+        self.assertEqual(op_data['type'], op.type.name)
+        self.assertEqual(op_data['status'], op.status.name)

--- a/src/ralph/operations/tests/test_event_receiver.py
+++ b/src/ralph/operations/tests/test_event_receiver.py
@@ -10,7 +10,7 @@ from ralph.tests import RalphTestCase
 
 class ChangesReceiverTestCase(RalphTestCase):
 
-    fixtures = ['operation_statuses']
+    fixtures = ['operation_types', 'operation_statuses']
 
     def setUp(self):
         with open(
@@ -24,6 +24,7 @@ class ChangesReceiverTestCase(RalphTestCase):
         op = Operation.objects.get(ticket_id='SOMEPROJ-42')
 
         self.assertEqual('username.fortytwo', op.assignee.username)
+        self.assertEqual('username.fourtwenty', op.reporter.username)
         self.assertEqual('Open', op.status.name)
 
     def test_recorded_operation_gets_updated(self):

--- a/src/ralph/operations/tests/test_jira_processor.py
+++ b/src/ralph/operations/tests/test_jira_processor.py
@@ -22,9 +22,19 @@ class JiraProcessorTestCase(RalphTestCase):
             jira.get_assignee_username(self.jira_event)
         )
 
-    def test_get_assiignee_username_no_assignee_returns_none(self):
+    def test_get_assignee_username_no_assignee_returns_none(self):
         self.jira_event['issue']['fields']['assignee'] = None
         self.assertIsNone(jira.get_assignee_username(self.jira_event))
+
+    def test_get_reporter_username(self):
+        self.assertEqual(
+            'username.fourtwenty',
+            jira.get_reporter_username(self.jira_event)
+        )
+
+    def test_get_reporter_username_no_reporter_returns_none(self):
+        self.jira_event['issue']['fields']['reporter'] = None
+        self.assertIsNone(jira.get_reporter_username(self.jira_event))
 
     def test_get_title(self):
         self.assertEqual(

--- a/src/ralph/operations/tests/test_models.py
+++ b/src/ralph/operations/tests/test_models.py
@@ -7,7 +7,7 @@ from ralph.tests import RalphTestCase
 
 
 class OperationModelsTestCase(RalphTestCase):
-    fixtures = ['operation_types']
+    fixtures = ['operation_types', 'operation_statuses']
 
     def setUp(self):
         self.failure = FailureFactory()

--- a/src/ralph/operations/views.py
+++ b/src/ralph/operations/views.py
@@ -8,8 +8,9 @@ from ralph.operations.models import Operation
 
 class OperationInline(RalphTabularM2MInline):
     model = Operation
-    raw_id_fields = ('assignee',)
-    fields = ['title', 'description', 'assignee', 'type', 'status', 'ticket_id']
+    raw_id_fields = ('assignee', 'reporter')
+    fields = ['title', 'description', 'reporter', 'type',
+              'status', 'ticket_id']
     extra = 1
     verbose_name = _('Operation')
 
@@ -27,7 +28,7 @@ class OperationInlineReadOnlyForExisting(OperationInline):
     show_change_link = True
     verbose_name_plural = _('Existing Operations')
     fields = [
-        'title', 'description', 'assignee', 'type', 'status', 'get_ticket_url'
+        'title', 'description', 'reporter', 'type', 'status', 'get_ticket_url'
     ]
 
     def get_readonly_fields(self, request, obj=None):


### PR DESCRIPTION
In order to improve tracking possibilities for every operation
this patch introduces a reporter property that replaces assignee
on in some listings.

Change-management event receiver will now also recognize and attach
reporter to new and existing changes.