### PR TITLE
Update Pillow to 6.2.2

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -33,5 +33,5 @@ factory-boy==2.11.1
 Faker==0.9.0
 openpyxl==2.4.0
 typing==3.6.6
-Pillow==6.2.0
+Pillow==6.2.2
 


### PR DESCRIPTION
This version contains important bug fixes making Ralph
safer to use.