### PR TITLE
Fix duplicate hostname

### DIFF
--- a/src/ralph/networks/forms.py
+++ b/src/ralph/networks/forms.py
@@ -121,6 +121,15 @@ class SimpleNetworkForm(EthernetLockDeleteForm):
                 params={'ip': address},
             )
 
+    def _validate_hostame_uniqueness_in_dc(self):
+            address = self.cleaned_data['address']
+            new_hostname = self.cleaned_data['hostname']
+            if not self.ip or self.ip.address != address:
+                ip = IPAddress(address=address, hostname=new_hostname)
+            else:
+                ip = self.ip
+            ip.validate_hostname_uniqueness_in_dc(new_hostname)
+
     def clean_address(self):
         if self._dhcp_expose_should_lock_fields:
             # if address is locked, just return current address
@@ -164,8 +173,7 @@ class SimpleNetworkForm(EthernetLockDeleteForm):
                 raise ValidationError(
                     _('Cannot expose in DHCP without MAC address'),
                 )
-            new_hostname = self.cleaned_data['hostname']
-            self.ip.validate_hostname_uniqueness_in_dc(new_hostname)
+            self._validate_hostame_uniqueness_in_dc()
         return dhcp_expose
 
     def _validate_mac_address(self):

--- a/src/ralph/networks/forms.py
+++ b/src/ralph/networks/forms.py
@@ -164,6 +164,8 @@ class SimpleNetworkForm(EthernetLockDeleteForm):
                 raise ValidationError(
                     _('Cannot expose in DHCP without MAC address'),
                 )
+            new_hostname = self.cleaned_data['hostname']
+            self.ip.validate_hostname_uniqueness_in_dc(new_hostname)
         return dhcp_expose
 
     def _validate_mac_address(self):

--- a/src/ralph/networks/tests/test_forms.py
+++ b/src/ralph/networks/tests/test_forms.py
@@ -4,13 +4,13 @@ from django.test import RequestFactory
 from ralph.assets.models.components import Ethernet, EthernetSpeed
 from ralph.data_center.tests.factories import DataCenterFactory
 from ralph.networks.models import IPAddress
-from ralph.networks.tests.factories import IPAddressFactory
+from ralph.networks.tests.factories import (
+    IPAddressFactory,
+    NetworkEnvironmentFactory,
+    NetworkFactory
+)
 from ralph.tests import RalphTestCase
 from ralph.tests.models import PolymorphicTestModel
-from ralph.networks.tests.factories import (
-    NetworkFactory,
-    NetworkEnvironmentFactory
-)
 
 
 class NetworkInlineTestCase(RalphTestCase):

--- a/src/ralph/networks/tests/test_forms.py
+++ b/src/ralph/networks/tests/test_forms.py
@@ -409,8 +409,7 @@ class NetworkInlineWithDHCPExposeTestCase(RalphTestCase):
                 )
             )
         )
-        network.save()
-        self.test_dhcp_expose_for_new_record_should_pass()
+        self.test_dhcp_expose_for_new_record_should_pass()  # generate duplicate
         obj2 = PolymorphicTestModel.objects.create(hostname='xyz')
         inline_data = {
             'TOTAL_FORMS': 2,

--- a/src/ralph/networks/tests/test_models.py
+++ b/src/ralph/networks/tests/test_models.py
@@ -570,7 +570,7 @@ class IPAddressTest(RalphTestCase):
         ):
             self.ip.clean()
 
-    def test_duplicate_hostname_with_dhcp_expose_should_not_pass(self):
+    def test_duplicate_hostname_with_dhcp_exposition_should_not_pass(self):
         name = 'random.hostname.net'
         network = NetworkFactory(
             address='192.168.0.0/24',


### PR DESCRIPTION
If two IPs have the same hostname in DHCP, one is ignored. This PR adds validation of such scenario when "expose in DHCP" is selected while creating or updating IP address.