### PR TITLE
Switching to Discourse

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,5 +39,3 @@ Visit our documentation on [readthedocs.org](https://ralph-ng.readthedocs.org)
 ## Getting help
 
 * Online forum for Ralph community: https://ralph.discourse.group
-* Chat support: [![Gitter](https://img.shields.io/gitter/room/gitterHQ/gitter.svg)](https://gitter.im/allegro/ralph?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
-


### PR DESCRIPTION
Gitter has been removed, we switched to Discourse with open source hosting