### PR TITLE
Remove gender attribute from the user model

### DIFF
--- a/src/ralph/accounts/admin.py
+++ b/src/ralph/accounts/admin.py
@@ -276,7 +276,7 @@ class RalphUserAdmin(UserAdmin, RalphAdmin):
         }),
         (_('Profile'), {
             'fields': (
-                'gender', 'country', 'city'
+                'country', 'city'
             )
         }),
         (_('Job info'), {

--- a/src/ralph/accounts/migrations/0006_remove_ralphuser_gender.py
+++ b/src/ralph/accounts/migrations/0006_remove_ralphuser_gender.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('accounts', '0005_auto_20170814_1636'),
+    ]
+
+    operations = [
+        migrations.RemoveField(
+            model_name='ralphuser',
+            name='gender',
+        ),
+    ]

--- a/src/ralph/accounts/models.py
+++ b/src/ralph/accounts/models.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 import hashlib
 
-from dj.choices import Country, Gender
+from dj.choices import Country
 from django.conf import settings
 from django.contrib.auth.models import AbstractUser
 from django.db import models
@@ -70,11 +70,6 @@ class RalphUser(
     AutocompleteTooltipMixin
 ):
 
-    gender = models.PositiveIntegerField(
-        verbose_name=_('gender'),
-        choices=Gender(),
-        default=Gender.unspecified.id,
-    )
     country = models.PositiveIntegerField(
         verbose_name=_('country'),
         choices=Country(),
@@ -170,7 +165,7 @@ class RalphUser(
 
     def save(self, *args, **kwargs):
         # set default values if None provided
-        for field in ('gender', 'country'):
+        for field in ('country',):
             val = getattr(self, field)
             if val is None:
                 val = self._meta.get_field_by_name(field)[0].default

--- a/src/ralph/accounts/templates/ralphuser/user_profile.html
+++ b/src/ralph/accounts/templates/ralphuser/user_profile.html
@@ -41,12 +41,6 @@
             <dd>{{ request.user.get_city_display }}</dd>
           </dl>
         </div>
-        <div class="small-6 columns end">
-          <dl>
-            <dt>{% trans "Gender" %}</dt>
-            <dd>{{ request.user.get_gender_display }}</dd>
-          </dl>
-        </div>
       </div>
     </fieldset>
 

--- a/src/ralph/accounts/tests/tests.py
+++ b/src/ralph/accounts/tests/tests.py
@@ -2,9 +2,7 @@
 import unittest
 from datetime import date
 
-from dj.choices import Gender
 from django.conf import settings
-from django.contrib.auth import get_user_model
 from django.core.urlresolvers import reverse
 from django.test import TestCase
 from rest_framework import status
@@ -105,11 +103,6 @@ class RalphUserAPITests(RalphAPITestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data['count'], RalphUser.objects.count())
 
-    def test_user_gender_is_unspecified_by_default(self):
-            user = get_user_model().objects.create(username='testuser42')
-
-            self.assertEqual(user.gender, Gender.unspecified)
-
     def test_get_user_details(self):
         region = Region.objects.create(name='EU')
         self.user1.regions.add(region)
@@ -124,7 +117,6 @@ class RalphUserAPITests(RalphAPITestCase):
         self.assertEqual(response.data['first_name'], self.user1.first_name)
         self.assertEqual(response.data['last_name'], self.user1.last_name)
         self.assertEqual(response.data['regions'][0]['id'], region.id)
-        self.assertEqual(response.data['gender'], Gender.unspecified.raw)
         self.assertEqual(
             response.data['assets_as_owner'][0]['id'], bo_asset_as_owner.id
         )

--- a/src/ralph/locale/en/LC_MESSAGES/django.po
+++ b/src/ralph/locale/en/LC_MESSAGES/django.po
@@ -108,10 +108,6 @@ msgstr ""
 msgid "country"
 msgstr ""
 
-#: accounts/models.py:74
-msgid "gender"
-msgstr ""
-
 #: accounts/models.py:84
 msgid "city"
 msgstr ""


### PR DESCRIPTION
The information about users' genders is not required for
asset management and should be stored in connected services.