### PR TITLE
Introduce cloud synchronisation

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,6 +32,9 @@ setup(
             'test_ralph = ralph.__main__:test',
             'validate_ralph = ralph.cross_validator.__main__:main',
         ],
+        'ralph.cloud_sync_processors': [
+            'noop=ralph.virtual.processors.noop:endpoint',
+        ],
     },
     classifiers=[
         'Development Status :: 4 - Beta',

--- a/src/ralph/admin/tests/tests_views.py
+++ b/src/ralph/admin/tests/tests_views.py
@@ -93,6 +93,7 @@ FACTORY_MAP = {
     'ralph.virtual.models.CloudHost': 'ralph.virtual.tests.factories.CloudHostFullFactory',  # noqa
     'ralph.virtual.models.CloudProject': 'ralph.virtual.tests.factories.CloudProjectFactory',  # noqa
     'ralph.virtual.models.CloudProvider': 'ralph.virtual.tests.factories.CloudProviderFactory',  # noqa
+    'ralph.virtual.models.CloudSyncProcessor': 'ralph.virtual.tests.factories.CloudSyncProcessorFactory',  # noqa
     'ralph.virtual.models.VirtualServer': 'ralph.virtual.tests.factories.VirtualServerFullFactory',  # noqa
     'ralph.virtual.models.VirtualServerType': 'ralph.virtual.tests.factories.VirtualServerTypeFactory',  # noqa
     'ralph.security.models.Vulnerability': 'ralph.security.tests.factories.VulnerabilityFactory',  # noqa

--- a/src/ralph/apps.py
+++ b/src/ralph/apps.py
@@ -14,6 +14,7 @@ class RalphAppConfig(AppConfig):
         when app is ready.
         """
         super().ready()
+
         package = self.module.__name__
         for module in self.get_load_modules_when_ready():
             try:

--- a/src/ralph/urls/base.py
+++ b/src/ralph/urls/base.py
@@ -51,6 +51,7 @@ urlpatterns = [
     url(r'^', include('ralph.admin.autocomplete_urls')),
     url(r'^dhcp/', include('ralph.dhcp.urls')),
     url(r'^deployment/', include('ralph.deployment.urls')),
+    url(r'^virtual/', include('ralph.virtual.urls')),
     url(r'^', include('ralph.lib.transitions.urls')),
     url(r'^i18n/', include('django.conf.urls.i18n')),
     url(

--- a/src/ralph/virtual/admin.py
+++ b/src/ralph/virtual/admin.py
@@ -489,4 +489,5 @@ class CloudProjectAdmin(CustomFieldValueAdminMixin, RalphAdmin):
 
 @register(CloudProvider)
 class CloudProviderAdmin(RalphAdmin):
-    pass
+    list_display = ['name', 'cloud_sync_enabled', 'cloud_sync_driver']
+    list_filter = ['name', 'cloud_sync_enabled', 'cloud_sync_driver']

--- a/src/ralph/virtual/cloudsync.py
+++ b/src/ralph/virtual/cloudsync.py
@@ -1,0 +1,82 @@
+import json
+import logging
+import threading
+
+import pkg_resources
+from django.db.models import Q
+from django.http import (
+    HttpResponse,
+    HttpResponseBadRequest,
+    HttpResponseNotFound
+)
+from django.views.decorators.csrf import csrf_exempt
+from django.views.decorators.http import require_POST
+
+from ralph.virtual.models import CloudProvider
+
+logger = logging.getLogger(__name__)
+
+
+ENTRY_POINTS_GROUP = 'ralph.cloud_sync_processors'
+CLOUD_SYNC_DRIVERS = None
+LOCK = threading.Lock()
+
+
+def load_processors():
+    global CLOUD_SYNC_DRIVERS
+
+    # NOTE(romcheg): Check if processors were loaded prior to locking anything.
+    if CLOUD_SYNC_DRIVERS is not None:
+        return
+
+    with LOCK:
+        # NOTE(romcheg): Double check in order to avoid race conditions.
+        if CLOUD_SYNC_DRIVERS is not None:
+            return
+
+        logger.info('Loading cloud sync processors.')
+
+        CLOUD_SYNC_DRIVERS = {}
+
+        for ep in pkg_resources.iter_entry_points(ENTRY_POINTS_GROUP):
+            try:
+                CLOUD_SYNC_DRIVERS[ep.name] = ep.resolve()
+            except ImportError:
+                logger.error(
+                    'Could not import DC asset event processor from {}.'
+                    ''.format(ep.module_name)
+                )
+
+
+@csrf_exempt
+@require_POST
+def cloud_sync_router(request, cloud_provider_id):
+    load_processors()
+
+    raw_data = request.read().decode('utf-8')
+
+    try:
+        event_data = json.loads(raw_data)
+    except ValueError:
+        return HttpResponseBadRequest('Content must be a valid JSON text.')
+
+    try:
+        cloud_provider = CloudProvider.objects.get(
+            Q(
+                pk=cloud_provider_id,
+                cloud_sync_enabled=True,
+                cloud_sync_driver__isnull=False
+            ) & ~Q(cloud_sync_driver='')
+        )
+
+        processor = CLOUD_SYNC_DRIVERS[
+            cloud_provider.cloud_sync_driver
+        ]
+    except CloudProvider.DoesNotExist:
+        return HttpResponseNotFound()
+    except KeyError:
+        return HttpResponse('Specified processor is not available', status=501)
+
+    processor(cloud_provider, event_data)
+
+    return HttpResponse(status=204)

--- a/src/ralph/virtual/migrations/0010_auto_20181018_0822.py
+++ b/src/ralph/virtual/migrations/0010_auto_20181018_0822.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('virtual', '0009_auto_20170522_0745'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='cloudprovider',
+            name='cloud_sync_driver',
+            field=models.CharField(max_length=128, null=True, blank=True),
+        ),
+        migrations.AddField(
+            model_name='cloudprovider',
+            name='cloud_sync_enabled',
+            field=models.BooleanField(default=False),
+        ),
+    ]

--- a/src/ralph/virtual/models.py
+++ b/src/ralph/virtual/models.py
@@ -40,6 +40,11 @@ class CloudProvider(AdminAbsoluteUrlMixin, NamedMixin):
         verbose_name = _('Cloud provider')
         verbose_name_plural = _('Cloud providers')
 
+    cloud_sync_enabled = models.BooleanField(
+        null=False, blank=False, default=False
+    )
+    cloud_sync_driver = models.CharField(max_length=128, null=True, blank=True)
+
 
 class CloudFlavor(AdminAbsoluteUrlMixin, BaseObject):
     name = models.CharField(_('name'), max_length=255)

--- a/src/ralph/virtual/processors/noop.py
+++ b/src/ralph/virtual/processors/noop.py
@@ -1,0 +1,9 @@
+import logging
+
+
+logger = logging.getLogger(__name__)
+
+
+def endpoint(cloud_provider, event_data):
+    """The endpoint for DC asset synchronisation that does nothing."""
+    logger.info('Received new DC asset synchronisation event. Doing nothing.')

--- a/src/ralph/virtual/tests/factories.py
+++ b/src/ralph/virtual/tests/factories.py
@@ -24,6 +24,8 @@ from ralph.virtual.models import (
 class CloudProviderFactory(DjangoModelFactory):
 
     name = factory.Iterator(['openstack', 'openstack2'])
+    cloud_sync_enabled = False
+    cloud_sync_driver = factory.Iterator(['noop'])
 
     class Meta:
         model = CloudProvider

--- a/src/ralph/virtual/tests/test_cloudsync.py
+++ b/src/ralph/virtual/tests/test_cloudsync.py
@@ -1,0 +1,90 @@
+from unittest.mock import Mock
+
+from django.core.urlresolvers import reverse
+
+from ralph.api.tests._base import RalphAPITestCase
+from ralph.virtual import cloudsync
+from ralph.virtual.tests.factories import CloudProviderFactory
+
+
+class TestCloudSyncRouter(RalphAPITestCase):
+
+    def setUp(self):
+        super().setUp()
+
+        cloudsync.load_processors()
+
+    def test_event_routed_correctly(self):
+        processor_name = 'proucessah'
+        cloud_provider = CloudProviderFactory(
+            cloud_sync_enabled=True,
+            cloud_sync_driver=processor_name
+        )
+
+        cloudsync.CLOUD_SYNC_DRIVERS[processor_name] = Mock()
+        test_data = {'test': True}
+
+        url = reverse('cloud-sync-router', args=(cloud_provider.id,))
+        self.client.post(url, test_data, format='json')
+
+        cloudsync.CLOUD_SYNC_DRIVERS[
+            processor_name
+        ].assert_called_once_with(cloud_provider, test_data)
+
+    def test_404_bad_provider_id(self):
+        bad_provider_id = 42
+
+        url = reverse('cloud-sync-router', args=(bad_provider_id,))
+        resp = self.client.post(url, {}, format='json')
+
+        self.assertEqual(404, resp.status_code)
+
+    def test_404_sync_disabled(self):
+        cloud_provider = CloudProviderFactory(cloud_sync_enabled=False)
+
+        url = reverse('cloud-sync-router', args=(cloud_provider.id,))
+        resp = self.client.post(url, {}, format='json')
+
+        self.assertEqual(404, resp.status_code)
+
+    def test_404_processor_not_set(self):
+        cloud_provider = CloudProviderFactory(
+            cloud_sync_enabled=True,
+            cloud_sync_driver=None
+        )
+
+        url = reverse('cloud-sync-router', args=(cloud_provider.id,))
+        resp = self.client.post(url, {}, format='json')
+
+        self.assertEqual(404, resp.status_code)
+
+    def test_400_bad_json(self):
+        processor_name = 'proucessah'
+        cloud_provider = CloudProviderFactory(
+            cloud_sync_enabled=True,
+            cloud_sync_driver=processor_name
+        )
+
+        cloudsync.CLOUD_SYNC_DRIVERS[processor_name] = Mock()
+        test_data = None
+
+        url = reverse('cloud-sync-router', args=(cloud_provider.id,))
+        resp = self.client.post(url, test_data)
+
+        self.assertEqual(400, resp.status_code)
+        self.assertEqual(
+            0,
+            cloudsync.CLOUD_SYNC_DRIVERS[processor_name].call_count
+        )
+
+    def test_501_processor_not_available(self):
+        cloud_provider = CloudProviderFactory(
+            cloud_sync_enabled=True,
+            cloud_sync_driver='CloudSyncProcessorFactory'
+        )
+
+        url = reverse('cloud-sync-router', args=(cloud_provider.id,))
+        resp = self.client.post(url, {}, format='json')
+
+        self.assertEqual(501, resp.status_code)
+        self.assertEqual(b'Specified processor is not available', resp.content)

--- a/src/ralph/virtual/urls.py
+++ b/src/ralph/virtual/urls.py
@@ -1,0 +1,11 @@
+from django.conf.urls import url
+
+from ralph.virtual.cloudsync import cloud_sync_router
+
+urlpatterns = [
+    url(
+        r'^cloudsync/(?P<cloud_provider_id>\d+)/$',
+        cloud_sync_router,
+        name='cloud-sync-router',
+    ),
+]


### PR DESCRIPTION
This patch extends cloud providers to contain necessary settings for cloud syncronisation such as switchable option for enabling or disabling the syncronisation for every specific provider and pluggable syncronisation event processor.  The cloud syncronisation endpoint accepts POST requests for every cloud provider for which the syncronisation is enabled and an event processor is selected. Events are routed for necessary processors in the context of a selected cloud provider.