### PR TITLE
Fetching available networks for cloud hosts

### DIFF
--- a/src/ralph/virtual/admin.py
+++ b/src/ralph/virtual/admin.py
@@ -207,6 +207,10 @@ class CloudNetworkInline(RalphTabularInline):
         return False
 
 
+class CloudHostNetworkView(NetworkView):
+    pass
+
+
 @register(CloudHost)
 class CloudHostAdmin(
     ScanStatusInChangeListMixin, CustomFieldValueAdminMixin, RalphAdmin
@@ -237,6 +241,7 @@ class CloudHostAdmin(
     raw_id_override_parent = {'parent': CloudProject}
     inlines = [CloudNetworkInline]
     change_views = [
+        CloudHostNetworkView,
         CloudHostSecurityInfoView
     ]
     fieldsets = (

--- a/src/ralph/virtual/models.py
+++ b/src/ralph/virtual/models.py
@@ -206,8 +206,8 @@ class CloudHost(PreviousStateMixin,
 
     @cached_property
     def rack(self):
-        if isinstance(self.hypervisor, DataCenterAsset):
-                return self.hypervisor.rack
+        if self.hypervisor:
+            return self.hypervisor.rack
         return None
 
     @property
@@ -373,10 +373,7 @@ class VirtualServer(
     def rack(self):
         if self.parent_id:
             polymorphic_parent = self.polymorphic_parent.last_descendant
-            if (
-                isinstance(polymorphic_parent, DataCenterAsset) or
-                isinstance(polymorphic_parent, CloudHost)
-            ):
+            if (isinstance(polymorphic_parent, (DataCenterAsset, CloudHost))):
                 return polymorphic_parent.rack
         return None
 

--- a/src/ralph/virtual/tests/test_models.py
+++ b/src/ralph/virtual/tests/test_models.py
@@ -32,7 +32,7 @@ from ralph.virtual.tests.factories import (
 
 # NOTE(romcheg): If at some point someone finds a better name for this
 #                they are welcome to propose it or change it oneself.
-class CommonCodeMixin(object):
+class NetworkableBaseObjectTestMixin(object):
     """Provides common code required for this test module."""
 
     def _generate_rack_with_networks(self, num_networks=5):
@@ -182,7 +182,7 @@ class OpenstackModelsTestCase(RalphTestCase):
         self.assertEqual(new_host.service_env, self.service_env[1])
 
 
-class CloudHostTestCase(RalphTestCase, CommonCodeMixin):
+class CloudHostTestCase(RalphTestCase, NetworkableBaseObjectTestMixin):
     def setUp(self):
         self.service = ServiceFactory()
         self.service_env = ServiceEnvironmentFactory(service=self.service)
@@ -234,7 +234,7 @@ class CloudHostTestCase(RalphTestCase, CommonCodeMixin):
         self.assertNetworksTheSame(nets, host._get_available_networks())
 
 
-class VirtualServerTestCase(RalphTestCase, CommonCodeMixin):
+class VirtualServerTestCase(RalphTestCase, NetworkableBaseObjectTestMixin):
     def setUp(self):
         self.vs = VirtualServerFullFactory()
         self.custom_field_str = CustomField.objects.create(


### PR DESCRIPTION
This patch allows to fetch available networks for cloud hosts
basing on the rack that contains the corresponding DC asset. It
also makes possible to fetch available networks for virtual servers
that are hosted by cloud hosts.