### PR TITLE
nginx service waiting for web:8000 at startup

### DIFF
--- a/contrib/docker/ralph.entrypoint.nginx
+++ b/contrib/docker/ralph.entrypoint.nginx
@@ -1,0 +1,16 @@
+#!/bin/bash
+set -e
+
+export RALPH_URL="web:8000"
+
+function ralph_ready(){
+  curl -s "${RALPH_URL}"
+}
+
+>&2 echo "Checking Ralph (at ${RALPH_URL})..."
+until ralph_ready; do
+  >&2 echo "Ralph is unavailable - waiting 1 sec for ${RALPH_URL}"
+  sleep 1
+done
+>&2 echo "Ralph is up - continuing with nginx..."
+sh /docker-entrypoint.sh nginx -g 'daemon off;'

--- a/docker/Dockerfile-static
+++ b/docker/Dockerfile-static
@@ -9,3 +9,6 @@ LABEL version="$RALPH_VERSION"
 
 COPY --from=allegro/ralph:latest /usr/share/ralph/static /opt/static
 COPY contrib/docker/ralph.conf.nginx /etc/nginx/conf.d/default.conf
+COPY contrib/docker/ralph.entrypoint.nginx /entrypoint.sh
+RUN sed -i 's/\r//' /entrypoint.sh && chmod +x /entrypoint.sh
+ENTRYPOINT ["/entrypoint.sh"]


### PR DESCRIPTION
the docker  compose command docker-compose up -d can result in a nginx container exited after error connecting to web:8000 (proxy_pass http://web:8000; in nginx conf file) when web container is still not available.
using ralf.entrypoint.nginx script as entrypoint.sh for the nginx image will start nginx process only after service web is active and responding on port 8000 