### PR TITLE
Remove unique_together constraint on min_ip/max_ip

### DIFF
--- a/src/ralph/networks/models/networks.py
+++ b/src/ralph/networks/models/networks.py
@@ -397,7 +397,7 @@ class Network(
     class Meta:
         verbose_name = _('network')
         verbose_name_plural = _('networks')
-        unique_together = ('min_ip', 'max_ip')
+        #unique_together = ('min_ip', 'max_ip')
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)


### PR DESCRIPTION
This constraint breaks saving via the REST API due to the use of the save() method to calculate these fields values.

Resolves #3143.

From my reading of the code this constraint shouldn't be required so long as the model is calculating this field, since the validation is being enforced there. But otherwise the validator code needs to become custom in order to ignore the missing min_ip/max_ip fields when posting via REST.