### PR TITLE
Dont remove extra permissions automatically

### DIFF
--- a/src/ralph/__init__.py
+++ b/src/ralph/__init__.py
@@ -1,14 +1,1 @@
-from django.db.models.options import Options
-
 __version__ = "3.0.0"
-
-
-def monkey_options_init(self, meta, app_label):
-    self._old__init__(meta, app_label)
-    self.default_permissions = ("add", "change", "delete", "view")
-
-
-Options._old__init__ = Options.__init__
-Options.__init__ = lambda self, meta, app_label=None: monkey_options_init(
-    self, meta, app_label
-)

--- a/src/ralph/accounts/management/commands/_base.py
+++ b/src/ralph/accounts/management/commands/_base.py
@@ -1,6 +1,5 @@
-# -*- coding: utf-8 -*-
 """
-Base command class and utilities for extra view permissions management.
+Base command class and utilities for permissions management.
 
 Provides shared functionality like psql-style table output formatting.
 """

--- a/src/ralph/accounts/management/commands/_base.py
+++ b/src/ralph/accounts/management/commands/_base.py
@@ -1,0 +1,116 @@
+# -*- coding: utf-8 -*-
+"""
+Base command class and utilities for extra view permissions management.
+
+Provides shared functionality like psql-style table output formatting.
+"""
+
+import re
+from typing import Callable
+
+from django.core.management.base import BaseCommand
+
+# Pre-compiled regex for ANSI escape codes
+ANSI_ESCAPE_RE = re.compile(r"\x1B(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~])")
+
+
+def strip_ansi(text: str) -> str:
+    """Remove ANSI escape codes from text."""
+    return ANSI_ESCAPE_RE.sub("", text)
+
+
+def calculate_column_widths(headers: list[str], rows: list[list]) -> list[int]:
+    """Calculate the maximum width needed for each column."""
+    widths = [len(h) for h in headers]
+    for row in rows:
+        for i, val in enumerate(row):
+            plain_val = strip_ansi(str(val))
+            widths[i] = max(widths[i], len(plain_val))
+    return widths
+
+
+def format_separator(widths: list[int]) -> str:
+    """Format the horizontal separator line."""
+    return "+-" + "-+-".join("-" * w for w in widths) + "-+"
+
+
+def format_header(headers: list[str], widths: list[int]) -> str:
+    """Format the header row."""
+    cells = (h.ljust(widths[i]) for i, h in enumerate(headers))
+    return "| " + " | ".join(cells) + " |"
+
+
+def format_row(
+    row: list,
+    widths: list[int],
+    row_idx: int,
+    style_map: dict[tuple[int, int], Callable],
+) -> str:
+    """Format a single data row with optional styling."""
+    formatted = []
+    for col_idx, val in enumerate(row):
+        cell = str(val).ljust(widths[col_idx])
+        style_fn = style_map.get((row_idx, col_idx))
+        formatted.append(style_fn(cell) if style_fn else cell)
+    return "| " + " | ".join(formatted) + " |"
+
+
+def format_table(
+    headers: list[str],
+    rows: list[list],
+    style_map: dict[tuple[int, int], Callable] = None,
+) -> list[str]:
+    """
+    Format data as psql-style table lines.
+
+    Args:
+        headers: Column header names.
+        rows: List of rows, each row is a list of values.
+        style_map: Optional dict mapping (row_idx, col_idx) to style function.
+
+    Returns:
+        List of formatted lines ready to print.
+    """
+    if not rows:
+        return ["(0 rows)"]
+
+    style_map = style_map or {}
+    widths = calculate_column_widths(headers, rows)
+    separator = format_separator(widths)
+
+    lines = [
+        separator,
+        format_header(headers, widths),
+        separator,
+        *[format_row(row, widths, idx, style_map) for idx, row in enumerate(rows)],
+        separator,
+        f"({len(rows)} rows)",
+    ]
+    return lines
+
+
+def format_summary(active: int, orphaned: int) -> str:
+    """Format permission summary counts."""
+    return (
+        f"\n Active permissions:   {active}\n"
+        f" Orphaned permissions: {orphaned}\n"
+        f" Total in database:    {active + orphaned}\n"
+    )
+
+
+class PermissionBaseCommand(BaseCommand):
+    """Base command with table output utilities."""
+
+    def print_table(
+        self,
+        headers: list[str],
+        rows: list[list],
+        style_map: dict[tuple[int, int], Callable] = None,
+    ):
+        """Print data in psql-style table format."""
+        for line in format_table(headers, rows, style_map):
+            self.stdout.write(line)
+
+    def print_summary(self, active: int, orphaned: int):
+        """Print permission summary counts."""
+        self.stdout.write(format_summary(active, orphaned))

--- a/src/ralph/accounts/management/commands/audit_extra_view_permissions.py
+++ b/src/ralph/accounts/management/commands/audit_extra_view_permissions.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 Management command to list and audit extra view permissions.
 

