### PR TITLE
Preserve LF line endings for shell scripts

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+* text=auto
+
+*.sh text eol=lf

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,4 @@
 * text=auto
 
+# Preserve LF line endings for shell scripts, even on Windows
 *.sh text eol=lf


### PR DESCRIPTION
When developing on a Windows system, if the developer's git configuration includes `core.autocrlf true` (which is often [recommended](https://help.github.com/articles/dealing-with-line-endings/)), line endings in all text files will be written to the developer's repository as CRLF. Since the developer's repository is subsequently mounted by the ralph_ng VM, the deploy process attempts to run these shell scripts, which now have CRLF line endings. This fails with errors such as `$'\r': command not found`.

This `.gitattributes` file ensures that all shell scripts will have LF newlines, even when the repository is checked out on Windows.