### PR TITLE
Add sqlpqarse to requirements/base.txt

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -24,7 +24,7 @@ redis==2.10.3
 requests==2.9.1
 rq==0.5.6
 six>=1.9.0
-sqlparse==0.1.16
+sqlparse==0.2.3
 Unidecode==0.04.18
 tablib==0.11.5
 factory-boy


### PR DESCRIPTION
Django requires sqlparse for DB's vendors (excluding PostgreSQL).
@rcsheets thanks for testing.
For futher information, see
https://github.com/django/django/blob/2162f0983de0dfe2178531638ce7ea56f54dd4e7/django/db/backends/base/operations.py#L289-L307