--- a/src/ralph/accounts/management/commands/audit_extra_view_permissions.py
+++ b/src/ralph/accounts/management/commands/audit_extra_view_permissions.py
@@ -1,0 +1,102 @@
+# -*- coding: utf-8 -*-
+"""
+Management command to list and audit extra view permissions.
+
+This command provides an overview of all extra view permissions,
+showing which are active, orphaned, and their group assignments.
+"""
+
+import json
+
+from ralph.accounts.management.commands._base import PermissionBaseCommand
+from ralph.lib.permissions.utils import get_permission_info_list
+
+
+class Command(PermissionBaseCommand):
+    help = "List and audit all extra view permissions."
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--show-groups",
+            action="store_true",
+            help="Show which groups have each permission.",
+        )
+        parser.add_argument(
+            "--orphaned-only",
+            action="store_true",
+            help="Show only orphaned permissions.",
+        )
+        parser.add_argument(
+            "--format",
+            choices=["table", "json"],
+            default="table",
+            help="Output format (default: table).",
+        )
+
+    def handle(self, *args, **options):
+        show_groups = options["show_groups"]
+        orphaned_only = options["orphaned_only"]
+        output_format = options["format"]
+
+        data, active_count, orphaned_count = get_permission_info_list(
+            include_groups=show_groups,
+            orphaned_only=orphaned_only,
+        )
+
+        if output_format == "json":
+            self._output_json(data, active_count, orphaned_count)
+        else:
+            self._output_table(data, active_count, orphaned_count, show_groups)
+
+    def _output_table(self, data, active_count, orphaned_count, show_groups):
+        """Output permissions in psql-style table format."""
+        self.print_summary(active_count, orphaned_count)
+
+        if not data:
+            self.stdout.write("(0 rows)\n")
+            return
+
+        # Build headers and rows
+        headers = ["status", "codename", "name", "content_type"]
+        if show_groups:
+            headers.append("groups")
+
+        rows = []
+        style_map = {}
+
+        for idx, info in enumerate(data):
+            row = [info.status, info.codename, info.name, info.content_type]
+            if show_groups:
+                groups_str = ", ".join(info.groups) or "(none)"
+                row.append(groups_str)
+            rows.append(row)
+
+            # Style the status column
+            if info.is_orphaned:
+                style_map[(idx, 0)] = self.style.ERROR
+            else:
+                style_map[(idx, 0)] = self.style.SUCCESS
+
+        self.print_table(headers, rows, style_map)
+
+    def _output_json(self, data, active_count, orphaned_count):
+        """Output permissions in JSON format."""
+        output = {
+            "summary": {
+                "active_count": active_count,
+                "orphaned_count": orphaned_count,
+                "total_count": active_count + orphaned_count,
+            },
+            "permissions": [
+                {
+                    "codename": info.codename,
+                    "name": info.name,
+                    "content_type": info.content_type,
+                    "status": info.status,
+                    "groups": info.groups,
+                }
+                for info in data
+            ],
+        }
+
+        self.stdout.write(json.dumps(output, indent=2))

--- a/src/ralph/accounts/management/commands/audit_extra_view_permissions.py
+++ b/src/ralph/accounts/management/commands/audit_extra_view_permissions.py
@@ -9,7 +9,7 @@ showing which are active, orphaned, and their group assignments.
 import json
 
 from ralph.accounts.management.commands._base import PermissionBaseCommand
-from ralph.lib.permissions.utils import get_permission_info_list
+from ralph.lib.permissions.utils import collect_permission_info
 
 
 class Command(PermissionBaseCommand):
@@ -38,7 +38,7 @@ class Command(PermissionBaseCommand):
         orphaned_only = options["orphaned_only"]
         output_format = options["format"]
 
-        data, active_count, orphaned_count = get_permission_info_list(
+        data, active_count, orphaned_count = collect_permission_info(
             include_groups=show_groups,
             orphaned_only=orphaned_only,
         )

--- a/src/ralph/accounts/management/commands/cleanup_extra_view_permissions.py
+++ b/src/ralph/accounts/management/commands/cleanup_extra_view_permissions.py
@@ -1,0 +1,102 @@
+# -*- coding: utf-8 -*-
+"""
+Management command to clean up orphaned extra view permissions.
+
+Orphaned permissions are those that start with 'can_view_extra_' but are not
+associated with any currently registered view. This can happen when views are
+removed or when conditionally-loaded views (e.g., DNSView) are not available
+in the current environment.
+"""
+
+import logging
+
+from ralph.accounts.management.commands._base import PermissionBaseCommand
+from ralph.lib.permissions.views import get_orphaned_extra_view_permissions
+from ralph.lib.permissions.utils import get_permission_groups
+
+logger = logging.getLogger(__name__)
+
+
+class Command(PermissionBaseCommand):
+    help = (
+        "Clean up orphaned extra view permissions that are no longer "
+        "associated with any registered view."
+    )
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--dry-run",
+            action="store_true",
+            help="Show what would be deleted without actually deleting.",
+        )
+        parser.add_argument(
+            "--force",
+            action="store_true",
+            help="Skip confirmation prompt.",
+        )
+        parser.add_argument(
+            "--exclude",
+            action="append",
+            default=[],
+            metavar="CODENAME",
+            help="Exclude permission codename from deletion (can be repeated).",
+        )
+
+    def handle(self, *args, **options):
+        dry_run = options["dry_run"]
+        force = options["force"]
+        exclude = set(options["exclude"])
+
+        orphaned = get_orphaned_extra_view_permissions()
+
+        if exclude:
+            orphaned = orphaned.exclude(codename__in=exclude)
+
+        if not orphaned.exists():
+            self.stdout.write(
+                self.style.SUCCESS("No orphaned extra view permissions found.")
+            )
+            return
+
+        # Display orphaned permissions in table format
+        count = orphaned.count()
+        self.stdout.write(
+            self.style.WARNING(f"\nFound {count} orphaned permission(s):\n")
+        )
+
+        headers = ["codename", "content_type", "groups"]
+        rows = []
+        style_map = {}
+
+        for idx, perm in enumerate(orphaned):
+            groups = get_permission_groups(perm)
+            groups_str = ", ".join(groups) or "(none)"
+            rows.append([perm.codename, str(perm.content_type), groups_str])
+
+        self.print_table(headers, rows, style_map)
+
+        if dry_run:
+            self.stdout.write(
+                self.style.NOTICE("\nDry run - no permissions were deleted.")
+            )
+            return
+
+        if not force:
+            self.stdout.write(
+                self.style.WARNING(
+                    "\nWARNING: Deleting will remove permissions from all groups!"
+                )
+            )
+            confirm = input("Are you sure you want to delete? [y/N]: ")
+            if confirm.lower() != "y":
+                self.stdout.write(self.style.NOTICE("Aborted."))
+                return
+
+        deleted_count, _ = orphaned.delete()
+
+        self.stdout.write(
+            self.style.SUCCESS(f"Deleted {deleted_count} orphaned permission(s).")
+        )
+        logger.info(
+            "Deleted %d orphaned permission(s) via management command.", deleted_count
+        )

