### PR TITLE
display related virtual hosts

### DIFF
--- a/src/ralph/data_center/templates/data_center/datacenterasset/relations.html
+++ b/src/ralph/data_center/templates/data_center/datacenterasset/relations.html
@@ -51,7 +51,26 @@
                   {% endfor %}
               </table>
           {% endif %}
-      {% endfor %}
+          {% if rel_obj_type == "physical_hosts" %}
+              <h2>{% trans "Physical hosts" %}</h2>
+              <table>
+                  <tr>
+                      <th>{% trans "Hostname" %}</th>
+                      <th>{% trans "IP Address" %}</th>
+                  </tr>
+                  {% for physical_host in objects %}
+                      <tr>
+                        <td><a href="{{ physical_host.get_absolute_url }}">{{ physical_host.hostname }}</a></td>
+                        <td>
+                          {% for addr in physical_host.ipaddresses %}
+                              {{ addr }}<br>
+                          {% endfor %}
+                        </td>
+                      </tr>
+                  {% endfor %}
+              </table>
+          {% endif %}
+       {% endfor %}
 
   {% else %}
     <p>{% trans "No related objects found." %}</p>

--- a/src/ralph/data_center/templates/data_center/datacenterasset/relations.html
+++ b/src/ralph/data_center/templates/data_center/datacenterasset/relations.html
@@ -32,6 +32,25 @@
                   {% endfor %}
               </table>
           {% endif %}
+          {% if rel_obj_type == "virtual_hosts" %}
+              <h2>{% trans "Virtual hosts" %}</h2>
+              <table>
+                  <tr>
+                      <th>{% trans "Hostname" %}</th>
+                      <th>{% trans "IP Address" %}</th>
+                  </tr>
+                  {% for virtual_host in objects %}
+                      <tr>
+                        <td><a href="{{ virtual_host.get_absolute_url }}">{{ virtual_host.hostname }}</a></td>
+                        <td>
+                          {% for addr in virtual_host.ipaddresses %}
+                              {{ addr }}<br>
+                          {% endfor %}
+                        </td>
+                      </tr>
+                  {% endfor %}
+              </table>
+          {% endif %}
       {% endfor %}
 
   {% else %}

--- a/src/ralph/data_center/tests/test_view.py
+++ b/src/ralph/data_center/tests/test_view.py
@@ -8,8 +8,9 @@ from django.test import TestCase
 from ralph.data_center.models import DataCenterAsset
 from ralph.data_center.tests.factories import (
     ClusterFactory,
-    DataCenterAssetFullFactory,
-    DataCenterAssetFactory)
+    DataCenterAssetFactory,
+    DataCenterAssetFullFactory
+)
 from ralph.data_center.views import RelationsView
 from ralph.security.models import ScanStatus
 from ralph.security.tests.factories import (
@@ -17,11 +18,13 @@ from ralph.security.tests.factories import (
     VulnerabilityFactory
 )
 from ralph.tests.mixins import ClientMixin
-from ralph.virtual.models import VirtualServer, CloudHost
+from ralph.virtual.models import CloudHost, VirtualServer
 from ralph.virtual.tests.factories import (
+    CloudHostFactory,
     CloudHostFullFactory,
-    VirtualServerFullFactory,
-    VirtualServerFactory, CloudHostFactory)
+    VirtualServerFactory,
+    VirtualServerFullFactory
+)
 
 
 def tomorrow():

--- a/src/ralph/data_center/tests/test_view.py
+++ b/src/ralph/data_center/tests/test_view.py
@@ -1,23 +1,27 @@
 from datetime import datetime, timedelta
 from urllib.parse import urlencode
 
+from django.contrib.contenttypes.models import ContentType
 from django.core.urlresolvers import reverse
 from django.test import TestCase
 
+from ralph.data_center.models import DataCenterAsset
 from ralph.data_center.tests.factories import (
     ClusterFactory,
-    DataCenterAssetFullFactory
-)
+    DataCenterAssetFullFactory,
+    DataCenterAssetFactory)
+from ralph.data_center.views import RelationsView
 from ralph.security.models import ScanStatus
 from ralph.security.tests.factories import (
     SecurityScanFactory,
     VulnerabilityFactory
 )
 from ralph.tests.mixins import ClientMixin
+from ralph.virtual.models import VirtualServer, CloudHost
 from ralph.virtual.tests.factories import (
     CloudHostFullFactory,
-    VirtualServerFullFactory
-)
+    VirtualServerFullFactory,
+    VirtualServerFactory, CloudHostFactory)
 
 
 def tomorrow():
@@ -267,3 +271,48 @@ class DCHostFilterByPatchDeadline(ClientMixin, TestCase):
             int(response.context_data['object_id']),
             self.asset_with_today_vul.id,
         )
