### PR TITLE
Fix build-depends for newer Debian

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -2,7 +2,7 @@ Source: ralph
 Section: python
 Priority: extra
 Maintainer: pylabs@allegrogroup.com
-Build-Depends: debhelper (>= 9), dh-virtualenv, git, libmysqlclient-dev, python3 (>=3.4), python3-dev (>=3.4), libffi-dev, nodejs
+Build-Depends: debhelper (>= 9), dh-virtualenv, git, libmysqlclient-dev | default-libmysqlclient-dev, python3 (>=3.4), python3-dev (>=3.4), libffi-dev, nodejs
 Standards-Version: 3.9.5
 
 Package: ralph-core


### PR DESCRIPTION

Newer Debian uses the default-libmysqlclient-dev metapackage (which points to either MySQL or MariaDB) instead of libmysqlclient-dev, so accept either in Build-Depends.