--- a/src/ralph/accounts/management/commands/cleanup_extra_view_permissions.py
+++ b/src/ralph/accounts/management/commands/cleanup_extra_view_permissions.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 Management command to clean up orphaned extra view permissions.
 

--- a/src/ralph/accounts/management/commands/export_group_permissions.py
+++ b/src/ralph/accounts/management/commands/export_group_permissions.py
@@ -1,0 +1,43 @@
+# -*- coding: utf-8 -*-
+"""
+Management command to export group permissions to a JSON file.
+"""
+
+import json
+
+from django.contrib.auth.models import Group
+from django.core.management.base import BaseCommand
+
+
+def export_all_group_permissions() -> dict[str, list[str]]:
+    """Export all group permissions as {group_name: ["app_label.codename", ...]}."""
+    result = {}
+    for group in Group.objects.prefetch_related("permissions__content_type").all():
+        if group.permissions.exists():
+            result[group.name] = [
+                f"{perm.content_type.app_label}.{perm.codename}"
+                for perm in group.permissions.all()
+            ]
+    return result
+
+
+class Command(BaseCommand):
+    help = "Export group permissions to a JSON file."
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "file",
+            help="Output JSON file path.",
+        )
+
+    def handle(self, *args, **options):
+        mappings = export_all_group_permissions()
+
+        with open(options["file"], "w") as f:
+            json.dump(mappings, f, indent=2)
+
+        self.stdout.write(
+            self.style.SUCCESS(
+                f"Exported permissions for {len(mappings)} groups to {options['file']}"
+            )
+        )

--- a/src/ralph/accounts/management/commands/export_group_permissions.py
+++ b/src/ralph/accounts/management/commands/export_group_permissions.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 Management command to export group permissions to a JSON file.
 """

--- a/src/ralph/accounts/management/commands/restore_group_permissions.py
+++ b/src/ralph/accounts/management/commands/restore_group_permissions.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 Management command to restore group permissions from a JSON file.
 """

--- a/src/ralph/accounts/management/commands/restore_group_permissions.py
+++ b/src/ralph/accounts/management/commands/restore_group_permissions.py
@@ -1,0 +1,95 @@
+# -*- coding: utf-8 -*-
+"""
+Management command to restore group permissions from a JSON file.
+"""
+
+import json
+
+from django.contrib.auth.models import Group, Permission
+from django.core.management.base import CommandError
+
+from ralph.accounts.management.commands._base import PermissionBaseCommand
+
+
+def assign_permission_to_group(
+    group_name: str, perm_key: str
+) -> tuple[bool, str | None]:
+    """
+    Assign permission to group. Returns (success, error).
+
+    perm_key format: "app_label.codename" (e.g., "accounts.can_view_extra_dnsview")
+    """
+    try:
+        group = Group.objects.get(name=group_name)
+    except Group.DoesNotExist:
+        return False, f"Group '{group_name}' not found"
+
+    try:
+        app_label, codename = perm_key.split(".", 1)
+        perm = Permission.objects.get(
+            codename=codename,
+            content_type__app_label=app_label,
+        )
+    except ValueError:
+        return (
+            False,
+            f"Invalid permission format '{perm_key}' (expected 'app_label.codename')",
+        )
+    except Permission.DoesNotExist:
+        return False, f"Permission '{perm_key}' not found"
+
+    group.permissions.add(perm)
+    return True, None
+
+
+class Command(PermissionBaseCommand):
+    help = "Restore group permissions from a JSON file."
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "file",
+            help="Input JSON file path.",
+        )
+        parser.add_argument(
+            "--dry-run",
+            action="store_true",
+            help="Show what would be done without making changes.",
+        )
+
+    def handle(self, *args, **options):
+        dry_run = options["dry_run"]
+
+        try:
+            with open(options["file"], "r") as f:
+                mappings = json.load(f)
+        except FileNotFoundError:
+            raise CommandError(f"File not found: {options['file']}")
+        except json.JSONDecodeError as e:
+            raise CommandError(f"Invalid JSON file: {e}")
+
+        headers = ["group", "permission", "status"]
+        rows = []
+        style_map = {}
+        row_idx = 0
+
+        for group_name, perm_keys in mappings.items():
+            for perm_key in perm_keys:
+                if dry_run:
+                    rows.append([group_name, perm_key, "WOULD ASSIGN"])
+                    style_map[(row_idx, 2)] = self.style.NOTICE
+                else:
+                    success, error = assign_permission_to_group(group_name, perm_key)
+                    if success:
+                        rows.append([group_name, perm_key, "ASSIGNED"])
+                        style_map[(row_idx, 2)] = self.style.SUCCESS
+                    else:
+                        rows.append([group_name, perm_key, error])
+                        style_map[(row_idx, 2)] = self.style.WARNING
+                row_idx += 1
+
+        if rows:
+            self.stdout.write("\n")
+            self.print_table(headers, rows, style_map)
+
+        action = "Would restore" if dry_run else "Restored"
+        self.stdout.write(self.style.SUCCESS(f"\n{action} {len(rows)} assignment(s)."))

