### PR TITLE
Revert "Allow user input on package build"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,14 +25,14 @@ release-new-version:
 # changelog and the tag.
 build-package:
 	docker build --force-rm -f docker/Dockerfile-deb -t ralph-deb:latest .
-	docker run --rm -it -v $(shell pwd):/volume ralph-deb:latest build-package
+	docker run --rm -v $(shell pwd):/volume ralph-deb:latest build-package
 	docker image rm --force ralph-deb:latest
 
 # build-snapshot-package renerates a snapshot changelog and uses it to build
 # snapshot version of the package. It is mainly used for testing.
 build-snapshot-package:
 	docker build --force-rm -f docker/Dockerfile-deb -t ralph-deb:latest .
-	docker run --rm -it -v $(shell pwd):/volume ralph-deb:latest build-snapshot-package
+	docker run --rm -v $(shell pwd):/volume ralph-deb:latest build-snapshot-package
 	docker image rm --force ralph-deb:latest
 
 build-docker-image: version = $(shell git describe --abbrev=0)


### PR DESCRIPTION
Reverts allegro/ralph#3560 - breaks process of realeasing new version as tty is not available on ralph building machines