### PR TITLE
Fix docker-compose: upgrade MySQL 5.7 to 8.0

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -34,7 +34,7 @@ services:
 
   db:
     platform: linux/amd64
-    image: mysql:5.7
+    image: mysql:8.0
     environment:
       MYSQL_DATABASE: ralph_ng
       MYSQL_ROOT_PASSWORD: ralph_ng


### PR DESCRIPTION
## Summary

The `allegro/ralph:latest` Docker image ships Django 4.2+ which requires MySQL 8 or later. The current `docker-compose.yml` pins `mysql:5.7`, causing `ralphctl migrate` to fail immediately on a fresh deployment:

```
django.db.utils.NotSupportedError: MySQL 8 or later is required (found 5.7.44).
```

This upgrades the MySQL image from `5.7` to `8.0`.

## Reproduction

```bash
cd docker
docker compose up -d
docker compose exec web ralphctl migrate
# -> NotSupportedError: MySQL 8 or later is required (found 5.7.44).
```