### PR TITLE
Fix api rendering in web browser

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -16,6 +16,7 @@ django-transaction-hooks==0.2  # it's merged to Django 1.9 - remove this when Dj
 djangorestframework==3.2.2
 djangorestframework_xml==1.2.0
 drf-nested-routers==0.11.1
+Markdown<3.0  # headerid extension removed in 3.0 - see #3313 for details
 mysqlclient==1.3.13
 netaddr==0.7.18
 python-dateutil==2.4.2

--- a/src/ralph/api/tests/test_rendering.py
+++ b/src/ralph/api/tests/test_rendering.py
@@ -1,0 +1,22 @@
+from django.core.urlresolvers import reverse
+from rest_framework import status
+from rest_framework.test import APIClient, APITestCase
+
+from ralph.api.tests._base import APIPermissionsTestMixin
+
+
+class APIBrowsableClient(APIClient):
+    renderer_classes_list = (
+        'rest_framework.renderers.BrowsableAPIRenderer',
+    )
+    default_format = 'text/html'
+
+
+class RalphAPIRenderingTests(APIPermissionsTestMixin, APITestCase):
+    client_class = APIBrowsableClient
+
+    def test_rendering(self):
+        url = reverse('test-ralph-api:api-root')
+        self.client.force_authenticate(self.user1)
+        response = self.client.get(url, HTTP_ACCEPT='text/html')
+        self.assertEqual(response.status_code, status.HTTP_200_OK)


### PR DESCRIPTION
New version of [Python-Markdown](https://github.com/Python-Markdown/markdown) (3.0) drops `headerid` extension - this cause internal server error when rendering api pages using BrowsableRenderer (in web browser). To fix it we need to put upper bound on markdown version.

Original exception:
```
ModuleNotFoundError
No module named 'headerid(level=2)'
```