### PR TITLE
Facilitate accessing SCM status over API

### DIFF
--- a/src/ralph/assets/api/serializers.py
+++ b/src/ralph/assets/api/serializers.py
@@ -36,6 +36,7 @@ from ralph.assets.models.components import (
     Memory,
     Processor
 )
+from ralph.configuration_management.api import SCMInfoSerializer
 from ralph.lib.custom_fields.api import WithCustomFieldsSerializerMixin
 from ralph.licences.api_simple import SimpleBaseObjectLicenceSerializer
 from ralph.networks.api_simple import IPAddressSimpleSerializer
@@ -245,6 +246,7 @@ class BaseObjectPolymorphicSerializer(
     serializer).
     """
     service_env = ServiceEnvironmentSerializer()
+    scmstatuscheck = SCMInfoSerializer()
 
     class Meta:
         model = BaseObject

--- a/src/ralph/assets/api/views.py
+++ b/src/ralph/assets/api/views.py
@@ -125,7 +125,7 @@ class BaseObjectViewSet(PolymorphicViewSetMixin, RalphAPIViewSet):
     http_method_names = ['get', 'options', 'head']
     filter_fields = [
         'id', 'service_env', 'service_env', 'service_env__service__uid',
-        'content_type'
+        'content_type', 'scmstatuscheck__check_result'
     ]
     extended_filter_fields = {
         'name': BASE_OBJECT_NAME_FILTER_FIELDS,

--- a/src/ralph/data_center/api/serializers.py
+++ b/src/ralph/data_center/api/serializers.py
@@ -10,6 +10,7 @@ from ralph.assets.api.serializers import (
     NetworkComponentSerializerMixin,
     OwnersFromServiceEnvSerializerMixin
 )
+from ralph.configuration_management.api import SCMInfoSerializer
 from ralph.data_center.models import (
     Accessory,
     BaseObjectCluster,
@@ -118,6 +119,7 @@ class DataCenterAssetSimpleSerializer(RalphAPISerializer):
 
 class DataCenterAssetSerializer(ComponentSerializerMixin, AssetSerializer):
     rack = SimpleRackSerializer()
+    scmstatuscheck = SCMInfoSerializer()
 
     class Meta(AssetSerializer.Meta):
         model = DataCenterAsset

--- a/src/ralph/virtual/api.py
+++ b/src/ralph/virtual/api.py
@@ -17,6 +17,7 @@ from ralph.assets.api.views import (
     BaseObjectViewSetMixin
 )
 from ralph.assets.models import Ethernet
+from ralph.configuration_management.api import SCMInfoSerializer
 from ralph.data_center.api.serializers import DataCenterAssetSimpleSerializer
 from ralph.data_center.models import DCHost
 from ralph.virtual.admin import VirtualServerAdmin
@@ -106,6 +107,7 @@ class CloudHostSerializer(
     parent = CloudProjectSimpleSerializer(source='cloudproject')
     cloudflavor = CloudFlavorSimpleSerializer()
     service_env = ServiceEnvironmentSimpleSerializer()
+    scmstatuscheck = SCMInfoSerializer()
 
     class Meta(BaseObjectSerializer.Meta):
         model = CloudHost
@@ -137,6 +139,7 @@ class VirtualServerSerializer(ComponentSerializerMixin, BaseObjectSerializer):
     # TODO: cast BaseObject to DataCenterAsset for hypervisor field
     hypervisor = DataCenterAssetSimpleSerializer(source='parent')
     # TODO: clusters
+    scmstatuscheck = SCMInfoSerializer()
 
     class Meta(BaseObjectSerializer.Meta):
         model = VirtualServer


### PR DESCRIPTION
 - Allow to filter base objects by the check result of their SCM status.
 - Add SCM status information to the API output for base objects.