### PR TITLE
more generic createsuperuser.py

### DIFF
--- a/docker/createsuperuser.py
+++ b/docker/createsuperuser.py
@@ -7,8 +7,14 @@ django.setup()
 
 from django.contrib.auth import get_user_model
 print('Updating superuser info')
-u = get_user_model().objects.get(username='ralph')
-u.set_password('ralph')
-u.is_superuser = True
-u.is_staff = True
-u.save()
+try:
+    u = get_user_model().objects.get(username='ralph')
+    u.set_password('ralph')
+    u.is_superuser = True
+    u.is_staff = True
+    u.save()
+    print('Updated superuser')
+except:
+    u = get_user_model().objects.create_superuser('ralph', '', 'ralph')
+    u.save()
+    print('Created superuser')


### PR DESCRIPTION
I would to automatize ralph installation on Ubuntu 18.04

this little change allow to create superuser even if ralph user is not yet configured by executing
python3 docker/createsuperuser.py