--- a/src/ralph/accounts/tests/test_permission_commands.py
+++ b/src/ralph/accounts/tests/test_permission_commands.py
@@ -1,8 +1,3 @@
-# -*- coding: utf-8 -*-
-"""
-Tests for permission management commands.
-"""
-
 import json
 import tempfile
 from io import StringIO
@@ -31,8 +26,6 @@ from ralph.accounts.models import RalphUser
 
 
 class BaseFormattersTestCase(TestCase):
-    """Tests for _base.py formatting functions."""
-
     def test_strip_ansi_removes_escape_codes(self):
         text_with_ansi = "\x1b[31mred text\x1b[0m"
         result = strip_ansi(text_with_ansi)

--- a/src/ralph/accounts/tests/test_permission_commands.py
+++ b/src/ralph/accounts/tests/test_permission_commands.py
@@ -1,0 +1,392 @@
+# -*- coding: utf-8 -*-
+"""
+Tests for permission management commands.
+"""
+
+import json
+import tempfile
+from io import StringIO
+
+from django.contrib.auth.models import Group, Permission
+from django.contrib.contenttypes.models import ContentType
+from django.core.management import call_command
+from django.core.management.base import CommandError
+from django.test import TestCase
+
+from ralph.accounts.management.commands._base import (
+    calculate_column_widths,
+    format_header,
+    format_row,
+    format_separator,
+    format_table,
+    strip_ansi,
+)
+from ralph.accounts.management.commands.export_group_permissions import (
+    export_all_group_permissions,
+)
+from ralph.accounts.management.commands.restore_group_permissions import (
+    assign_permission_to_group,
+)
+from ralph.accounts.models import RalphUser
+
+
+class BaseFormattersTestCase(TestCase):
+    """Tests for _base.py formatting functions."""
+
+    def test_strip_ansi_removes_escape_codes(self):
+        text_with_ansi = "\x1b[31mred text\x1b[0m"
+        result = strip_ansi(text_with_ansi)
+        self.assertEqual(result, "red text")
+
+    def test_strip_ansi_preserves_plain_text(self):
+        plain_text = "plain text"
+        result = strip_ansi(plain_text)
+        self.assertEqual(result, plain_text)
+
+    def test_calculate_column_widths_uses_header_length(self):
+        headers = ["short", "longer_header"]
+        rows = [["a", "b"]]
+        widths = calculate_column_widths(headers, rows)
+        self.assertEqual(widths, [5, 13])
+
+    def test_calculate_column_widths_uses_row_length(self):
+        headers = ["a", "b"]
+        rows = [["very_long_value", "x"]]
+        widths = calculate_column_widths(headers, rows)
+        self.assertEqual(widths, [15, 1])
+
+    def test_format_separator(self):
+        widths = [5, 10]
+        result = format_separator(widths)
+        self.assertEqual(result, "+-------+------------+")
+
+    def test_format_header(self):
+        headers = ["col1", "col2"]
+        widths = [5, 10]
+        result = format_header(headers, widths)
+        self.assertEqual(result, "| col1  | col2       |")
+
+    def test_format_row_without_styling(self):
+        row = ["val1", "val2"]
+        widths = [5, 10]
+        result = format_row(row, widths, 0, {})
+        self.assertEqual(result, "| val1  | val2       |")
+
+    def test_format_row_with_styling(self):
+        row = ["val1", "val2"]
+        widths = [5, 10]
+        style_fn = lambda x: f"[{x}]"  # noqa
+        style_map = {(0, 0): style_fn}
+        result = format_row(row, widths, 0, style_map)
+        self.assertIn("[val1 ]", result)
+
+    def test_format_table_empty_rows(self):
+        headers = ["col1", "col2"]
+        rows = []
+        result = format_table(headers, rows)
+        self.assertEqual(result, ["(0 rows)"])
+
+    def test_format_table_with_data(self):
+        headers = ["col1", "col2"]
+        rows = [["a", "b"], ["c", "d"]]
+        result = format_table(headers, rows)
+        self.assertEqual(
+            len(result), 7
+        )  # separator, header, separator, 2 rows, separator, count
+        self.assertIn("(2 rows)", result[-1])
+
+
+class ExportGroupPermissionsTestCase(TestCase):
+    """Tests for export_group_permissions command."""
+
+    def setUp(self):
+        self.group1 = Group.objects.create(name="TestGroup1")
+        self.group2 = Group.objects.create(name="TestGroup2")
+        self.group_empty = Group.objects.create(name="EmptyGroup")
+
+        # Get some existing permissions
+        self.perm1 = Permission.objects.first()
+        self.perm2 = Permission.objects.last()
+
+        self.group1.permissions.add(self.perm1)
+        self.group2.permissions.add(self.perm1, self.perm2)
+
+    def test_export_all_group_permissions_function(self):
+        result = export_all_group_permissions()
+
+        self.assertIn("TestGroup1", result)
+        self.assertIn("TestGroup2", result)
+        self.assertNotIn("EmptyGroup", result)  # Empty groups not included
+
+        # Check format is app_label.codename
+        for perm_key in result["TestGroup1"]:
+            self.assertIn(".", perm_key)
+
+    def test_export_command_creates_file(self):
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
+            temp_path = f.name
+
+        out = StringIO()
+        call_command("export_group_permissions", temp_path, stdout=out)
+
+        with open(temp_path, "r") as f:
+            data = json.load(f)
+
+        self.assertIn("TestGroup1", data)
+        self.assertIn("Exported permissions for", out.getvalue())
+
+    def test_export_format_is_app_label_codename(self):
+        result = export_all_group_permissions()
+
+        for group_name, perm_keys in result.items():
+            for perm_key in perm_keys:
+                parts = perm_key.split(".", 1)
+                self.assertEqual(len(parts), 2)
+                app_label, codename = parts
+                # Verify permission exists
+                self.assertTrue(
+                    Permission.objects.filter(
+                        codename=codename,
+                        content_type__app_label=app_label,
+                    ).exists()
+                )
+
+
+class RestoreGroupPermissionsTestCase(TestCase):
+    """Tests for restore_group_permissions command."""
+
+    def setUp(self):
+        self.group = Group.objects.create(name="RestoreTestGroup")
+        self.perm = Permission.objects.first()
+        self.perm_key = f"{self.perm.content_type.app_label}.{self.perm.codename}"
+
+    def test_assign_permission_to_group_success(self):
+        success, error = assign_permission_to_group(self.group.name, self.perm_key)
+
+        self.assertTrue(success)
+        self.assertIsNone(error)
+        self.assertIn(self.perm, self.group.permissions.all())
+
+    def test_assign_permission_to_group_invalid_group(self):
+        success, error = assign_permission_to_group("NonExistentGroup", self.perm_key)
+
+        self.assertFalse(success)
+        self.assertIn("not found", error)
+
+    def test_assign_permission_to_group_invalid_permission(self):
+        success, error = assign_permission_to_group(
+            self.group.name, "invalid.permission"
+        )
+
+        self.assertFalse(success)
+        self.assertIn("not found", error)
+
+    def test_assign_permission_to_group_invalid_format(self):
+        success, error = assign_permission_to_group(self.group.name, "no_dot_here")
+
+        self.assertFalse(success)
+        self.assertIn("Invalid permission format", error)
+
+    def test_restore_command_dry_run(self):
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
+            json.dump({self.group.name: [self.perm_key]}, f)
+            temp_path = f.name
+
+        out = StringIO()
+        call_command("restore_group_permissions", temp_path, "--dry-run", stdout=out)
+
+        output = out.getvalue()
+        self.assertIn("WOULD ASSIGN", output)
+        self.assertNotIn(self.perm, self.group.permissions.all())
+
+    def test_restore_command_actual_restore(self):
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
+            json.dump({self.group.name: [self.perm_key]}, f)
+            temp_path = f.name
+
+        out = StringIO()
+        call_command("restore_group_permissions", temp_path, stdout=out)
+
+        output = out.getvalue()
+        self.assertIn("ASSIGNED", output)
+        self.assertIn(self.perm, self.group.permissions.all())
+
+    def test_restore_command_file_not_found(self):
+        out = StringIO()
+        with self.assertRaises(CommandError) as ctx:
+            call_command(
+                "restore_group_permissions", "/nonexistent/file.json", stderr=out
+            )
+
+        self.assertIn("File not found", str(ctx.exception))
+
+    def test_restore_command_invalid_json(self):
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
+            f.write("not valid json {{{")
+            temp_path = f.name
+
+        with self.assertRaises(CommandError) as ctx:
+            call_command("restore_group_permissions", temp_path)
+
+        self.assertIn("Invalid JSON", str(ctx.exception))
+
+
+class CleanupExtraViewPermissionsTestCase(TestCase):
+    """Tests for cleanup_extra_view_permissions command."""
+
+    def setUp(self):
+        # Create an orphaned extra view permission
+        content_type = ContentType.objects.get_for_model(RalphUser)
+        self.orphaned_perm = Permission.objects.create(
+            codename="can_view_extra_orphanedtestview",
+            name="Can view OrphanedTestView",
+            content_type=content_type,
+        )
+
+        self.group = Group.objects.create(name="CleanupTestGroup")
+        self.group.permissions.add(self.orphaned_perm)
+
+    def test_cleanup_dry_run_does_not_delete(self):
+        out = StringIO()
+        call_command("cleanup_extra_view_permissions", "--dry-run", stdout=out)
+
+        output = out.getvalue()
+        self.assertIn("Dry run", output)
+        self.assertTrue(
+            Permission.objects.filter(
+                codename="can_view_extra_orphanedtestview"
+            ).exists()
+        )
+
+    def test_cleanup_with_force_deletes(self):
+        out = StringIO()
+        call_command("cleanup_extra_view_permissions", "--force", stdout=out)
+
+        output = out.getvalue()
+        self.assertIn("Deleted", output)
+        self.assertFalse(
+            Permission.objects.filter(
+                codename="can_view_extra_orphanedtestview"
+            ).exists()
+        )
+
+    def test_cleanup_exclude_option(self):
+        out = StringIO()
+        call_command(
+            "cleanup_extra_view_permissions",
+            "--force",
+            "--exclude=can_view_extra_orphanedtestview",
+            stdout=out,
+        )
+
+        # Permission should still exist because it was excluded
+        self.assertTrue(
+            Permission.objects.filter(
+                codename="can_view_extra_orphanedtestview"
+            ).exists()
+        )
+
+    def test_cleanup_no_orphaned_permissions(self):
+        # Delete the orphaned permission first
+        self.orphaned_perm.delete()
+
+        out = StringIO()
+        call_command("cleanup_extra_view_permissions", stdout=out)
+
+        output = out.getvalue()
+        self.assertIn("No orphaned", output)
+
+
+class AuditExtraViewPermissionsTestCase(TestCase):
+    """Tests for audit_extra_view_permissions command."""
+
+    def setUp(self):
+        content_type = ContentType.objects.get_for_model(RalphUser)
+        self.orphaned_perm = Permission.objects.create(
+            codename="can_view_extra_audittestview",
+            name="Can view AuditTestView",
+            content_type=content_type,
+        )
+
+    def test_audit_table_format(self):
+        out = StringIO()
+        call_command("audit_extra_view_permissions", stdout=out)
+
+        output = out.getvalue()
+        self.assertIn("Active permissions", output)
+        self.assertIn("Orphaned permissions", output)
+
+    def test_audit_json_format(self):
+        out = StringIO()
+        call_command("audit_extra_view_permissions", "--format=json", stdout=out)
+
+        output = out.getvalue()
+        data = json.loads(output)
+
+        self.assertIn("summary", data)
+        self.assertIn("permissions", data)
+        self.assertIn("active_count", data["summary"])
+        self.assertIn("orphaned_count", data["summary"])
+
+    def test_audit_orphaned_only(self):
+        out = StringIO()
+        call_command(
+            "audit_extra_view_permissions",
+            "--orphaned-only",
+            "--format=json",
+            stdout=out,
+        )
+
+        output = out.getvalue()
+        data = json.loads(output)
+
+        for perm in data["permissions"]:
+            self.assertEqual(perm["status"], "ORPHANED")
+
+    def test_audit_show_groups(self):
+        group = Group.objects.create(name="AuditTestGroup")
+        group.permissions.add(self.orphaned_perm)
+
+        out = StringIO()
+        call_command(
+            "audit_extra_view_permissions",
+            "--show-groups",
+            "--format=json",
+            stdout=out,
+        )
+
+        output = out.getvalue()
+        data = json.loads(output)
+
+        # Find our test permission and check groups
+        for perm in data["permissions"]:
+            if perm["codename"] == "can_view_extra_audittestview":
+                self.assertIn("AuditTestGroup", perm["groups"])
+                break
+
+
+class ExportRestoreRoundTripTestCase(TestCase):
+    """Test that export and restore work together correctly."""
+
+    def setUp(self):
+        self.group = Group.objects.create(name="RoundTripTestGroup")
+        self.perm = Permission.objects.first()
+        self.group.permissions.add(self.perm)
+
+    def test_export_restore_roundtrip(self):
+        # Export
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
+            temp_path = f.name
+
+        call_command("export_group_permissions", temp_path)
+
+        # Clear permissions
+        self.group.permissions.clear()
+        self.assertNotIn(self.perm, self.group.permissions.all())
+
+        # Restore
+        call_command("restore_group_permissions", temp_path)
+
+        # Verify
+        self.group.refresh_from_db()
+        self.assertIn(self.perm, self.group.permissions.all())

