### PR TITLE
fix issue with showing proper form error for DNS tab

### DIFF
--- a/src/ralph/dns/forms.py
+++ b/src/ralph/dns/forms.py
@@ -44,7 +44,8 @@ class DNSRecordForm(forms.Form):
     ptr = forms.BooleanField(
         label=_('PTR'),
         initial=False,
-        required=False
+        required=False,
+        widget=forms.CheckboxInput(attrs={'disabled': True})
     )
 
     def clean(self):

--- a/src/ralph/dns/tests.py
+++ b/src/ralph/dns/tests.py
@@ -550,7 +550,7 @@ class TestPublishAutoTXTToDNSaaS(TransactionTestCase):
 
 class TestDNSForm(TestCase):
     def test_unknown_field_goes_to_non_field_errors(self):
-        errors = {'unknown_field': ['value']}
+        errors = {'errors': [{'reason': 'unknown', 'comment': 'value'}]}
         form = DNSRecordForm({})
         add_errors(form, errors)
         self.assertIn('value', form.non_field_errors())


### PR DESCRIPTION
New DNSaaS has different response scheme for 400 errors.