### PR TITLE
Apache2 wsgi intergration on Debian 9

### DIFF
--- a/contrib/ralph.conf.apache2-wsgi
+++ b/contrib/ralph.conf.apache2-wsgi
@@ -1,0 +1,39 @@
+<IfModule mod_ssl.c>
+	<VirtualHost _default_:443>
+		ServerName  ralph.example.com
+		ServerAlias ralph
+		ServerAdmin webmaster@localhost
+		ErrorLog ${APACHE_LOG_DIR}/error.log
+		CustomLog ${APACHE_LOG_DIR}/access.log combined
+		SSLEngine on
+		SSLCertificateFile    /etc/ssl/certs/ssl-cert-snakeoil.pem
+		SSLCertificateKeyFile /etc/ssl/private/ssl-cert-snakeoil.key
+
+		## --- RALPH's CONFIGURATION ---
+		SetEnv	DATABASE_PASSWORD ralphsecret
+		SetEnv	DATABASE_HOST 	127.0.0.1
+		SetEnv	DATABASE_USER	ralph
+		SetEnv	DATABASE_NAME	ralph
+		SetEnv	RALPH_DEBUG	True
+		## ---
+
+		Alias /static /opt/ralph/static
+		Alias /media /opt/ralph/media
+		<Directory /opt/ralph/static>
+			Require all granted
+		</Directory>
+
+		<Directory /opt/ralph/ralph-core>
+			<Files wsgi.py>
+				Require all granted
+			</Files>
+		</Directory>
+
+		LogLevel info
+
+		WSGIDaemonProcess ralph-core python-path=/opt/ralph/ralph-core python-home=/opt/ralph/ralph-core
+		WSGIProcessGroup %{GLOBAL}
+		WSGIScriptAlias / /opt/ralph/ralph-core/lib/python3.5/site-packages/ralph/wsgi.py  process-group=ralph-core
+	</VirtualHost>
+</IfModule>
+# vim: syntax=apache ts=4 sw=4 sts=4 sr noet

--- a/debian/rules
+++ b/debian/rules
@@ -9,7 +9,7 @@ override_dh_virtualenv:
 	npm install
 	node_modules/bower/bin/bower --allow-root install
 	node_modules/gulp/bin/gulp.js
-	dh_virtualenv --python /usr/bin/python3.4
+	dh_virtualenv --python /usr/bin/python3.5
 
 override_dh_shlibdeps:
 	dh_shlibdeps --dpkg-shlibdeps-params=--ignore-missing-info

--- a/packaging/upload-package.sh
+++ b/packaging/upload-package.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+## Uploading the package to bintray
+
 set -e
 
 DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
@@ -13,6 +15,8 @@ if [ ! -z "$BINTRAY_APIKEY" ]; then
 	GENERIC_DEB_NAME=`basename $DEB_NAME`
 	curl -T $DEB_NAME -uvi4m:$BINTRAY_APIKEY "https://api.bintray.com/content/vi4m/ralph/ralph/3-snapshot/dists/wheezy/main/binary-amd64/$GENERIC_DEB_NAME;deb_distribution=wheezy;deb_component=main;deb_architecture=amd64?publish=1"
 else
-	echo "Error. BINTRAY_APIKEY is missing"
-	exit 1
+	echo "ERROR: Unable to upload package to BINTRAY" 2>&1
+	echo "BINTRAY_APIKEY is missing." 2>&1
+	## This should not fail the build
+	#exit 1
 fi

--- a/src/ralph/wsgi.py
+++ b/src/ralph/wsgi.py
@@ -7,16 +7,34 @@ For more information on this file, see
 https://docs.djangoproject.com/en/1.8/howto/deployment/wsgi/
 """
 
+## Loading WSGI environment variables into the django application:
+## https://exceptionshub.com/access-apache-setenv-variable-from-django-wsgi-py-file.html
+
 import os
-import django
-
 from django.core.wsgi import get_wsgi_application
-from django.core.handlers.wsgi import WSGIHandler
 
-class WSGIEnvironment(WSGIHandler):
-    def __call__(self, environ, start_response):
-        os.environ.setdefault("DJANGO_SETTINGS_MODULE", "ralph.settings")
-        django.setup()
-        return super(WSGIEnvironment, self).__call__(environ, start_response)
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "ralph.settings")
 
-application = WSGIEnvironment()
+KEYS_TO_LOAD = [
+    # A list of the keys you'd like to load from the WSGI environ
+    # into os.environ
+	'DATABASE_HOST',
+	'DATABASE_USER',
+	'DATABASE_NAME',
+	'DATABASE_PASSWORD'
+]
+
+def loading_app(wsgi_environ, start_response):
+    global real_app
+    for key in KEYS_TO_LOAD:
+        try:
+            os.environ[key] = wsgi_environ[key]
+        except KeyError:
+            # The WSGI environment doesn't have the key
+            pass
+    real_app = get_wsgi_application()
+    return real_app(wsgi_environ, start_response)
+
+real_app = loading_app
+
+application = lambda env, start: real_app(env, start)

--- a/src/ralph/wsgi.py
+++ b/src/ralph/wsgi.py
@@ -8,9 +8,15 @@ https://docs.djangoproject.com/en/1.8/howto/deployment/wsgi/
 """
 
 import os
+import django
 
 from django.core.wsgi import get_wsgi_application
+from django.core.handlers.wsgi import WSGIHandler
 
-os.environ.setdefault("DJANGO_SETTINGS_MODULE", "ralph.settings")
+class WSGIEnvironment(WSGIHandler):
+    def __call__(self, environ, start_response):
+        os.environ.setdefault("DJANGO_SETTINGS_MODULE", "ralph.settings")
+        django.setup()
+        return super(WSGIEnvironment, self).__call__(environ, start_response)
 
-application = get_wsgi_application()
+application = WSGIEnvironment()


### PR DESCRIPTION
Hello,

That's what I've done to build the packages on debian stretch and load Ralph-ng behind Apache2 using mod_wsgi.

I've choosen to load the configuration form SetEnv directives and pass it from WSGI to django using this method: https://exceptionshub.com/access-apache-setenv-variable-from-django-wsgi-py-file.html

What do you think about that ? Isn't optimal, but for me it's really useful in our environment.


