### PR TITLE
Better export of DCAsset's parent

### DIFF
--- a/src/ralph/admin/mixins.py
+++ b/src/ralph/admin/mixins.py
@@ -400,9 +400,11 @@ class RalphAdminImportExportMixin(ImportExportModelAdmin):
         resource = self.get_export_resource_class()
         fk_fields = []
         for name, field in resource.fields.items():
-            if isinstance(field.widget, ForeignKeyWidget):
+            if (
+                isinstance(field.widget, ForeignKeyWidget) and
+                not getattr(field, '_exclude_in_select_related', False)
+            ):
                 fk_fields.append(field.attribute)
-
         if fk_fields:
             queryset = queryset.select_related(*fk_fields)
         resource_select_related = getattr(resource._meta, 'select_related', [])

--- a/src/ralph/data_importer/resources.py
+++ b/src/ralph/data_importer/resources.py
@@ -326,8 +326,11 @@ class DataCenterAssetResource(RalphModelResource):
             # notice that dc_asset.management_ip property could not be used
             # here, because it will omit prefetch_related cache
             for eth in dc_asset.ethernet_set.all():
-                if eth.ipaddress and eth.ipaddress.is_management:
-                    return eth.ipaddress
+                try:
+                    if eth.ipaddress and eth.ipaddress.is_management:
+                        return eth.ipaddress
+                except physical.IPAddress.DoesNotExist:
+                    pass
 
     def dehydrate_management_ip(self, dc_asset):
         return str(self._get_management_ip(dc_asset))


### PR DESCRIPTION
* export parent's management_ip
* show proper `str` of parent (instead of `BaseObject object` every time)