+
+
+class RelationsViewTest(TestCase):
+    def setUp(self):
+        self.view = RelationsView()
+        self.view.object = DataCenterAssetFactory()
+
+    def test_should_add_cloud_hosts_to_dictionary(self):
+        cloud_host = ContentType.objects.get_for_model(CloudHost)
+        self.view.object.cloudhost_set.add(*CloudHostFactory.create_batch(4))
+        related_objects = {}
+        self.view._add_cloud_hosts(related_objects)
+        content_type = {
+            c_t.content_type for c_t in related_objects['cloud_hosts']
+        }
+
+        self.assertEqual(4, len(related_objects['cloud_hosts']))
+        self.assertEqual(1, len(content_type))
+        self.assertEqual(cloud_host, content_type.pop())
+
+    def test_should_add_virtual_hosts_to_dictionary(self):
+        virtual_server = ContentType.objects.get_for_model(VirtualServer)
+        self.view.object.children.add(*VirtualServerFactory.create_batch(4))
+        related_objects = {}
+        self.view._add_virtual_hosts(related_objects)
+        content_type = {
+            c_t.content_type for c_t in related_objects['virtual_hosts']
+        }
+
+        self.assertEqual(4, len(related_objects['virtual_hosts']))
+        self.assertEqual(1, len(content_type))
+        self.assertEqual(virtual_server, content_type.pop())
+
+    def test_should_add_physical_hosts_to_dictionary(self):
+        physical_server = ContentType.objects.get_for_model(DataCenterAsset)
+        self.view.object.children.add(*DataCenterAssetFactory.create_batch(4))
+        related_objects = {}
+        self.view._add_physical_hosts(related_objects)
+        content_type = {
+            c_t.content_type for c_t in related_objects['physical_hosts']
+        }
+
+        self.assertEqual(4, len(related_objects['physical_hosts']))
+        self.assertEqual(1, len(content_type))
+        self.assertEqual(physical_server, content_type.pop())

--- a/src/ralph/data_center/views.py
+++ b/src/ralph/data_center/views.py
@@ -1,4 +1,7 @@
+from django.contrib.contenttypes.models import ContentType
+
 from ralph.admin.views.extra import RalphDetailView
+from ralph.virtual.models import VirtualServer
 
 
 class RelationsView(RalphDetailView):
@@ -15,7 +18,11 @@ class RelationsView(RalphDetailView):
             related_objects['cloud_hosts'] = cloud_hosts
 
     def _add_virtual_hosts(self, related_objects):
-        virtual_hosts = list(self.object.children.all())
+        virtual_server = ContentType.objects.get_for_model(VirtualServer)
+        virtual_hosts = list(
+            self.object.children.filter(content_type=virtual_server)
+        )
+
         if virtual_hosts:
             related_objects['virtual_hosts'] = virtual_hosts
 

--- a/src/ralph/data_center/views.py
+++ b/src/ralph/data_center/views.py
@@ -14,11 +14,17 @@ class RelationsView(RalphDetailView):
         if cloud_hosts:
             related_objects['cloud_hosts'] = cloud_hosts
 
+    def _add_virtual_hosts(self, related_objects):
+        virtual_hosts = list(self.object.children.all())
+        if virtual_hosts:
+            related_objects['virtual_hosts'] = virtual_hosts
+
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
 
         related_objects = {}
         self._add_cloud_hosts(related_objects)
+        self._add_virtual_hosts(related_objects)
         context['related_objects'] = related_objects
 
         return context

--- a/src/ralph/data_center/views.py
+++ b/src/ralph/data_center/views.py
@@ -1,6 +1,7 @@
 from django.contrib.contenttypes.models import ContentType
 
 from ralph.admin.views.extra import RalphDetailView
+from ralph.data_center.models import DataCenterAsset
 from ralph.virtual.models import VirtualServer
 
 
@@ -26,12 +27,22 @@ class RelationsView(RalphDetailView):
         if virtual_hosts:
             related_objects['virtual_hosts'] = virtual_hosts
 
+    def _add_physical_hosts(self, related_objects):
+        physical_server = ContentType.objects.get_for_model(DataCenterAsset)
+        physical_hosts = list(
+            self.object.children.filter(content_type=physical_server)
+        )
+
+        if physical_hosts:
+            related_objects['physical_hosts'] = physical_hosts
+
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
 
         related_objects = {}
         self._add_cloud_hosts(related_objects)
         self._add_virtual_hosts(related_objects)
+        self._add_physical_hosts(related_objects)
         context['related_objects'] = related_objects
 
         return context


### PR DESCRIPTION
In Relations tab of DatacenterAsset, related virtual servers will be displayed.