### PR TITLE
Invalid port in documentation

### DIFF
--- a/docs/installation/installation.md
+++ b/docs/installation/installation.md
@@ -182,7 +182,7 @@ cat ~/.profile
 
 Run your ralph instance with `ralph runserver 0.0.0.0:8000`
 
-Now, point your browser to the http://localhost:8000 and log in. Happy Ralphing!
+Now, point your browser to the http://localhost and log in. Happy Ralphing!
 
 ## Docker installation (experimental)
 


### PR DESCRIPTION
Nginx is on port 80, not 8000. Some users report manual is wrong about it. 