### PR TITLE
add Service env for licences and supports

### DIFF
--- a/src/ralph/licences/admin.py
+++ b/src/ralph/licences/admin.py
@@ -89,13 +89,14 @@ class LicenceAdmin(
     ]
     date_hierarchy = 'created'
     list_display = [
-        'niw', 'licence_type', 'software', 'manufacturer', 'invoice_date',
-        'invoice_no', 'valid_thru', 'created', 'region', 'property_of',
-        'number_bought', 'used', 'free'
+        'niw', 'licence_type', 'software', 'manufacturer', 'service_env',
+        'invoice_date', 'invoice_no', 'valid_thru', 'created', 'region',
+        'property_of', 'number_bought', 'used', 'free'
     ]
     readonly_fields = ['used', 'free']
     list_select_related = [
-        'licence_type', 'software', 'region', 'property_of', 'manufacturer'
+        'licence_type', 'software', 'region', 'property_of', 'manufacturer',
+        'service_env', 'service_env__service', 'service_env__environment'
     ]
     raw_id_fields = [
         'software', 'manufacturer', 'budget_info', 'office_infrastructure',
@@ -120,6 +121,7 @@ class LicenceAdmin(
             'fields': (
                 'licence_type', 'manufacturer', 'software', 'niw', 'sn',
                 'valid_thru', 'license_details', 'region', 'remarks',
+                'service_env'
             )
         }),
         (_('Financial info'), {
@@ -127,7 +129,7 @@ class LicenceAdmin(
                 'order_no', 'invoice_no', 'price', 'invoice_date',
                 'number_bought', 'used', 'free', 'accounting_id',
                 'budget_info', 'provider', 'office_infrastructure',
-                'property_of', 'service_env'
+                'property_of'
             )
         }),
     )

--- a/src/ralph/licences/api.py
+++ b/src/ralph/licences/api.py
@@ -2,7 +2,10 @@
 from ralph.accounts.api_simple import SimpleRalphUserSerializer
 from ralph.api import RalphAPISerializer, RalphAPIViewSet, router
 from ralph.api.serializers import ReversionHistoryAPISerializerMixin
-from ralph.assets.api.serializers import BaseObjectSimpleSerializer
+from ralph.assets.api.serializers import (
+    BaseObjectSimpleSerializer,
+    ServiceEnvironmentSimpleSerializer
+)
 from ralph.licences.models import (
     BaseObjectLicence,
     Licence,
@@ -48,11 +51,12 @@ class LicenceSerializer(BaseObjectSimpleSerializer):
     users = LicenceUserSerializer(
         many=True, read_only=True, source='licenceuser_set'
     )
+    service_env = ServiceEnvironmentSimpleSerializer()
 
     class Meta:
         model = Licence
         depth = 1
-        exclude = ('content_type', 'service_env', 'configuration_path')
+        exclude = ('content_type', 'configuration_path')
 
 
 class SoftwareSerializer(RalphAPISerializer):
@@ -85,7 +89,8 @@ class LicenceViewSet(RalphAPIViewSet):
     serializer_class = LicenceSerializer
     select_related = [
         'region', 'manufacturer', 'office_infrastructure', 'licence_type',
-        'software'
+        'software', 'service_env', 'service_env__service',
+        'service_env__environment'
     ]
     prefetch_related = [
         'tags', 'users', 'licenceuser_set__user',

--- a/src/ralph/licences/tests/test_api.py
+++ b/src/ralph/licences/tests/test_api.py
@@ -4,6 +4,7 @@ from rest_framework import status
 
 from ralph.accounts.tests.factories import RegionFactory
 from ralph.api.tests._base import RalphAPITestCase
+from ralph.assets.tests.factories import ServiceEnvironmentFactory
 from ralph.back_office.tests.factories import BackOfficeAssetFactory
 from ralph.licences.models import BaseObjectLicence, Licence, LicenceUser
 from ralph.licences.tests.factories import LicenceFactory
@@ -21,6 +22,8 @@ class LicenceAPITests(RalphAPITestCase):
         BaseObjectLicence.objects.create(
             licence=self.licence2, base_object=self.base_object
         )
+        self.service_env = ServiceEnvironmentFactory()
+        self.licence4 = LicenceFactory(service_env=self.service_env)
 
     def test_get_licence_list(self):
         url = reverse('licence-list')
@@ -49,6 +52,23 @@ class LicenceAPITests(RalphAPITestCase):
         )
         self.assertEqual(
             response.data['users'][0]['user']['id'], self.user1.id,
+        )
+
+    def test_get_licence_with_service_env(self):
+        url = reverse('licence-detail', args=(self.licence4.id,))
+        response = self.client.get(url, format='json')
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(
+            response.data['service_env']['id'], self.service_env.id
+        )
+        self.assertEqual(
+            response.data['service_env']['service'],
+            self.service_env.service.name
+        )
+        self.assertEqual(
+            response.data['service_env']['environment'],
+            self.service_env.environment.name
         )
 
     def test_get_licence_with_base_object_details(self):

--- a/src/ralph/licences/tests/test_functional.py
+++ b/src/ralph/licences/tests/test_functional.py
@@ -42,13 +42,12 @@ class BaseObjectLicenceTest(ClientMixin, TestCase):
             data=data,
             follow=True
         )
-        new_licence = Licence.objects.order_by('-created').first()
+        new_licence = Licence.objects.get(niw='111')
 
         self.assertEqual(response.status_code, 200)
         self.assertNotIn('errors', response.context_data)
         self.assertEqual(new_licence.licence_type, self.licence.licence_type)
         self.assertEqual(new_licence.software, self.licence.software)
