### PR TITLE
Restricted custom fields

### DIFF
--- a/src/ralph/lib/custom_fields/forms.py
+++ b/src/ralph/lib/custom_fields/forms.py
@@ -1,6 +1,7 @@
 from django import forms
 from django.contrib.contenttypes.forms import BaseGenericInlineFormSet
 from django.contrib.contenttypes.models import ContentType
+from django.db.models import Q
 from django.utils.translation import ugettext_lazy as _
 from django.utils.translation import ugettext
 
@@ -39,6 +40,15 @@ class CustomFieldValueWithClearChildrenForm(CustomFieldValueForm):
 
 
 class CustomFieldValueFormSet(BaseGenericInlineFormSet):
+
+    def __init__(self, request=None, queryset=None, *args, **kwargs):
+        queryset = queryset.filter(
+            Q(custom_field__managing_group__isnull=True) |
+            Q(custom_field__managing_group__in=request.user.groups.all())
+        )
+
+        super().__init__(queryset=queryset, *args, **kwargs)
+
     def _construct_form(self, i, **kwargs):
         form = super()._construct_form(i, **kwargs)
         # fix for https://code.djangoproject.com/ticket/12028, together with

--- a/src/ralph/lib/custom_fields/migrations/0005_customfield_managing_group.py
+++ b/src/ralph/lib/custom_fields/migrations/0005_customfield_managing_group.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('auth', '0006_require_contenttypes_0002'),
+        ('custom_fields', '0004_auto_20161214_1126'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='customfield',
+            name='managing_group',
+            field=models.ForeignKey(blank=True, null=True, help_text='When set, only members of the specified group will be allowed to set, change or unset values of this custom field for objects.', to='auth.Group'),
+        ),
+    ]

--- a/src/ralph/lib/custom_fields/models.py
+++ b/src/ralph/lib/custom_fields/models.py
@@ -3,6 +3,7 @@ import six
 
 from dj.choices import Choices
 from django import forms
+from django.contrib.auth.models import Group
 from django.contrib.contenttypes import generic
 
 from django.contrib.contenttypes.models import ContentType
@@ -71,6 +72,14 @@ class CustomField(AdminAbsoluteUrlMixin, TimeStampMixin, models.Model):
         null=True,
         blank=True,
         default='',
+    )
+    managing_group = models.ForeignKey(
+        Group, blank=True, null=True,
+        help_text=_(
+            "When set, only members of the specified group will be "
+            "allowed to set, change or unset values of this custom field "
+            "for objects."
+        )
     )
     use_as_configuration_variable = models.BooleanField(
         default=False,


### PR DESCRIPTION
Add an optional managing group property to custom fields. If set,
adding, changing or deleting values of those custom fields will
be restricted to mebmerb of a specified groups only.

Custom field form will not show such custom field values to
unauthorized users.