### PR TITLE
Filtering by configuration path and module for more objects

### DIFF
--- a/src/ralph/data_center/admin.py
+++ b/src/ralph/data_center/admin.py
@@ -343,7 +343,7 @@ class DataCenterAssetAdmin(
         'status', 'barcode', 'sn', 'hostname', 'invoice_no', 'invoice_date',
         'order_no', 'model__name',
         ('model__category', RelatedAutocompleteFieldListFilter), 'service_env',
-        ('configuration_path', TreeRelatedAutocompleteFilterWithDescendants),
+        'configuration_path__path',
         ('configuration_path__module', TreeRelatedAutocompleteFilterWithDescendants),  # noqa
         MacAddressFilter,
         'depreciation_end_date', 'force_depreciation', 'remarks',
@@ -568,7 +568,7 @@ class DCHostAdmin(ScanStatusInChangeListMixin, RalphAdmin):
     list_filter = [
         DCHostHostnameFilter,
         'service_env',
-        ('configuration_path', TreeRelatedAutocompleteFilterWithDescendants),
+        'configuration_path__path',
         ('configuration_path__module', TreeRelatedAutocompleteFilterWithDescendants),  # noqa
         ('content_type', DCHostTypeListFilter),
         MacAddressFilter,

--- a/src/ralph/data_center/admin.py
+++ b/src/ralph/data_center/admin.py
@@ -343,7 +343,7 @@ class DataCenterAssetAdmin(
         'status', 'barcode', 'sn', 'hostname', 'invoice_no', 'invoice_date',
         'order_no', 'model__name',
         ('model__category', RelatedAutocompleteFieldListFilter), 'service_env',
-        'configuration_path',
+        ('configuration_path', TreeRelatedAutocompleteFilterWithDescendants),
         ('configuration_path__module', TreeRelatedAutocompleteFilterWithDescendants),  # noqa
         MacAddressFilter,
         'depreciation_end_date', 'force_depreciation', 'remarks',
@@ -568,7 +568,8 @@ class DCHostAdmin(ScanStatusInChangeListMixin, RalphAdmin):
     list_filter = [
         DCHostHostnameFilter,
         'service_env',
-        'configuration_path',
+        ('configuration_path', TreeRelatedAutocompleteFilterWithDescendants),
+        ('configuration_path__module', TreeRelatedAutocompleteFilterWithDescendants),  # noqa
         ('content_type', DCHostTypeListFilter),
         MacAddressFilter,
         IPFilter,

--- a/src/ralph/virtual/admin.py
+++ b/src/ralph/virtual/admin.py
@@ -98,7 +98,7 @@ class VirtualServerAdmin(
     list_filter = [
         BaseObjectHostnameFilter, 'sn', 'service_env', IPFilter,
         'parent', TagsListFilter, MacAddressFilter,
-        ('configuration_path', TreeRelatedAutocompleteFilterWithDescendants),
+        'configuration_path__path',
         ('configuration_path__module', TreeRelatedAutocompleteFilterWithDescendants),  # noqa
         ('securityscan__vulnerabilities__patch_deadline', VulnerabilitesByPatchDeadline),  # noqa
         (
@@ -223,7 +223,7 @@ class CloudHostAdmin(
     list_filter = [
         BaseObjectHostnameFilter, 'cloudprovider', 'service_env',
         'cloudflavor', TagsListFilter,
-        ('configuration_path', TreeRelatedAutocompleteFilterWithDescendants),
+        'configuration_path__path',
         ('configuration_path__module', TreeRelatedAutocompleteFilterWithDescendants),  # noqa
         ('securityscan__vulnerabilities__patch_deadline', VulnerabilitesByPatchDeadline),  # noqa
         (

--- a/src/ralph/virtual/admin.py
+++ b/src/ralph/virtual/admin.py
@@ -92,12 +92,13 @@ class VirtualServerAdmin(
     CustomFieldValueAdminMixin,
     TransitionAdminMixin,
     RalphAdmin
-):
+    ):
     form = VirtualServerForm
     search_fields = ['hostname', 'sn', 'ethernet_set__ipaddress__hostname']
     list_filter = [
         BaseObjectHostnameFilter, 'sn', 'service_env', IPFilter,
         'parent', TagsListFilter, MacAddressFilter,
+        ('configuration_path', TreeRelatedAutocompleteFilterWithDescendants),
         ('configuration_path__module', TreeRelatedAutocompleteFilterWithDescendants),  # noqa
         ('securityscan__vulnerabilities__patch_deadline', VulnerabilitesByPatchDeadline),  # noqa
         (
@@ -222,6 +223,8 @@ class CloudHostAdmin(
     list_filter = [
         BaseObjectHostnameFilter, 'cloudprovider', 'service_env',
         'cloudflavor', TagsListFilter,
+        ('configuration_path', TreeRelatedAutocompleteFilterWithDescendants),
+        ('configuration_path__module', TreeRelatedAutocompleteFilterWithDescendants),  # noqa
         ('securityscan__vulnerabilities__patch_deadline', VulnerabilitesByPatchDeadline),  # noqa
         (
             'securityscan__vulnerabilities', RelatedAutocompleteFieldListFilter

--- a/src/ralph/virtual/admin.py
+++ b/src/ralph/virtual/admin.py
@@ -92,7 +92,7 @@ class VirtualServerAdmin(
     CustomFieldValueAdminMixin,
     TransitionAdminMixin,
     RalphAdmin
-    ):
+):
     form = VirtualServerForm
     search_fields = ['hostname', 'sn', 'ethernet_set__ipaddress__hostname']
     list_filter = [


### PR DESCRIPTION
This patch adds ability to filter objects DataCenterAsset, DCHost,
VirtualServer or CloudHost types by their configuration_path.module
and configuration_path.path.