### PR TITLE
Remove unique constraint from MAC address

### DIFF
--- a/src/ralph/assets/models/components.py
+++ b/src/ralph/assets/models/components.py
@@ -114,7 +114,7 @@ class Ethernet(Component):
         verbose_name=_('label'), max_length=255, blank=True, null=True
     )
     mac = MACAddressField(
-        verbose_name=_('MAC address'), unique=True,
+        verbose_name=_('MAC address'),
         validators=[mac_validator], max_length=24, null=True, blank=True
     )
     speed = models.PositiveIntegerField(


### PR DESCRIPTION
Remove unique constraint from MAC address since a MAC address is not necessarily unique.
In large (virtual-)environments the uniqueness of a MAC address can not be guaranteed. It should only be unique within a layer 2 domain and not globally.