### PR TITLE
Add related hosts to api RAS-1267

### DIFF
--- a/src/ralph/data_center/api/serializers.py
+++ b/src/ralph/data_center/api/serializers.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
-from rest_framework import serializers
 from django.contrib.contenttypes.models import ContentType
+from rest_framework import serializers
 
 from ralph.api import RalphAPISerializer
 from ralph.api.serializers import RalphAPISaveSerializer

--- a/src/ralph/data_center/api/serializers.py
+++ b/src/ralph/data_center/api/serializers.py
@@ -1,4 +1,6 @@
 # -*- coding: utf-8 -*-
+from django.contrib.contenttypes.models import ContentType
+
 from rest_framework import serializers
 
 from ralph.api import RalphAPISerializer
@@ -25,6 +27,7 @@ from ralph.data_center.models import (
     VIP
 )
 from ralph.security.api import SecurityScanSerializer
+from ralph.virtual.models import VirtualServer
 
 
 class ClusterTypeSerializer(RalphAPISerializer):
@@ -122,36 +125,43 @@ class DataCenterAssetSerializer(ComponentSerializerMixin, AssetSerializer):
     rack = SimpleRackSerializer()
     scmstatuscheck = SCMInfoSerializer()
     securityscan = SecurityScanSerializer()
-
     related_hosts = serializers.SerializerMethodField()
 
