### PR TITLE
make network vlan searchable

### DIFF
--- a/src/ralph/networks/admin.py
+++ b/src/ralph/networks/admin.py
@@ -111,7 +111,7 @@ class NetworkRalphChangeList(RalphChangeList):
 class NetworkAdmin(RalphMPTTAdmin):
     ordering = ['min_ip', '-max_ip']
     change_form_template = 'admin/data_center/network/change_form.html'
-    search_fields = ['name', 'address', 'remarks']
+    search_fields = ['name', 'address', 'remarks', 'vlan']
     list_display = [
         'name', 'address', 'kind', 'vlan', 'network_environment',
         'subnetworks_count', 'ipaddresses_count'

--- a/src/ralph/networks/admin.py
+++ b/src/ralph/networks/admin.py
@@ -118,7 +118,7 @@ class NetworkAdmin(RalphMPTTAdmin):
     ]
     list_filter = [
         'network_environment', 'kind', 'dhcp_broadcast', 'racks',
-        'terminators', 'service_env',
+        'terminators', 'service_env', 'vlan',
         ('parent', RelatedAutocompleteFieldListFilter),
         ('min_ip', NetworkRangeFilter), ('address', NetworkClassFilter),
         ('max_ip', ContainsIPAddressFilter)


### PR DESCRIPTION
It would be much more convenient for us to directly search a network by its VLAN tag. This simple patch extends the list of searchable items by the vlan key.