-        self.assertEqual(new_licence.niw, '111')
         self.assertEqual(new_licence.region, self.licence.region)
         self.assertEqual(new_licence.price, 100)
         self.assertEqual(new_licence.number_bought, 3)

--- a/src/ralph/supports/admin.py
+++ b/src/ralph/supports/admin.py
@@ -32,6 +32,19 @@ class BaseObjectSupportView(RalphDetailViewAdmin):
     inlines = [BaseObjectSupportInline]
 
 
+class SupportAdminForm(RalphAdmin.form):
+    """
+    Service_env is not required for Supports.
+    """
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        # backward compatibility
+        service_env_field = self.fields.get('service_env', None)
+        if service_env_field:
+            service_env_field.required = False
+
+
 @register(Support)
 class SupportAdmin(
     AttachmentsMixin,
@@ -44,6 +57,7 @@ class SupportAdmin(
 
     change_views = [BaseObjectSupportView]
     actions = ['bulk_edit_action']
+    form = SupportAdminForm
     search_fields = [
         'name', 'serial_no', 'contract_id', 'description', 'remarks'
     ]
@@ -54,25 +68,28 @@ class SupportAdmin(
     ]
     date_hierarchy = 'created'
     list_display = [
-        'support_type', 'contract_id', 'name', 'serial_no', 'date_from',
-        'date_to', 'created', 'remarks', 'description'
+        'support_type', 'contract_id', 'name', 'serial_no', 'service_env',
+        'date_from', 'date_to', 'created', 'remarks', 'description'
     ]
     bulk_edit_list = [
         'status', 'asset_type', 'contract_id', 'description', 'price',
         'date_from', 'date_to', 'escalation_path', 'contract_terms',
-        'sla_type', 'producer', 'supplier', 'serial_no', 'invoice_no',
-        'invoice_date', 'period_in_months', 'property_of', 'budget_info',
-        'support_type'
+        'sla_type', 'producer', 'supplier', 'serial_no', 'service_env',
+        'invoice_no', 'invoice_date', 'period_in_months', 'property_of',
+        'budget_info', 'support_type'
     ]
-    list_select_related = ['support_type']
+    list_select_related = [
+        'support_type', 'service_env', 'service_env__service',
+        'service_env__environment'
+    ]
     resource_class = resources.SupportResource
-    raw_id_fields = ['budget_info', 'region', 'support_type']
+    raw_id_fields = ['budget_info', 'region', 'support_type', 'service_env']
     fieldsets = (
         (_('Basic info'), {
             'fields': (
                 'support_type', 'name', 'status', 'producer', 'description',
                 'date_from', 'date_to', 'serial_no', 'escalation_path',
-                'region', 'remarks',
+                'region', 'remarks', 'service_env'
             )
         }),
         (_('Contract info'), {

--- a/src/ralph/supports/api.py
+++ b/src/ralph/supports/api.py
@@ -4,6 +4,7 @@ from rest_framework import serializers
 
 from ralph.api import RalphAPISerializer, RalphAPIViewSet, router
 from ralph.assets.api.serializers import (
+    ServiceEnvironmentSimpleSerializer,
     StrField,
     TypeFromContentTypeSerializerMixin
 )
@@ -36,17 +37,21 @@ class SupportSerializer(TypeFromContentTypeSerializerMixin, RalphAPISerializer):
     base_objects = serializers.HyperlinkedRelatedField(
         many=True, view_name='baseobject-detail', read_only=True
     )
+    service_env = ServiceEnvironmentSimpleSerializer()
 
     class Meta:
         model = Support
         depth = 1
-        exclude = ('content_type', 'service_env', 'configuration_path')
+        exclude = ('content_type', 'configuration_path')
 
 
 class SupportViewSet(RalphAPIViewSet):
     queryset = Support.objects.all()
     serializer_class = SupportSerializer
-    select_related = ['region', 'budget_info', 'support_type', 'property_of']
+    select_related = [
+        'region', 'budget_info', 'support_type', 'property_of', 'service_env',
+        'service_env__service', 'service_env__environment'
+    ]
     prefetch_related = ['tags', Prefetch(
         'base_objects', queryset=BaseObject.objects.all()
     )]

--- a/src/ralph/supports/tests/test_api.py
+++ b/src/ralph/supports/tests/test_api.py
@@ -6,6 +6,7 @@ from rest_framework import status
 
 from ralph.accounts.models import Region
 from ralph.api.tests._base import RalphAPITestCase
+from ralph.assets.tests.factories import ServiceEnvironmentFactory
 from ralph.supports.models import Support, SupportStatus
 from ralph.supports.tests.factories import SupportFactory
 
@@ -13,7 +14,11 @@ from ralph.supports.tests.factories import SupportFactory
 class SupportAPITests(RalphAPITestCase):
     def setUp(self):
         super().setUp()
-        self.support = SupportFactory(name='support1')
+        self.service_env = ServiceEnvironmentFactory()
+        self.support = SupportFactory(
+            name='support1',
+            service_env=self.service_env
+        )
 
     def test_get_supports_list(self):
         url = reverse('support-list')
@@ -32,6 +37,14 @@ class SupportAPITests(RalphAPITestCase):
         self.assertEqual(response.data['status'], 'new')
         self.assertEqual(
             response.data['support_type']['id'], self.support.support_type.id
+        )
+        self.assertEqual(
+            response.data['service_env']['service'],
+            self.service_env.service.name
+        )
+        self.assertEqual(
+            response.data['service_env']['environment'],
+            self.service_env.environment.name
         )
         # TODO: baseobjects
 


### PR DESCRIPTION
Add new field Service env to licence. Also expose this field in api endpoints for licence and support.
Service env is also added to bulk edit and on list view of licences and supports.