### PR TITLE
Bumped `requests` version to 2.20.0

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -22,7 +22,7 @@ netaddr==0.7.18
 python-dateutil==2.4.2
 pytz==2015.4
 redis==2.10.3
-requests==2.9.1
+requests==2.20.0
 rq==0.5.6
 six>=1.9.0
 sqlparse==0.2.3
@@ -31,4 +31,3 @@ tablib==0.11.5
 factory-boy==2.11.1
 Faker==0.9.0
 openpyxl==2.4.0
-


### PR DESCRIPTION
Fix issue https://nvd.nist.gov/vuln/detail/CVE-2018-18074