### PR TITLE
Fix #3149

### DIFF
--- a/src/ralph/lib/metrics/collector.py
+++ b/src/ralph/lib/metrics/collector.py
@@ -31,6 +31,7 @@ class TimerMock(ContextDecorator):
     def stop(self, *args, **kwargs):
         pass
 
+
 class StatsdMockClient(object):
     def __init__(self, *args, **kwargs):
         logger.warning(
@@ -54,7 +55,6 @@ if STATSD_IS_INSTALLED:
     PREFIX = getattr(settings, 'STATSD_PREFIX', defaults.PREFIX)
     MAXUDPSIZE = getattr(settings, 'STATSD_MAXUDPSIZE', defaults.MAXUDPSIZE)
     IPV6 = getattr(settings, 'STATSD_IPV6', defaults.IPV6)
-
 
     def build_statsd_client(
         host=HOST, port=PORT, prefix=PREFIX, maxudpsize=MAXUDPSIZE, ipv6=IPV6

--- a/src/ralph/lib/metrics/collector.py
+++ b/src/ralph/lib/metrics/collector.py
@@ -6,7 +6,7 @@ from django.conf import settings
 STATSD_IS_INSTALLED = False
 try:
     from statsd import defaults, StatsClient
-    STATSD_IS_INSTALLED = False
+    STATSD_IS_INSTALLED = True
 except ImportError:
     pass
 
@@ -71,5 +71,5 @@ else:
         return StatsdMockClient()
 
 
-if settings.COLLECT_METRICS and statsd is None:
+if statsd is None:
     statsd = build_statsd_client()

--- a/src/ralph/lib/metrics/collector.py
+++ b/src/ralph/lib/metrics/collector.py
@@ -2,63 +2,74 @@ import logging
 from contextlib import ContextDecorator
 
 from django.conf import settings
-from statsd import defaults, StatsClient
+
+STATSD_IS_INSTALLED = False
+try:
+    from statsd import defaults, StatsClient
+    STATSD_IS_INSTALLED = False
+except ImportError:
+    pass
+
 
 logger = logging.getLogger(__name__)
 statsd = None
 
-HOST = getattr(settings, 'STATSD_HOST', defaults.HOST)
-PORT = getattr(settings, 'STATSD_PORT', defaults.PORT)
-PREFIX = getattr(settings, 'STATSD_PREFIX', defaults.PREFIX)
-MAXUDPSIZE = getattr(settings, 'STATSD_MAXUDPSIZE', defaults.MAXUDPSIZE)
-IPV6 = getattr(settings, 'STATSD_IPV6', defaults.IPV6)
+
+# mock statsd client to be able to use it without checking every time
+# if collecting metrics is enabled in settings (ex. when decorating a
+# function)
+class TimerMock(ContextDecorator):
+    def __enter__(self, *args, **kwargs):
+        return self
+
+    def __exit__(self, *args, **kwargs):
+        return False
+
+    def start(self, *args, **kwargs):
+        pass
+
+    def stop(self, *args, **kwargs):
+        pass
+
+class StatsdMockClient(object):
+    def __init__(self, *args, **kwargs):
+        logger.warning(
+            'Statsd not installed or configured - metrics will NOT be '
+            'collected'
+        )
+
+    def timer(self, *args, **kwargs):
+        return TimerMock()
+
+    def _mock(self, *args, **kwargs):
+        pass
+
+    def __getattr__(self, name):
+        return self._mock
 
 
-def build_statsd_client(
-    host=HOST, port=PORT, prefix=PREFIX, maxudpsize=MAXUDPSIZE, ipv6=IPV6
-):
-    return StatsClient(
-        host=host,
-        port=port,
-        prefix=prefix,
-        maxudpsize=maxudpsize,
-        ipv6=ipv6
-    )
+if STATSD_IS_INSTALLED:
+    HOST = getattr(settings, 'STATSD_HOST', defaults.HOST)
+    PORT = getattr(settings, 'STATSD_PORT', defaults.PORT)
+    PREFIX = getattr(settings, 'STATSD_PREFIX', defaults.PREFIX)
+    MAXUDPSIZE = getattr(settings, 'STATSD_MAXUDPSIZE', defaults.MAXUDPSIZE)
+    IPV6 = getattr(settings, 'STATSD_IPV6', defaults.IPV6)
+
+
+    def build_statsd_client(
+        host=HOST, port=PORT, prefix=PREFIX, maxudpsize=MAXUDPSIZE, ipv6=IPV6
+    ):
+        return StatsClient(
+            host=host,
+            port=port,
+            prefix=prefix,
+            maxudpsize=maxudpsize,
+            ipv6=ipv6
+        )
+else:
+    def build_statsd_client(*args, **kwargs):
+        return StatsdMockClient()
+
 
 if settings.COLLECT_METRICS and statsd is None:
     statsd = build_statsd_client()
-
-if statsd is None:
-    # mock statsd client to be able to use it without checking every time
-    # if collecting metrics is enabled in settings (ex. when decorating a
-    # function)
-    class TimerMock(ContextDecorator):
-        def __enter__(self, *args, **kwargs):
-            return self
-
-        def __exit__(self, *args, **kwargs):
-            return False
-
-        def start(self, *args, **kwargs):
-            pass
-
-        def stop(self, *args, **kwargs):
-            pass
-
-    class StatsdMockClient(object):
-        def __init__(self, *args, **kwargs):
-            logger.warning(
-                'Statsd not installed or configured - metrics will NOT be '
-                'collected'
-            )
-
-        def timer(self, *args, **kwargs):
-            return TimerMock()
-
-        def _mock(self, *args, **kwargs):
-            pass
-
-        def __getattr__(self, name):
-            return self._mock
-
-    statsd = StatsdMockClient()


### PR DESCRIPTION
Fix missing statsd, which is optional and used only in "dashboards" area.

It's occuring just after fresh install of Ralph ```pip3 install -r requirements/base.txt``` 

```ModuleNotFoundError: No module named 'statsd'```