-    def _get_physical_hosts(self, obj):
-        if 'data_center_assets' not in self.context.keys():
-            return []
-        physical_hosts = [ph for ph in self.context['data_center_assets']
-                          if ph.parent and ph.parent.pk == obj.pk]
-        return DataCenterAssetSimpleSerializer(
-            physical_hosts, many=True
+    def _get_serialized_sublist(self, full_list, serializer_class, cond):
+        return serializer_class(
+            [elem for elem in full_list if cond(elem)],
+            many=True, context=self.context
         ).data
 
-    def _get_virtual_hosts(self, obj):
-        if 'virtual_servers' not in self.context.keys():
-            return []
-        from ralph.virtual.api import VirtualServerSerializer
-        virtual_hosts = [vs for vs in self.context['virtual_servers']
-                         if vs.parent and vs.parent.pk == obj.pk]
-        return VirtualServerSerializer(virtual_hosts, many=True).data
+    def _get_physical_servers(self, obj):
+        dca = ContentType.objects.get_for_model(DataCenterAsset)
+        return self._get_serialized_sublist(
+            obj.children.all(),
+            DataCenterAssetSimpleSerializer,
+            lambda child: child.content_type == dca
+        )
+
+    def _get_virtual_servers(self, obj):
+        from ralph.virtual.api import VirtualServerSimpleSerializer
+        vs = ContentType.objects.get_for_model(VirtualServer)
+        return self._get_serialized_sublist(
+            obj.children.all(),
+            VirtualServerSimpleSerializer,
+            lambda child: child.content_type == vs
+        )
 
     def _get_cloud_hosts(self, obj):
         from ralph.virtual.api import CloudHostSimpleSerializer
-        return CloudHostSimpleSerializer(
-            obj.cloudhost_set.all(), many=True
-        ).data
+        return self._get_serialized_sublist(
+            obj.cloudhost_set.all(),
+            CloudHostSimpleSerializer,
+            lambda host: True
+        )
 
     def get_related_hosts(self, obj):
         related_hosts = {}
-        related_hosts['physical_hosts'] = self._get_physical_hosts(obj)
-        related_hosts['virtual_hosts'] = self._get_virtual_hosts(obj)
+        related_hosts['virtual_servers'] = self._get_virtual_servers(obj)
+        related_hosts['physical_servers'] = self._get_physical_servers(obj)
         related_hosts['cloud_hosts'] = self._get_cloud_hosts(obj)
         return related_hosts
 

--- a/src/ralph/data_center/api/serializers.py
+++ b/src/ralph/data_center/api/serializers.py
@@ -128,8 +128,8 @@ class DataCenterAssetSerializer(ComponentSerializerMixin, AssetSerializer):
     related_hosts = serializers.SerializerMethodField()
 
     def _get_physical_hosts(self, obj):
-       physical_server = ContentType.objects.get_for_model(DataCenterAsset)
-       return DataCenterAssetSimpleSerializer(
+        physical_server = ContentType.objects.get_for_model(DataCenterAsset)
+        return DataCenterAssetSimpleSerializer(
             obj.children.filter(content_type=physical_server), many=True
         ).data
 
@@ -141,8 +141,10 @@ class DataCenterAssetSerializer(ComponentSerializerMixin, AssetSerializer):
         ).data
 
     def _get_cloud_hosts(self, obj):
-       from ralph.virtual.api import CloudHostSimpleSerializer
-       return CloudHostSimpleSerializer(obj.cloudhost_set.all(), many=True).data
+        from ralph.virtual.api import CloudHostSimpleSerializer
+        return CloudHostSimpleSerializer(
+            obj.cloudhost_set.all(), many=True
+        ).data
 
     def get_related_hosts(self, obj):
         related_hosts = {}
@@ -150,7 +152,7 @@ class DataCenterAssetSerializer(ComponentSerializerMixin, AssetSerializer):
         related_hosts['virtual_hosts'] = self._get_virtual_hosts(obj)
         related_hosts['cloud_hosts'] = self._get_cloud_hosts(obj)
         return related_hosts
-    
+
     class Meta(AssetSerializer.Meta):
         model = DataCenterAsset
         depth = 2

--- a/src/ralph/data_center/api/views.py
+++ b/src/ralph/data_center/api/views.py
@@ -37,7 +37,6 @@ from ralph.data_center.models import (
     VIP
 )
 from ralph.security.models import SecurityScan
-from ralph.virtual.models import VirtualServer
 
 
 class DataCenterAssetFilterSet(NetworkableObjectFilters):
@@ -59,6 +58,8 @@ class DataCenterAssetViewSet(BaseObjectViewSetMixin, RalphAPIViewSet):
         'connections',
         'tags',
         'memory_set',
+        'children',
+        'cloudhost_set',
         Prefetch(
             'ethernet_set',
             queryset=Ethernet.objects.select_related('ipaddress')
@@ -83,12 +84,6 @@ class DataCenterAssetViewSet(BaseObjectViewSetMixin, RalphAPIViewSet):
     ]
     additional_filter_class = DataCenterAssetFilterSet
     exclude_filter_fields = ['configuration_path']
-
-    def get_serializer_context(self):
-        context = super().get_serializer_context()
-        context['virtual_servers'] = VirtualServer.objects.all()
-        context['data_center_assets'] = DataCenterAsset.objects.all()
-        return context
 
 
 class AccessoryViewSet(RalphAPIViewSet):

--- a/src/ralph/data_center/api/views.py
+++ b/src/ralph/data_center/api/views.py
@@ -37,6 +37,7 @@ from ralph.data_center.models import (
     VIP
 )
 from ralph.security.models import SecurityScan
+from ralph.virtual.models import VirtualServer
 
 
 class DataCenterAssetFilterSet(NetworkableObjectFilters):
@@ -52,7 +53,7 @@ class DataCenterAssetViewSet(BaseObjectViewSetMixin, RalphAPIViewSet):
         'service_env', 'service_env__service', 'service_env__environment',
         'rack', 'rack__server_room', 'rack__server_room__data_center',
         'property_of', 'budget_info', 'content_type',
-        'configuration_path__module'
+        'configuration_path__module',
     ]
     prefetch_related = base_object_descendant_prefetch_related + [
         'connections',
@@ -82,6 +83,12 @@ class DataCenterAssetViewSet(BaseObjectViewSetMixin, RalphAPIViewSet):
     ]
     additional_filter_class = DataCenterAssetFilterSet
     exclude_filter_fields = ['configuration_path']
+
+    def get_serializer_context(self):
+        context = super().get_serializer_context()
+        context['virtual_servers'] = VirtualServer.objects.all()
+        context['data_center_assets'] = DataCenterAsset.objects.all()
+        return context
 
 
 class AccessoryViewSet(RalphAPIViewSet):

--- a/src/ralph/data_center/tests/test_api.py
+++ b/src/ralph/data_center/tests/test_api.py
@@ -55,7 +55,7 @@ class DataCenterAssetAPITests(RalphAPITestCase):
 
     def test_get_data_center_assets_list(self):
         url = reverse('datacenterasset-list')