--- a/src/ralph/lib/permissions/tests/api.py
+++ b/src/ralph/lib/permissions/tests/api.py
@@ -2,7 +2,6 @@
 from django.conf.urls import include
 from django.urls import re_path
 from rest_framework import permissions, routers, serializers, viewsets
-
 from ralph.lib.permissions.api import (
     ObjectPermissionsMixin,
     PermissionsForObjectFilter,

--- a/src/ralph/lib/permissions/utils.py
+++ b/src/ralph/lib/permissions/utils.py
@@ -130,7 +130,3 @@ def assign_permission_to_group(codename: str, group_name: str) -> AssignmentResu
 
     group.permissions.add(perm)
     return AssignmentResult(True)
-
-
-# Aliases for backward compatibility
-get_permission_info_list = collect_permission_info

--- a/src/ralph/lib/permissions/utils.py
+++ b/src/ralph/lib/permissions/utils.py
@@ -3,9 +3,9 @@ Utility functions for extra view permissions management.
 """
 
 from dataclasses import dataclass
-from typing import Optional
 
-from django.contrib.auth.models import Group, Permission
+from django.contrib.auth.models import Permission
+from django.db.models import QuerySet
 
 from ralph.admin.sites import ralph_site
 
@@ -36,7 +36,7 @@ class AssignmentResult:
     """Result of a permission assignment operation."""
 
     success: bool
-    error: Optional[str] = None
+    error: str | None = None
 
 
 def get_registered_codenames() -> set[str]:
@@ -56,14 +56,14 @@ def get_admin_view_mapping() -> dict:
     }
 
 
-def query_permissions():
+def query_permissions() -> QuerySet[Permission]:
     """Returns all extra view permissions."""
     return Permission.objects.filter(
         codename__startswith=EXTRA_VIEW_PERMISSION_PREFIX
     ).select_related("content_type")
 
 
-def query_orphaned_permissions():
+def query_orphaned_permissions() -> QuerySet[Permission]:
     """Returns permissions not associated with any registered view."""
     return query_permissions().exclude(codename__in=get_registered_codenames())
 
@@ -104,28 +104,3 @@ def collect_permission_info(
         )
 
     return result, len(get_registered_codenames()), len(orphaned_codenames)
-
-
-def export_permission_mappings() -> dict[str, list[str]]:
-    """Exports current permission-group mappings as {codename: [group_names]}."""
-    return {
-        perm.codename: get_permission_groups(perm)
-        for perm in query_permissions().prefetch_related("group_set")
-        if perm.group_set.exists()
-    }
-
-
-def assign_permission_to_group(codename: str, group_name: str) -> AssignmentResult:
-    """Assigns a permission to a group."""
-    try:
-        perm = Permission.objects.get(codename=codename)
-    except Permission.DoesNotExist:
-        return AssignmentResult(False, f"Permission '{codename}' does not exist")
-
-    try:
-        group = Group.objects.get(name=group_name.strip())
-    except Group.DoesNotExist:
-        return AssignmentResult(False, f"Group '{group_name}' does not exist")
-
-    group.permissions.add(perm)
-    return AssignmentResult(True)

--- a/src/ralph/lib/permissions/utils.py
+++ b/src/ralph/lib/permissions/utils.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 Utility functions for extra view permissions management.
 """

--- a/src/ralph/lib/permissions/utils.py
+++ b/src/ralph/lib/permissions/utils.py
@@ -1,0 +1,136 @@
+# -*- coding: utf-8 -*-
+"""
+Utility functions for extra view permissions management.
+"""
+
+from dataclasses import dataclass
+from typing import Optional
+
+from django.contrib.auth.models import Group, Permission
+
+from ralph.admin.sites import ralph_site
+
+EXTRA_VIEW_PERMISSION_PREFIX = "can_view_extra_"
+
+
+@dataclass
+class PermissionInfo:
+    """Permission with metadata."""
+
+    codename: str
+    name: str
+    content_type: str
+    is_orphaned: bool
+    groups: list[str] = None
+
+    def __post_init__(self):
+        if self.groups is None:
+            self.groups = []
+
+    @property
+    def status(self) -> str:
+        return "ORPHANED" if self.is_orphaned else "ACTIVE"
+
+
+@dataclass
+class AssignmentResult:
+    """Result of a permission assignment operation."""
+
+    success: bool
+    error: Optional[str] = None
+
+
+def get_registered_codenames() -> set[str]:
+    """Returns codenames for all currently registered permission views."""
+    from ralph.lib.permissions.views import _permission_views
+
+    return {codename for _, codename in _permission_views}
+
+
+def get_admin_view_mapping() -> dict:
+    """Returns a mapping of view classes to their associated models."""
+    return {
+        change_view: model
+        for model, admin_class in ralph_site._registry.items()
+        if admin_class.change_views
+        for change_view in admin_class.change_views
+    }
+
+
+def query_permissions():
+    """Returns all extra view permissions."""
+    return Permission.objects.filter(
+        codename__startswith=EXTRA_VIEW_PERMISSION_PREFIX
+    ).select_related("content_type")
+
+
+def query_orphaned_permissions():
+    """Returns permissions not associated with any registered view."""
+    return query_permissions().exclude(codename__in=get_registered_codenames())
+
+
+def get_permission_groups(perm: Permission) -> list[str]:
+    """Returns group names that have the given permission."""
+    return list(perm.group_set.values_list("name", flat=True))
+
+
+def collect_permission_info(
+    include_groups: bool = False,
+    orphaned_only: bool = False,
+) -> tuple[list[PermissionInfo], int, int]:
+    """
+    Collects permission data for all extra view permissions.
+
+    Returns: (permissions, active_count, orphaned_count)
+    """
+    orphaned_codenames = set(
+        query_orphaned_permissions().values_list("codename", flat=True)
+    )
+
+    result = []
+    for perm in query_permissions():
+        is_orphaned = perm.codename in orphaned_codenames
+
+        if orphaned_only and not is_orphaned:
+            continue
+
+        result.append(
+            PermissionInfo(
+                codename=perm.codename,
+                name=perm.name,
+                content_type=str(perm.content_type),
+                is_orphaned=is_orphaned,
+                groups=get_permission_groups(perm) if include_groups else [],
+            )
+        )
+
+    return result, len(get_registered_codenames()), len(orphaned_codenames)
+
+
+def export_permission_mappings() -> dict[str, list[str]]:
+    """Exports current permission-group mappings as {codename: [group_names]}."""
+    return {
+        perm.codename: get_permission_groups(perm)
+        for perm in query_permissions().prefetch_related("group_set")
+        if perm.group_set.exists()
+    }
+
+
+def assign_permission_to_group(codename: str, group_name: str) -> AssignmentResult:
+    """Assigns a permission to a group."""
+    try:
+        perm = Permission.objects.get(codename=codename)
+    except Permission.DoesNotExist:
+        return AssignmentResult(False, f"Permission '{codename}' does not exist")
+
+    try:
+        group = Group.objects.get(name=group_name.strip())
+    except Group.DoesNotExist:
+        return AssignmentResult(False, f"Group '{group_name}' does not exist")
+
+    group.permissions.add(perm)
+    return AssignmentResult(True)
+
+
+# Aliases for backward compatibility
+get_permission_info_list = collect_permission_info

--- a/src/ralph/lib/permissions/views.py
+++ b/src/ralph/lib/permissions/views.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import logging
 
 from django.contrib.auth import get_user_model

--- a/src/ralph/lib/permissions/views.py
+++ b/src/ralph/lib/permissions/views.py
@@ -13,6 +13,8 @@ logger = logging.getLogger(__name__)
 
 _permission_views = []
 
+EXTRA_VIEW_PERMISSION_PREFIX = "can_view_extra_"
+
 
 def view_permission_dispatch(func):
     """
@@ -51,7 +53,7 @@ class PermissionViewMetaClass(type):
     """
 
     def __new__(cls, name, bases, attrs):
-        codename = "can_view_extra_{}".format(name.lower())
+        codename = "{}{}".format(EXTRA_VIEW_PERMISSION_PREFIX, name.lower())
 
         attrs["permision_codename"] = codename
         new_class = super().__new__(cls, name, bases, attrs)
@@ -61,45 +63,93 @@ class PermissionViewMetaClass(type):
         return new_class
 
 
-def update_extra_view_permissions(sender, **kwargs):
-    """
-    Get all views that inherit the PermissionViewMetaClass and
-    adding them permission.
-    """
-    if sender.name != "django.contrib.auth":
-        return
-    logger.info("Updating extra views permissions...")
+def _get_admin_view_mapping():
+    """Returns a mapping of view classes to their associated models."""
     admin_classes = {}
     for model, admin_class in ralph_site._registry.items():
         if admin_class.change_views:
             for change_view in admin_class.change_views:
                 admin_classes[change_view] = model
+    return admin_classes
 
-    old_permission = Permission.objects.filter(
-        codename__startswith="can_view_extra_"
-    ).values_list("id", flat=True)
-    current_permission = []
+
+def _get_registered_codenames():
+    """Returns the set of codenames for all currently registered permission views."""
+    return {codename for _, codename in _permission_views}
+
+
+def get_orphaned_extra_view_permissions():
+    """
+    Returns a queryset of permissions that start with 'can_view_extra_' but
+    are not associated with any currently registered view.
+
+    Useful for identifying permissions that may need manual cleanup.
+    """
+    current_codenames = _get_registered_codenames()
+    return Permission.objects.filter(
+        codename__startswith=EXTRA_VIEW_PERMISSION_PREFIX
+    ).exclude(codename__in=current_codenames)
+
+
+def update_extra_view_permissions(sender, **kwargs):
+    """
+    Get all views that inherit the PermissionViewMetaClass and
+    adding them permission.
+
+    NOTE: This function does NOT delete orphaned permissions to prevent
+    accidental data loss when views are conditionally loaded (e.g., DNSView
+    when ENABLE_DNSAAS_INTEGRATION is disabled). Use the management command
+    `cleanup_extra_view_permissions` to manually remove unused permissions.
+    """
+    if sender.name != "django.contrib.auth":
+        return
+    logger.info("Updating extra views permissions...")
+
+    admin_classes = _get_admin_view_mapping()
+
+    old_permission_ids = set(
+        Permission.objects.filter(
+            codename__startswith=EXTRA_VIEW_PERMISSION_PREFIX
+        ).values_list("id", flat=True)
+    )
+
+    current_permission_ids = []
+    created_count = 0
+    existing_count = 0
+
     for class_view, codename in _permission_views:
         model = admin_classes.get(class_view, None)
         if not model:
             model = get_user_model()
         ct = ContentType.objects.get_for_model(model)
-        perm, _ = Permission.objects.get_or_create(
+        perm, created = Permission.objects.get_or_create(
             content_type=ct,
             codename=codename,
             defaults={"name": "Can view {}".format(class_view.__name__)},
         )
-        current_permission.append(perm.id)
+        current_permission_ids.append(perm.id)
+        if created:
+            created_count += 1
+            logger.debug("Created permission: %s for model %s", codename, model)
+        else:
+            existing_count += 1
 
-    # Remove old permission codename views.
-    permission_ids = set(old_permission) - set(current_permission)
-    if permission_ids:
+    logger.info(
+        "Extra view permissions: %d total (%d created, %d existing)",
+        len(current_permission_ids),
+        created_count,
+        existing_count,
+    )
+
+    # Identify orphaned permissions (not deleting them)
+    orphaned_permission_ids = old_permission_ids - set(current_permission_ids)
+    if orphaned_permission_ids:
+        orphaned_codenames = Permission.objects.filter(
+            id__in=orphaned_permission_ids
+        ).values_list("codename", flat=True)
         logger.warning(
-            "Removing unused permissions: %s",
-            ", ".join(
-                Permission.objects.filter(id__in=permission_ids).values_list(
-                    "codename", flat=True
-                )
-            ),
+            "Found %d orphaned permission(s): %s. "
+            "Run 'cleanup_extra_view_permissions' to remove them.",
+            len(orphaned_permission_ids),
+            ", ".join(orphaned_codenames),
         )
-        Permission.objects.filter(id__in=permission_ids).delete()


### PR DESCRIPTION
In case of misconfiguration, e.g. `ralph.dns` not in INSTALLED_APPS

Used to be:
WARNING Removing unused permissions: can_view_extra_clusterdnsview, can_view_extra_dnsview, can_view_extra_virtualserverdnsview

Now will be:
WARNING Found 3 orphaned permission(s): can_view_extra_clusterdnsview, can_view_extra_dnsview, can_view_extra_virtualserverdnsview. Run 'cleanup_extra_view_permissions' to remove them.
