### PR TITLE
Removed warning `Empty msgid.` during *.PO files creating process

### DIFF
--- a/src/ralph/dhcp/admin.py
+++ b/src/ralph/dhcp/admin.py
@@ -42,7 +42,7 @@ class DNSServerGroupAdmin(RalphAdmin):
     list_display = ('name', 'servers_formatted')
     readonly_fields = ['networks']
     fieldsets = (
-        (_(''), {
+        (None, {
             'fields': (
                 'name',
                 'networks',

--- a/src/ralph/networks/views.py
+++ b/src/ralph/networks/views.py
@@ -60,7 +60,7 @@ class NetworkView(RalphDetailViewAdmin):
     available_networks.short_description = _('Available networks')
     available_networks.allow_tags = True
     fieldsets = (
-        (_(''), {
+        (None, {
             'fields': (
                 'available_networks',
             )


### PR DESCRIPTION
Admin fieldset as title accept `None` instead as empty lang string