-        with self.assertNumQueries(21):
+        with self.assertNumQueries(19):
             response = self.client.get(url, format='json')
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(
@@ -99,6 +99,9 @@ class DataCenterAssetAPITests(RalphAPITestCase):
         virtual_server_2 = VirtualServerFactory(
             parent=dc_asset_3
         )
+        dc_asset_4 = DataCenterAssetFullFactory(
+            parent=dc_asset_3
+        )
         url = reverse('datacenterasset-detail', args=(dc_asset_3.id,))
         response = self.client.get(url, format='json')
         self.assertEqual(
@@ -106,9 +109,6 @@ class DataCenterAssetAPITests(RalphAPITestCase):
         )
         self.assertEqual(
             len(response.data['related_hosts']['virtual_hosts']), 2
-        )
-        self.assertEqual(
-            len(response.data['related_hosts']['physical_hosts']), 0
         )
         self.assertEqual(
             response.data['related_hosts']['virtual_hosts'][0]['id'],
@@ -121,6 +121,13 @@ class DataCenterAssetAPITests(RalphAPITestCase):
         self.assertEqual(
             response.data['related_hosts']['cloud_hosts'][0]['hostname'],
             cloud_host.hostname
+        )
+        self.assertEqual(
+            len(response.data['related_hosts']['physical_hosts']), 1
+        )
+        self.assertEqual(
+            response.data['related_hosts']['physical_hosts'][0]['hostname'],
+            dc_asset_4.hostname
         )
 
 

--- a/src/ralph/data_center/tests/test_api.py
+++ b/src/ralph/data_center/tests/test_api.py
@@ -111,13 +111,13 @@ class DataCenterAssetAPITests(RalphAPITestCase):
         self.assertEqual(
             len(response.data['related_hosts']['virtual_servers']), 2
         )
-        self.assertEqual(
+        self.assertIn(
             response.data['related_hosts']['virtual_servers'][0]['hostname'],
-            virtual_server.hostname
+            (virtual_server.hostname, virtual_server_2.hostname)
         )
-        self.assertEqual(
+        self.assertIn(
             response.data['related_hosts']['virtual_servers'][1]['hostname'],
-            virtual_server_2.hostname
+            (virtual_server.hostname, virtual_server_2.hostname)
         )
         self.assertEqual(
             response.data['related_hosts']['cloud_hosts'][0]['hostname'],

--- a/src/ralph/data_center/tests/test_api.py
+++ b/src/ralph/data_center/tests/test_api.py
@@ -67,7 +67,7 @@ class DataCenterAssetAPITests(RalphAPITestCase):
 
     def test_get_data_center_assets_list(self):
         url = reverse('datacenterasset-list')
-        with self.assertNumQueries(15):
+        with self.assertNumQueries(66):
             response = self.client.get(url, format='json')
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(

--- a/src/ralph/data_center/tests/test_api.py
+++ b/src/ralph/data_center/tests/test_api.py
@@ -52,19 +52,10 @@ class DataCenterAssetAPITests(RalphAPITestCase):
         )
         self.dc_asset.tags.add('db', 'test')
         self.dc_asset_2 = DataCenterAssetFullFactory()
-        self.cloud_host = CloudHostFactory(
-            hypervisor=self.dc_asset_2
-        )
-        self.virtual_server = VirtualServerFactory(
-            parent=self.dc_asset_2
-        )
-        self.virtual_server_2 = VirtualServerFactory(
-            parent=self.dc_asset_2
-        )
 
     def test_get_data_center_assets_list(self):
         url = reverse('datacenterasset-list')
-        with self.assertNumQueries(66):
+        with self.assertNumQueries(21):
             response = self.client.get(url, format='json')
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(
@@ -98,7 +89,17 @@ class DataCenterAssetAPITests(RalphAPITestCase):
         )
 
     def test_get_data_center_asset_details_related_hosts(self):
-        url = reverse('datacenterasset-detail', args=(self.dc_asset_2.id,))
+        dc_asset_3 = DataCenterAssetFullFactory()
+        cloud_host = CloudHostFactory(
+            hypervisor=dc_asset_3
+        )
+        virtual_server = VirtualServerFactory(
+            parent=dc_asset_3
+        )
+        virtual_server_2 = VirtualServerFactory(
+            parent=dc_asset_3
+        )
+        url = reverse('datacenterasset-detail', args=(dc_asset_3.id,))
         response = self.client.get(url, format='json')
         self.assertEqual(
             len(response.data['related_hosts']['cloud_hosts']), 1
@@ -111,15 +112,15 @@ class DataCenterAssetAPITests(RalphAPITestCase):
         )
         self.assertEqual(
             response.data['related_hosts']['virtual_hosts'][0]['id'],
-            self.virtual_server.id
+            virtual_server.id
         )
         self.assertEqual(
             response.data['related_hosts']['virtual_hosts'][0]['hostname'],
-            self.virtual_server.hostname
+            virtual_server.hostname
         )
         self.assertEqual(
             response.data['related_hosts']['cloud_hosts'][0]['hostname'],
-            self.cloud_host.hostname
+            cloud_host.hostname
         )
 
 

--- a/src/ralph/data_center/tests/test_api.py
+++ b/src/ralph/data_center/tests/test_api.py
@@ -55,7 +55,7 @@ class DataCenterAssetAPITests(RalphAPITestCase):
 
     def test_get_data_center_assets_list(self):
         url = reverse('datacenterasset-list')
-        with self.assertNumQueries(19):
+        with self.assertNumQueries(17):
             response = self.client.get(url, format='json')
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(
@@ -97,7 +97,8 @@ class DataCenterAssetAPITests(RalphAPITestCase):
             parent=dc_asset_3
         )
         virtual_server_2 = VirtualServerFactory(
-            parent=dc_asset_3
+            parent=dc_asset_3,
+            hostname='random_test_hostname'
         )
         dc_asset_4 = DataCenterAssetFullFactory(
             parent=dc_asset_3
@@ -108,28 +109,27 @@ class DataCenterAssetAPITests(RalphAPITestCase):
             len(response.data['related_hosts']['cloud_hosts']), 1
         )
         self.assertEqual(
-            len(response.data['related_hosts']['virtual_hosts']), 2
+            len(response.data['related_hosts']['virtual_servers']), 2
         )
         self.assertEqual(
-            response.data['related_hosts']['virtual_hosts'][0]['id'],
-            virtual_server.id
-        )
-        self.assertEqual(
-            response.data['related_hosts']['virtual_hosts'][0]['hostname'],
+            response.data['related_hosts']['virtual_servers'][0]['hostname'],
             virtual_server.hostname
+        )
+        self.assertEqual(
+            response.data['related_hosts']['virtual_servers'][1]['hostname'],
+            virtual_server_2.hostname
         )
         self.assertEqual(
             response.data['related_hosts']['cloud_hosts'][0]['hostname'],
             cloud_host.hostname
         )
         self.assertEqual(
-            len(response.data['related_hosts']['physical_hosts']), 1
+            len(response.data['related_hosts']['physical_servers']), 1
         )
         self.assertEqual(
-            response.data['related_hosts']['physical_hosts'][0]['hostname'],
+            response.data['related_hosts']['physical_servers'][0]['hostname'],
             dc_asset_4.hostname
         )
-
 
     def test_create_data_center_asset(self):
         url = reverse('datacenterasset-list')

--- a/src/ralph/data_center/tests/test_api.py
+++ b/src/ralph/data_center/tests/test_api.py
@@ -29,10 +29,7 @@ from ralph.data_center.tests.factories import (
 )
 from ralph.networks.tests.factories import IPAddressFactory
 
-from ralph.virtual.tests.factories import (
-    VirtualServerFactory,
-    CloudHostFactory
-    )
+from ralph.virtual.tests.factories import CloudHostFactory, VirtualServerFactory
 
 
 class DataCenterAssetAPITests(RalphAPITestCase):

--- a/src/ralph/virtual/api.py
+++ b/src/ralph/virtual/api.py
@@ -136,6 +136,13 @@ class VirtualServerTypeSerializer(RalphAPISerializer):
         model = VirtualServerType
 
 
+class VirtualServerSimpleSerializer(BaseObjectSerializer):
+    class Meta(BaseObjectSerializer):
+        model = VirtualServer
+        fields = ['hostname', 'url']
+        _skip_tags_field = True
+
+
 # TODO: select related
 class VirtualServerSerializer(ComponentSerializerMixin, BaseObjectSerializer):
     type = VirtualServerTypeSerializer()


### PR DESCRIPTION
Return the lists of CloudsHosts, VirtualServers and DataCenterAssets related with any DataCenterAsset in API.