### PR TITLE
Bump tablib and fix ValueError

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -26,5 +26,5 @@ rq==0.5.6
 six>=1.9.0
 sqlparse==0.1.16
 Unidecode==0.04.18
-tablib==0.11.2
+tablib==0.11.5
 factory-boy


### PR DESCRIPTION
tablib 0.11.2 raise ``ValueError`` on python 3.6 (tablib#254)