### PR TITLE
Add relations view for data center assets

### DIFF
--- a/src/ralph/data_center/admin.py
+++ b/src/ralph/data_center/admin.py
@@ -56,6 +56,7 @@ from ralph.data_center.models.virtual import (
     Database,
     VIP
 )
+from ralph.data_center.views import RelationsView
 from ralph.data_importer import resources
 from ralph.deployment.mixins import ActiveDeploymentMessageMixin
 from ralph.lib.custom_fields.admin import CustomFieldValueAdminMixin
@@ -330,6 +331,10 @@ class DataCenterAssetSCMInfo(SCMCheckInfo):
     url_name = 'datacenterasset_scm_info'
 
 
+class DataCenterAssetRelationsView(RelationsView):
+    url = 'datacenterasset_relations'
+
+
 @register(DataCenterAsset)
 class DataCenterAssetAdmin(
     SCMStatusCheckInChangeListMixin,
@@ -352,6 +357,7 @@ class DataCenterAssetAdmin(
         DataCenterAssetNetworkView,
         DataCenterAssetSecurityInfo,
         DataCenterAssetSCMInfo,
+        DataCenterAssetRelationsView,
         DataCenterAssetLicence,
         DataCenterAssetSupport,
         DataCenterAssetOperation,

--- a/src/ralph/data_center/templates/data_center/datacenterasset/relations.html
+++ b/src/ralph/data_center/templates/data_center/datacenterasset/relations.html
@@ -1,0 +1,42 @@
+{% extends BASE_TEMPLATE %}
+{% load i18n %}
+
+{% block bodyclass %}relations-tab{% endblock%}
+
+{% block view_content %}
+
+
+<h1>{% trans "Related objects" %}</h1>
+    {% if related_objects %}
+      {% for rel_obj_type, objects in related_objects.items %}
+          {% if rel_obj_type == "cloud_hosts" %}
+              <h2>{% trans "Cloud hosts" %}</h2>
+              <table>
+                  <tr>
+                      <th>{% trans "Hostname" %}</th>
+                      <th>{% trans "IP Address" %}</th>
+                      <th>{% trans "Cloud project" %}</th>
+                      <th>{% trans "Cloud provider" %}</th>
+                  </tr>
+                  {% for cloud_host in objects %}
+                      <tr>
+                          <td><a href="{{ cloud_host.get_absolute_url }}">{{ cloud_host.hostname }}</a></td>
+                          <td>
+                              {% for addr in cloud_host.ip_addresses %}
+                                  {{ addr }}<br>
+                              {% endfor %}
+                          </td>
+                          <td><a href="{{ cloud_host.cloudproject.get_absolute_url }}">{{ cloud_host.cloudproject.name }}</a></td>
+                          <td><a href="{{ cloud_host.cloudprovider.get_absolute_url }}">{{ cloud_host.cloudprovider.name }}</a></td>
+                      <tr>
+                  {% endfor %}
+              </table>
+          {% endif %}
+      {% endfor %}
+
+  {% else %}
+    <p>{% trans "No related objects found." %}</p>
+  {% endif %}
+
+
+{% endblock %}

--- a/src/ralph/data_center/views.py
+++ b/src/ralph/data_center/views.py
@@ -1,0 +1,23 @@
+from ralph.admin.views.extra import RalphDetailView
+
+
+class RelationsView(RalphDetailView):
+    icon = 'shekel'
+    label = 'Relations'
+    name = 'relations'
+    url_name = 'relations'
+    template_name = 'data_center/datacenterasset/relations.html'
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+
+        related_objects = {}
+
+        if self.object.cloudhost_set.exists():
+            related_objects['cloud_hosts'] = [
+                i for i in self.object.cloudhost_set.all()
+            ]
+
+        context['related_objects'] = related_objects
+
+        return context

--- a/src/ralph/data_center/views.py
+++ b/src/ralph/data_center/views.py
@@ -18,9 +18,7 @@ class RelationsView(RalphDetailView):
         context = super().get_context_data(**kwargs)
 
         related_objects = {}
-
         self._add_cloud_hosts(related_objects)
-
         context['related_objects'] = related_objects
 
         return context

--- a/src/ralph/data_center/views.py
+++ b/src/ralph/data_center/views.py
@@ -8,15 +8,18 @@ class RelationsView(RalphDetailView):
     url_name = 'relations'
     template_name = 'data_center/datacenterasset/relations.html'
 
+    def _add_cloud_hosts(self, related_objects):
+        cloud_hosts = list(self.object.cloudhost_set.all())
+
+        if cloud_hosts:
+            related_objects['cloud_hosts'] = cloud_hosts
+
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
 
         related_objects = {}
 
-        if self.object.cloudhost_set.exists():
-            related_objects['cloud_hosts'] = [
-                i for i in self.object.cloudhost_set.all()
-            ]
+        self._add_cloud_hosts(related_objects)
 
         context['related_objects'] = related_objects
 


### PR DESCRIPTION
At the moment only related cloud hosts are shown. If the idea works
in practice, more relations will be rendered.