### PR TITLE
Fix the issue that vagrant user has no write access to /home/ubuntu

### DIFF
--- a/vagrant/Vagrantfile
+++ b/vagrant/Vagrantfile
@@ -4,7 +4,7 @@ unless Vagrant.has_plugin?("vagrant-reload")
 end
 
 Vagrant.configure(2) do |config|
-    vm_user = "ubuntu"
+    vm_user = "vagrant"
     ralph_dir = "/home/#{vm_user}/ralph"
 
     config.vm.box = "ubuntu/xenial64"


### PR DESCRIPTION
The default user is vagrant when using "vagrant up", so vagrant user will have no access to "/home/ubuntu" when create venv directory or any other operations need write access.
When change "ubuntu" into "vagrant", the error disappeared. 