### PR TITLE
Custom handler404

### DIFF
--- a/src/ralph/lib/error_pages/views.py
+++ b/src/ralph/lib/error_pages/views.py
@@ -1,12 +1,12 @@
 from django import http
+from django.utils.translation import ugettext_lazy as _
 from django.views.decorators.csrf import requires_csrf_token
 
 
 @requires_csrf_token
 def page_not_found(request):
-    body = (
-        "<h1>Not Found</h1>"
-        "<p>The requested resource was not found on this server.</p>"
-    )
+    header = _('Not Found')
+    paragraph = _('The requested resource was not found on this server.')
+    body = "<h1>{}</h1><p>{}</p>".format(header, paragraph)
     content_type = 'text/html'
     return http.HttpResponseNotFound(body, content_type=content_type)

--- a/src/ralph/lib/error_pages/views.py
+++ b/src/ralph/lib/error_pages/views.py
@@ -1,0 +1,12 @@
+from django import http
+from django.views.decorators.csrf import requires_csrf_token
+
+
+@requires_csrf_token
+def page_not_found(request):
+    body = (
+        "<h1>Not Found</h1>"
+        "<p>The requested resource was not found on this server.</p>"
+    )
+    content_type = 'text/html'
+    return http.HttpResponseNotFound(body, content_type=content_type)

--- a/src/ralph/urls/__init__.py
+++ b/src/ralph/urls/__init__.py
@@ -1,1 +1,4 @@
 from ralph.urls.base import urlpatterns  # noqa
+
+
+handler404 = 'ralph.lib.error_pages.views.page_not_found'

--- a/src/ralph/urls/dev.py
+++ b/src/ralph/urls/dev.py
@@ -5,6 +5,7 @@ from django.conf.urls.static import static
 
 
 from ralph.urls import urlpatterns as base_urlpatterns
+from ralph.urls import handler404  # noqa
 
 urlpatterns = base_urlpatterns
 urlpatterns += [


### PR DESCRIPTION
Fix CVE-2019-3498 - prevent url spoofing by not presenting url on 404 error page.