### PR TITLE
Fixed override of AUTH_LDAP_USER_FLAGS_BY_GROUP

### DIFF
--- a/src/ralph/accounts/ldap.py
+++ b/src/ralph/accounts/ldap.py
@@ -21,11 +21,15 @@ LDAPSettings.defaults['GROUP_MAPPING'] = {}
 
 @receiver(populate_user)
 def staff_superuser_populate(sender, user, ldap_user, **kwargs):
-    user.is_superuser = 'superuser' in ldap_user.group_names
+    user.is_superuser = True if 'superuser' in ldap_user.group_names \
+        else user.is_superuser
+
     # only staff users will have access to ralph now,
     # because ralph using django admin panel
-    user.is_staff = 'active' in ldap_user.group_names
-    user.is_active = 'active' in ldap_user.group_names
+    user.is_staff = True if 'active' in ldap_user.group_names \
+        else user.is_staff
+    user.is_active = True if 'active' in ldap_user.group_names \
+        else user.is_active
 
 
 def mirror_groups(self):


### PR DESCRIPTION
- The attribute `AUTH_LDAP_USER_FLAGS_BY_GROUP`
  of `django_auth_ldap` is capable of setting the `is_active`,
  `is_staff` and `is_superuser` as well.
  But it got overridden by the receiver `staff_superuser_populate`
- Now both flavours are possible