### PR TITLE
Improve test factories

### DIFF
--- a/src/ralph/accounts/tests/factories.py
+++ b/src/ralph/accounts/tests/factories.py
@@ -45,6 +45,11 @@ class UserFactory(DjangoModelFactory):
                 self.groups.add(group)
 
 
+class SuperuserFactory(UserFactory):
+    is_superuser = True
+    is_staff = True
+
+
 class TeamFactory(DjangoModelFactory):
     name = factory.Iterator(["DBA", "sysadmins", "devops"])
 

--- a/src/ralph/api/tests/_base.py
+++ b/src/ralph/api/tests/_base.py
@@ -7,6 +7,7 @@ from django.db import connections, DEFAULT_DB_ALIAS
 from django.test.utils import CaptureQueriesContext  # noqa
 from rest_framework.test import APITestCase
 
+from ralph.accounts.tests.factories import SuperuserFactory, UserFactory
 from ralph.tests.models import Foo
 
 
@@ -88,9 +89,9 @@ class RalphAPITestCase(APITestCase):
             params.update(kwargs)
             return get_user_model().objects.create(**params)
 
-        cls.user1 = create_user("user1")
-        cls.user2 = create_user("user2")
-        cls.superuser = create_user("superuser", is_staff=True, is_superuser=True)
+        cls.user1 = UserFactory()
+        cls.user2 = UserFactory()
+        cls.superuser = SuperuserFactory()
 
     @classmethod
     def setUpClass(cls):

--- a/src/ralph/api/tests/test_filters.py
+++ b/src/ralph/api/tests/test_filters.py
@@ -3,9 +3,8 @@ from datetime import date
 from decimal import Decimal
 from urllib.parse import urlencode
 
-from django.contrib.auth import get_user_model
 from django.http import QueryDict
-from rest_framework.test import APIClient, APIRequestFactory
+from rest_framework.test import APIRequestFactory
 
 from ralph.api.filters import (
     ExtendedFiltersBackend,
@@ -13,20 +12,17 @@ from ralph.api.filters import (
     LookupFilterBackend,
     TRUE_VALUES,
 )
+from ralph.api.tests._base import RalphAPITestCase
 from ralph.api.tests.api import Bar, BarViewSet, ManufacturerViewSet, TestManufacturer
-from ralph.tests import RalphTestCase
 from ralph.tests.factories import TestManufacturerFactory
 
 
-class TestExtendedFiltersBackend(RalphTestCase):
+class TestExtendedFiltersBackend(RalphAPITestCase):
     def setUp(self):
         super().setUp()
         self.request_factory = APIRequestFactory()
         self.manufacture_1 = TestManufacturerFactory(name="test", country="Poland")
         self.manufacture_2 = TestManufacturerFactory(name="test2", country="test")
-        get_user_model().objects.create_superuser("test", "test@test.test", "test")
-        self.client = APIClient()
-        self.client.login(username="test", password="test")
         self.extended_filters_backend = ExtendedFiltersBackend()
 
     def test_extended_filter_fields(self):
@@ -55,13 +51,10 @@ class TestExtendedFiltersBackend(RalphTestCase):
         )
 
 
-class TestLookupFilterBackend(RalphTestCase):
+class TestLookupFilterBackend(RalphAPITestCase):
     def setUp(self):
         super().setUp()
         self.request_factory = APIRequestFactory()
-        get_user_model().objects.create_superuser("test", "test@test.test", "test")
-        self.client = APIClient()
-        self.client.login(username="test", password="test")
 
         Bar.objects.create(
             id=999999,

--- a/src/ralph/api/tests/test_rendering.py
+++ b/src/ralph/api/tests/test_rendering.py
@@ -84,7 +84,7 @@ ALL_API_ENDPOINTS = {
     "racks": "/api/racks/",
     "regions": "/api/regions/",
     "server-rooms": "/api/server-rooms/",
-    "services": "/api/services/",
+    "services": ("/api/services/", 25),
     "services-environments": "/api/services-environments/",
     "sim-card": "/api/sim-card/",
     "sim-card-cellular-carrier": "/api/sim-card-cellular-carrier/",
@@ -128,6 +128,10 @@ class RalphAPIRenderingTests(APIPermissionsTestMixin, APITestCase):
 
     @data(*ALL_API_ENDPOINTS.keys())
     def test_browsable_endpoint(self, model_name):
+        # Note: browsable API renders an HTML form at the bottom of the page
+        # which generates extra SQL queries for loading FK/choice widgets,
+        # not just the API response itself. Keep this in mind when adjusting
+        # max_queries for specific endpoints.
         endpoint, max_queries = (
             ALL_API_ENDPOINTS[model_name]
             if isinstance(ALL_API_ENDPOINTS[model_name], tuple)

--- a/src/ralph/assets/api/views.py
+++ b/src/ralph/assets/api/views.py
@@ -56,7 +56,7 @@ class ServiceViewSet(RalphAPIViewSet):
     queryset = models.Service.objects.all()
     serializer_class = serializers.ServiceSerializer
     save_serializer_class = serializers.SaveServiceSerializer
-    select_related = ["profit_center"]
+    select_related = ["profit_center", "support_team", "business_segment"]
     prefetch_related = ["business_owners", "technical_owners", "environments"]
     additional_filter_class = ServiceFilterSet
 
@@ -76,9 +76,16 @@ class ServiceEnvironmentViewSet(RalphAPIViewSet):
 
     queryset = models.ServiceEnvironment.objects.all()
     serializer_class = serializers.ServiceEnvironmentSerializer
-    select_related = ["service", "environment", "service__support_team"]
-    prefetch_related = ["tags"] + [
-        "service__{}".format(pr) for pr in ServiceViewSet.prefetch_related
+    select_related = [
+        "service",
+        "environment",
+        "service__support_team",
+        "content_type",
+        "service__profit_center",
+        "service__business_segment",
+    ]
+    prefetch_related = ["tags", "custom_fields"] + [
+        f"service__{pr}" for pr in ServiceViewSet.prefetch_related
     ]
     additional_filter_class = ServiceEnvFilterSet
 

--- a/src/ralph/assets/tests/factories.py
+++ b/src/ralph/assets/tests/factories.py
@@ -3,6 +3,7 @@ import factory
 from factory.django import DjangoModelFactory
 from factory.fuzzy import FuzzyText
 
+from ralph.accounts.tests.factories import UserFactory, TeamFactory
 from ralph.assets.models.assets import (
     AssetHolder,
     AssetModel,
@@ -224,14 +225,61 @@ class ProfitCenterFactory(DjangoModelFactory):
 
 
 class ServiceFactory(DjangoModelFactory):
-    name = factory.Iterator(["Backup systems", "load_balancing", "databases"])
+    name = factory.Iterator(
+        [
+            "Backup systems",
+            "load_balancing",
+            "databases",
+            "web servers",
+            "mail servers",
+            "DNS",
+            "DHCP",
+            "Monitoring",
+            "Logging",
+            "Authentication",
+        ]
+    )
     uid = factory.Sequence(lambda n: "sc-{}".format(n))
     business_segment = factory.SubFactory(BusinessSegmentFactory)
     profit_center = factory.SubFactory(ProfitCenterFactory)
+    support_team = factory.SubFactory(TeamFactory)
 
     class Meta:
         model = Service
         django_get_or_create = ["name"]
+
+    @factory.post_generation
+    def post_environments(self, create, extracted, **kwargs):
+        if not create:
+            return
+        if extracted:
+            for environment in extracted:
+                ServiceEnvironmentFactory(service=self, environment=environment)
+        else:
+            for _ in ["dev", "test", "prod"]:
+                ServiceEnvironmentFactory(service=self)
+
+    @factory.post_generation
+    def post_business_owners(self, create, extracted, **kwargs):
+        if not create:
+            return
+        if extracted:
+            for business_owner in extracted:
+                self.business_owners.add(business_owner)
+        else:
+            for _ in range(3):
+                self.business_owners.add(UserFactory())
+
+    @factory.post_generation
+    def post_technical_owners(self, create, extracted, **kwargs):
+        if not create:
+            return
+        if extracted:
+            for technical_owner in extracted:
+                self.technical_owners.add(technical_owner)
+        else:
+            for _ in range(3):
+                self.technical_owners.add(UserFactory())
 
 
 class ServiceEnvironmentFactory(DjangoModelFactory):

--- a/src/ralph/assets/tests/test_api.py
+++ b/src/ralph/assets/tests/test_api.py
@@ -120,9 +120,7 @@ class ServicesEnvironmentsAPITests(RalphAPITestCase):
         super().setUp()
         self.envs = EnvironmentFactory.create_batch(2)
         self.services = ServiceFactory.create_batch(2)
-        ServiceEnvironment.objects.create(
-            service=self.services[0], environment=self.envs[0]
-        )
+        ServiceEnvironmentFactory(service=self.services[0], environment=self.envs[0])
         self.team = TeamFactory()
         self.profit_center = ProfitCenterFactory()
 
@@ -140,7 +138,7 @@ class ServicesEnvironmentsAPITests(RalphAPITestCase):
         response = self.client.post(url, data, format="json")
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
         self.assertEqual(response.data["name"], "test-env")
-        self.assertEqual(Environment.objects.count(), 3)
+        self.assertEqual(Environment.objects.count(), 4)
 
     def test_patch_environment(self):
         env = self.envs[0]

--- a/src/ralph/assets/tests/test_api.py
+++ b/src/ralph/assets/tests/test_api.py
@@ -834,7 +834,7 @@ class DCHostAPITests(RalphAPITestCase):
         VirtualServerFullFactory.create_batch(20, parent=dc_assets[0])
         CloudHostFullFactory.create_batch(20, hypervisor=dc_assets[0])
         url = reverse("dchost-list") + "?limit=100"
-        with self.assertQueriesMoreOrLess(17, plus_minus=1):
+        with self.assertQueriesMoreOrLess(18, plus_minus=2):
             response = self.client.get(url)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data["count"], 63)

--- a/src/ralph/assets/tests/test_api.py
+++ b/src/ralph/assets/tests/test_api.py
@@ -333,7 +333,7 @@ class ServicesEnvironmentsAPITests(RalphAPITestCase):
             "environment": self.envs[0].id,
         }
         response = self.client.patch(url, data, format="json")
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.status_code, status.HTTP_200_OK, msg=response.data)
 
 
 class ProfitCenterAPITests(RalphAPITestCase):

--- a/src/ralph/assets/tests/test_api.py
+++ b/src/ralph/assets/tests/test_api.py
@@ -45,10 +45,8 @@ from ralph.data_center.tests.factories import (
 )
 from ralph.domains.models import Domain
 from ralph.domains.tests.factories import DomainFactory
-from ralph.lib.custom_fields.models import (
-    CustomField,
-    CustomFieldTypes,
-)
+from ralph.lib.custom_fields.models import CustomFieldTypes
+from ralph.lib.custom_fields.tests.factories import CustomFieldFactory
 from ralph.licences.models import Licence
 from ralph.licences.tests.factories import LicenceFactory
 from ralph.networks.tests.factories import IPAddressFactory
@@ -119,8 +117,10 @@ class ServicesEnvironmentsAPITests(RalphAPITestCase):
     def setUp(self):
         super().setUp()
         self.envs = EnvironmentFactory.create_batch(2)
-        self.services = ServiceFactory.create_batch(2)
-        ServiceEnvironmentFactory(service=self.services[0], environment=self.envs[0])
+        self.services = [
+            ServiceFactory(post_environments=[self.envs[0]]),
+            ServiceFactory(post_environments=[self.envs[1]]),
+        ]
         self.team = TeamFactory()
         self.profit_center = ProfitCenterFactory()
 
@@ -133,12 +133,13 @@ class ServicesEnvironmentsAPITests(RalphAPITestCase):
         self.assertIn("url", response.data)
 
     def test_create_environment(self):
+        env_count_before = Environment.objects.count()
         url = reverse("environment-list")
         data = {"name": "test-env"}
         response = self.client.post(url, data, format="json")
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
         self.assertEqual(response.data["name"], "test-env")
-        self.assertEqual(Environment.objects.count(), 4)
+        self.assertEqual(Environment.objects.count(), env_count_before + 1)
 
     def test_patch_environment(self):
         env = self.envs[0]
@@ -539,17 +540,27 @@ class BaseObjectAPITests(RalphAPITestCase):
         self.conf_class_1 = ConfigurationClassFactory(
             id=999999, module=self.conf_module_2, class_name="cls1"
         )
+        dc_env = EnvironmentFactory(name="prod")
+        dc_service = ServiceFactory(
+            name="test-service",
+            uid="sc-bo-api-1",
+            post_environments=[dc_env],
+        )
+        dc_service_env = dc_service.serviceenvironment_set.get(environment=dc_env)
         self.dc_asset = DataCenterAssetFactory(
             barcode="12543",
             price="9.00",
-            service_env__service__name="test-service",
-            service_env__service__uid="sc-123",
-            service_env__environment__name="prod",
+            service_env=dc_service_env,
             configuration_path=self.conf_class_1,
         )
         self.dc_asset.tags.add("tag2")
         self.ip = IPAddressFactory(ethernet=EthernetFactory(base_object=self.dc_asset))
-        self.service = ServiceEnvironmentFactory(service__name="myservice")
+        my_env = EnvironmentFactory(name="myservice-env")
+        my_service = ServiceFactory(
+            name="myservice",
+            post_environments=[my_env],
+        )
+        self.service = my_service.serviceenvironment_set.get(environment=my_env)
 
     def test_get_base_objects_list(self):
         url = reverse("baseobject-list")
@@ -562,7 +573,7 @@ class BaseObjectAPITests(RalphAPITestCase):
         self.assertCountEqual(barcodes, set(["12345", "12543"]))
 
     def test_get_base_objects_list_different_type_with_custom_fields(self):
-        CustomField.objects.create(name="test_field")
+        CustomFieldFactory(name="test_field")
         self.dc_asset.update_custom_field("test_field", "abc")
         self.bo_asset.update_custom_field("test_field", "def")
         url = reverse("baseobject-list")
@@ -589,7 +600,7 @@ class BaseObjectAPITests(RalphAPITestCase):
         response = self.client.get(url, format="json")
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         service_env = response.data["service_env"]
-        self.assertEqual(service_env["service_uid"], "sc-123")
+        self.assertEqual(service_env["service_uid"], "sc-bo-api-1")
         self.assertEqual(service_env["service"], "test-service")
         self.assertEqual(service_env["environment"], "prod")
 
@@ -754,7 +765,7 @@ class BaseObjectAPITests(RalphAPITestCase):
         self.assertEqual(len(response.data["results"]), 1)
 
     def test_filter_by_deletion_check(self):
-        service_env = ServiceEnvironmentFactory(service__uid="sc-321")
+        service_env = ServiceEnvironmentFactory(service__uid="sc-del-check")
         asset = DataCenterAssetFactory(service_env=service_env)
         licence_future = LicenceFactory(
             service_env=service_env, valid_thru="2026-01-01"
@@ -769,7 +780,7 @@ class BaseObjectAPITests(RalphAPITestCase):
 
         url = "{}?{}".format(
             reverse("baseobject-list"),
-            urlencode({"service": "sc-321", "deletion_check": "2025-01-01"}),
+            urlencode({"service": "sc-del-check", "deletion_check": "2025-01-01"}),
         )
         response = self.client.get(url, format="json")
         self.assertEqual(response.status_code, status.HTTP_200_OK)
@@ -783,9 +794,7 @@ class BaseObjectAPITests(RalphAPITestCase):
 class DCHostAPITests(RalphAPITestCase):
     def setUp(self):
         super().setUp()
-        self.cf = CustomField.objects.create(
-            name="test_cf", use_as_configuration_variable=True
-        )
+        self.cf = CustomFieldFactory(name="test_cf", use_as_configuration_variable=True)
         # BO asset isn't DC Host - will be skipped in API
         self.bo_asset = BackOfficeAssetFactory(barcode="12345", hostname="host1")
         self.conf_module_1 = ConfigurationModuleFactory()
@@ -797,7 +806,7 @@ class DCHostAPITests(RalphAPITestCase):
         )
         self.dc_asset = DataCenterAssetFullFactory(
             service_env__service__name="test-service",
-            service_env__service__uid="sc-123",
+            service_env__service__uid="sc-dc-host-1",
             service_env__environment__name="prod",
             configuration_path=self.conf_class_1,
         )
@@ -805,11 +814,11 @@ class DCHostAPITests(RalphAPITestCase):
         self.virtual = VirtualServerFullFactory(
             parent=self.dc_asset,
             configuration_path__module__name="ralph2",
-            service_env__service__uid="sc-222",
+            service_env__service__uid="sc-dc-host-2",
             service_env__environment__name="some_env",
         )
         self.virtual.update_custom_field("test_cf", "def")
-        se = ServiceEnvironmentFactory(service__uid="sc-333")
+        se = ServiceEnvironmentFactory(service__uid="sc-dc-host-3")
         self.cloud_host = CloudHostFullFactory(
             configuration_path__module__name="ralph3",
             service_env=se,
@@ -825,7 +834,7 @@ class DCHostAPITests(RalphAPITestCase):
         VirtualServerFullFactory.create_batch(20, parent=dc_assets[0])
         CloudHostFullFactory.create_batch(20, hypervisor=dc_assets[0])
         url = reverse("dchost-list") + "?limit=100"
-        with self.assertQueriesMoreOrLess(19, plus_minus=1):
+        with self.assertQueriesMoreOrLess(17, plus_minus=1):
             response = self.client.get(url)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data["count"], 63)
@@ -859,7 +868,7 @@ class DCHostAPITests(RalphAPITestCase):
         self.assertEqual(len(dca["ipaddresses"]), 2)
         self.assertCountEqual(dca["tags"], ["abc, cde", "xyz"])
         self.assertEqual(dca["configuration_path"]["module"]["name"], "ralph")
-        self.assertEqual(dca["service_env"]["service_uid"], "sc-123")
+        self.assertEqual(dca["service_env"]["service_uid"], "sc-dc-host-1")
         self.assertEqual(dca["object_type"], "datacenterasset")
         self.assertEqual(dca["custom_fields"], {"test_cf": "abc"})
         self.assertEqual(dca["configuration_variables"], {"test_cf": "abc"})
@@ -877,7 +886,7 @@ class DCHostAPITests(RalphAPITestCase):
         self.assertEqual(len(virt["ipaddresses"]), 1)
         self.assertCountEqual(virt["tags"], ["abc, cde", "xyz"])
         self.assertEqual(virt["configuration_path"]["module"]["name"], "ralph2")
-        self.assertEqual(virt["service_env"]["service_uid"], "sc-222")
+        self.assertEqual(virt["service_env"]["service_uid"], "sc-dc-host-2")
         self.assertEqual(virt["object_type"], "virtualserver")
         self.assertEqual(virt["custom_fields"], {"test_cf": "def"})
         self.assertEqual(virt["configuration_variables"], {"test_cf": "def"})
@@ -893,7 +902,7 @@ class DCHostAPITests(RalphAPITestCase):
         self.assertEqual(cloud["hostname"], self.cloud_host.hostname)
         self.assertCountEqual(cloud["tags"], ["abc, cde", "xyz"])
         self.assertEqual(cloud["configuration_path"]["module"]["name"], "ralph3")
-        self.assertEqual(cloud["service_env"]["service_uid"], "sc-333")
+        self.assertEqual(cloud["service_env"]["service_uid"], "sc-dc-host-3")
         self.assertEqual(cloud["object_type"], "cloudhost")
         self.assertEqual(len(cloud["ethernet"]), 1)
         self.assertEqual(len(cloud["ipaddresses"]), 1)
@@ -913,7 +922,9 @@ class DCHostAPITests(RalphAPITestCase):
         self.assertEqual(response.data["count"], 1)
 
     def test_filter_by_service_uid(self):
-        url = "{}?{}".format(reverse("dchost-list"), urlencode({"service": "sc-222"}))
+        url = "{}?{}".format(
+            reverse("dchost-list"), urlencode({"service": "sc-dc-host-2"})
+        )
         response = self.client.get(url, format="json")
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data["count"], 1)
@@ -974,7 +985,7 @@ class DCHostAPITests(RalphAPITestCase):
         self.assertEqual(self.cloud_host.hypervisor.id, new_hypervisor.id)
 
     def test_nested_customfields_view(self):
-        cf = CustomField.objects.create(
+        cf = CustomFieldFactory(
             name="test", type=CustomFieldTypes.STRING, default_value="xyz"
         )
         url = reverse("dchost-customfields-list", args=(self.virtual.id,))

--- a/src/ralph/assets/tests/test_api.py
+++ b/src/ralph/assets/tests/test_api.py
@@ -326,7 +326,7 @@ class ServicesEnvironmentsAPITests(RalphAPITestCase):
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
 
     def test_patch_service_environment(self):
-        service_env = ServiceEnvironment.objects.all()[0]
+        service_env = self.services[0].serviceenvironment_set.first()
         url = reverse("serviceenvironment-detail", args=(service_env.id,))
         data = {
             "service": self.services[0].id,

--- a/src/ralph/data_center/tests/test_api.py
+++ b/src/ralph/data_center/tests/test_api.py
@@ -85,8 +85,12 @@ class DataCenterAssetAPITests(RalphAPITestCase):
         self.assertEqual(len(response.data["memory"]), 2)
         self.assertEqual(response.data["memory"][0]["speed"], 1600)
         self.assertEqual(response.data["memory"][0]["size"], 8192)
-        self.assertEqual(response.data["business_owners"][0]["username"], "user1")
-        self.assertEqual(response.data["technical_owners"][0]["username"], "user2")
+        self.assertEqual(
+            response.data["business_owners"][0]["username"], self.user1.username
+        )
+        self.assertEqual(
+            response.data["technical_owners"][0]["username"], self.user2.username
+        )
 
     def test_get_data_center_asset_details_related_hosts(self):
         dc_asset_3 = DataCenterAssetFullFactory()
@@ -666,8 +670,12 @@ class ClusterAPITests(RalphAPITestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data["name"], self.cluster_1.name)
         self.assertEqual(response.data["hostname"], self.cluster_1.hostname)
-        self.assertEqual(response.data["business_owners"][0]["username"], "user1")
-        self.assertEqual(response.data["technical_owners"][0]["username"], "user2")
+        self.assertEqual(
+            response.data["business_owners"][0]["username"], self.user1.username
+        )
+        self.assertEqual(
+            response.data["technical_owners"][0]["username"], self.user2.username
+        )
         self.assertEqual(len(response.data["base_objects"]), 2)
         self.assertCountEqual(
             response.data["base_objects"],

--- a/src/ralph/data_importer/tests/test_commands.py
+++ b/src/ralph/data_importer/tests/test_commands.py
@@ -9,17 +9,22 @@ from django.core import management
 from django.test import TestCase
 
 from ralph.accounts.models import Region
+from ralph.accounts.tests.factories import RegionFactory, UserFactory
 from ralph.assets.models import ConfigurationClass
 from ralph.assets.models.assets import (
     AssetModel,
     Category,
-    Environment,
     Manufacturer,
-    Service,
-    ServiceEnvironment,
 )
-from ralph.assets.models.choices import ObjectModelType
+from ralph.assets.tests.factories import (
+    BackOfficeAssetModelFactory,
+    DataCenterAssetModelFactory,
+    EnvironmentFactory,
+    ServiceEnvironmentFactory,
+    ServiceFactory,
+)
 from ralph.back_office.models import BackOfficeAsset, Warehouse
+from ralph.back_office.tests.factories import WarehouseFactory
 from ralph.data_center.models import DataCenterAsset, DataCenterAssetStatus
 from ralph.data_center.models.physical import DataCenter, Rack, ServerRoom
 from ralph.data_center.tests.factories import DataCenterFactory
@@ -44,47 +49,30 @@ class DataImporterTestCase(TestCase):
     def setUp(self):  # noqa
         self.base_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
-        asset_model = AssetModel()
-        asset_model.name = "asset_model_1"
-        asset_model.type = ObjectModelType.back_office
-        asset_model.save()
+        asset_model = BackOfficeAssetModelFactory(name="asset_model_1")
         asset_content_type = ContentType.objects.get_for_model(AssetModel)
         ImportedObjects.objects.create(
             content_type=asset_content_type, object_pk=asset_model.pk, old_object_pk=1
         )
 
-        warehouse = Warehouse()
-        warehouse.name = "warehouse_1"
-        warehouse.save()
-
+        warehouse = WarehouseFactory(name="warehouse_1")
         warehouse_content_type = ContentType.objects.get_for_model(Warehouse)
         ImportedObjects.objects.create(
             content_type=warehouse_content_type, object_pk=warehouse.pk, old_object_pk=1
         )
 
-        environment = Environment()
-        environment.name = "environment_1"
-        environment.save()
+        environment = EnvironmentFactory(name="environment_1")
+        service = ServiceFactory(name="service_1")
+        ServiceEnvironmentFactory(environment=environment, service=service)
 
-        service = Service()
-        service.name = "service_1"
-        service.save()
-
-        service_environment = ServiceEnvironment()
-        service_environment.environment = environment
-        service_environment.service = service
-        service_environment.save()
-
-        region = Region(name="region_1")
-        region.save()
+        region = RegionFactory(name="region_1")
         region_content_type = ContentType.objects.get_for_model(region)
         ImportedObjects.objects.create(
             content_type=region_content_type, object_pk=region.pk, old_object_pk=1
         )
 
-        user_model = get_user_model()
         for user in ("iron.man", "superman", "james.bond", "sherlock.holmes"):
-            user_model.objects.create(username=user)
+            UserFactory(username=user)
 
     def test_get_resource(self):
         """Test get resources method."""
@@ -253,11 +241,7 @@ class DataImporterTestCase(TestCase):
 class IPManagementTestCase(TestCase):
     def setUp(self):
         self.base_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-        asset_model = AssetModel()
-        asset_model.id = 1  # required by csvs file
-        asset_model.name = "asset_model_1"
-        asset_model.type = ObjectModelType.all
-        asset_model.save()
+        DataCenterAssetModelFactory(id=1, name="asset_model_1")
 
     def test_data_center_asset_is_imported_when_ip_management_is_created(self):
         xlsx_path = os.path.join(

--- a/src/ralph/data_importer/tests/test_demo_data.py
+++ b/src/ralph/data_importer/tests/test_demo_data.py
@@ -11,4 +11,4 @@ class DemoDataTestCase(TestCase):
         management.call_command("demodata")
         self.assertEqual(DataCenterAsset.objects.count(), 422)
         self.assertEqual(BackOfficeAsset.objects.count(), 316)
-        self.assertTrue(get_user_model().objects.count() in range(32, 35))
+        self.assertIn(get_user_model().objects.count(), range(2520, 2530))

--- a/src/ralph/data_importer/tests/test_demo_data.py
+++ b/src/ralph/data_importer/tests/test_demo_data.py
@@ -11,4 +11,4 @@ class DemoDataTestCase(TestCase):
         management.call_command("demodata")
         self.assertEqual(DataCenterAsset.objects.count(), 422)
         self.assertEqual(BackOfficeAsset.objects.count(), 316)
-        self.assertIn(get_user_model().objects.count(), range(2500, 2530))
+        self.assertIn(get_user_model().objects.count(), range(2500, 2540))

--- a/src/ralph/data_importer/tests/test_demo_data.py
+++ b/src/ralph/data_importer/tests/test_demo_data.py
@@ -11,4 +11,4 @@ class DemoDataTestCase(TestCase):
         management.call_command("demodata")
         self.assertEqual(DataCenterAsset.objects.count(), 422)
         self.assertEqual(BackOfficeAsset.objects.count(), 316)
-        self.assertIn(get_user_model().objects.count(), range(2520, 2530))
+        self.assertIn(get_user_model().objects.count(), range(2500, 2530))

--- a/src/ralph/data_importer/tests/test_fields.py
+++ b/src/ralph/data_importer/tests/test_fields.py
@@ -7,7 +7,11 @@ from ralph.back_office.tests.factories import BackOfficeAssetFactory
 from ralph.data_importer.fields import ThroughField
 from ralph.data_importer.widgets import ManyToManyThroughWidget, UserManyToManyWidget
 from ralph.licences.models import BaseObjectLicence, LicenceUser
-from ralph.licences.tests.factories import LicenceFactory
+from ralph.licences.tests.factories import (
+    BaseObjectLicenceFactory,
+    LicenceFactory,
+    LicenceUserFactory,
+)
 
 
 class DataImporterFieldsTestCase(TestCase):
@@ -21,26 +25,26 @@ class DataImporterFieldsTestCase(TestCase):
         cls.licence2 = LicenceFactory()
 
     def setUp(self):
-        LicenceUser.objects.create(licence=self.licence, user=self.users[0])
+        LicenceUserFactory(licence=self.licence, user=self.users[0])
         for user in self.delete_users:
-            LicenceUser.objects.create(licence=self.licence, user=user)
-        BaseObjectLicence.objects.create(
+            LicenceUserFactory(licence=self.licence, user=user)
+        BaseObjectLicenceFactory(
             licence=self.licence,
             base_object=self.back_office_assets[0],
         )
-        BaseObjectLicence.objects.create(
+        BaseObjectLicenceFactory(
             licence=self.licence,
             base_object=self.back_office_assets[1],
         )
 
-        LicenceUser.objects.create(licence=self.licence2, user=self.users[0])
-        LicenceUser.objects.create(licence=self.licence2, user=self.users[3])
-        LicenceUser.objects.create(licence=self.licence2, user=self.delete_users[0])
-        BaseObjectLicence.objects.create(
+        LicenceUserFactory(licence=self.licence2, user=self.users[0])
+        LicenceUserFactory(licence=self.licence2, user=self.users[3])
+        LicenceUserFactory(licence=self.licence2, user=self.delete_users[0])
+        BaseObjectLicenceFactory(
             licence=self.licence2,
             base_object=self.back_office_assets[1],
         )
-        BaseObjectLicence.objects.create(
+        BaseObjectLicenceFactory(
             licence=self.licence2,
             base_object=self.back_office_assets[2],
         )

--- a/src/ralph/dc_view/tests.py
+++ b/src/ralph/dc_view/tests.py
@@ -8,8 +8,8 @@ from ralph.assets.models.choices import ObjectModelType
 from ralph.assets.tests.factories import (
     DataCenterAssetModelFactory,
     EnvironmentFactory,
-    ServiceEnvironment,
     ServiceFactory,
+    ServiceEnvironmentFactory,
 )
 from ralph.data_center.models.choices import Orientation
 from ralph.data_center.tests.factories import (
@@ -31,7 +31,7 @@ class TestRestAssetInfoPerRack(TestCase):
 
         environment = EnvironmentFactory()
         service = ServiceFactory(name="Service1")
-        service_env = ServiceEnvironment.objects.create(
+        service_env = ServiceEnvironmentFactory(
             service=service, environment=environment
         )
         asset_model = DataCenterAssetModelFactory(type=ObjectModelType.data_center)

--- a/src/ralph/domains/api.py
+++ b/src/ralph/domains/api.py
@@ -43,6 +43,7 @@ class DomainViewSet(RalphAPIViewSet):
         "custom_fields",
         "content_type",
         "additional_services",
+        "dns_provider",
         "licences__baseobjectlicence_set",
     ]
 

--- a/src/ralph/domains/tests/factories.py
+++ b/src/ralph/domains/tests/factories.py
@@ -15,40 +15,22 @@ from ralph.domains.models import (
 from ralph.domains.models.domains import DomainProviderAdditionalServices
 
 
-class DomainFactory(DjangoModelFactory):
-    name = factory.Sequence(lambda n: "www.domain{}.com".format(n))
-    domain_status = DomainStatus.active
-    technical_owner = factory.SubFactory(UserFactory)
-    business_owner = factory.SubFactory(UserFactory)
-    service_env = factory.SubFactory(ServiceEnvironmentFactory)
-
-    class Meta:
-        model = Domain
-
-
 class DNSProviderFactory(DjangoModelFactory):
-    name = factory.Sequence(lambda n: "dns-provider{}".format(n))
+    name = factory.Sequence(lambda n: f"dns-provider{n}")
 
     class Meta:
         model = DNSProvider
 
 
 class DomainCategoryFactory(DjangoModelFactory):
-    name = factory.Sequence(lambda n: "domain-contract{}".format(n))
+    name = factory.Sequence(lambda n: f"domain-contract{n}")
 
     class Meta:
         model = DomainCategory
 
 
-class DomainContractFactory(DjangoModelFactory):
-    domain = factory.SubFactory(DomainFactory)
-
-    class Meta:
-        model = DomainContract
-
-
 class DomainRegistrantFactory(DjangoModelFactory):
-    name = factory.Iterator(["ovh", "home.pl", "nazwa.pl"])
+    name = factory.Sequence(lambda n: f"fancy-domain{n}.pl")
 
     class Meta:
         model = DomainRegistrant
@@ -56,8 +38,31 @@ class DomainRegistrantFactory(DjangoModelFactory):
 
 
 class DomainProviderAdditionalServicesFactory(DjangoModelFactory):
-    name = factory.Iterator(["Masking", "Backorder", "Acquisition"])
+    name = factory.Sequence(lambda n: f"important-domain-provider{n}")
 
     class Meta:
         model = DomainProviderAdditionalServices
         django_get_or_create = ["name"]
+
+
+class DomainFactory(DjangoModelFactory):
+    name = factory.Sequence(lambda n: f"www.domain{n}.com")
+    domain_status = DomainStatus.active
+    technical_owner = factory.SubFactory(UserFactory)
+    business_owner = factory.SubFactory(UserFactory)
+    service_env = factory.SubFactory(ServiceEnvironmentFactory)
+    dns_provider = factory.SubFactory(DNSProviderFactory)
+
+    class Meta:
+        model = Domain
+
+    @factory.post_generation
+    def post_additional_services(self, create, extracted, **kwargs):
+        self.additional_services.add(DomainProviderAdditionalServicesFactory())
+
+
+class DomainContractFactory(DjangoModelFactory):
+    domain = factory.SubFactory(DomainFactory)
+
+    class Meta:
+        model = DomainContract

--- a/src/ralph/virtual/tests/factories.py
+++ b/src/ralph/virtual/tests/factories.py
@@ -9,6 +9,8 @@ from ralph.assets.tests.factories import (
     MemoryFactory,
     ProcessorFactory,
     ServiceEnvironmentFactory,
+    BaseObjectFactory,
+    ComponentModelFactory,
 )
 from ralph.data_center.tests.factories import DataCenterAssetFactory
 from ralph.virtual.models import (
@@ -19,7 +21,16 @@ from ralph.virtual.models import (
     CloudProvider,
     VirtualServer,
     VirtualServerType,
+    VirtualComponent,
 )
+
+
+class VirtualComponentFactory(DjangoModelFactory):
+    base_object = factory.SubFactory(BaseObjectFactory)
+    model = factory.SubFactory(ComponentModelFactory)
+
+    class Meta:
+        model = VirtualComponent
 
 
 class CloudImageFactory(DjangoModelFactory):

--- a/src/ralph/virtual/tests/test_api.py
+++ b/src/ralph/virtual/tests/test_api.py
@@ -5,25 +5,24 @@ from django.urls import reverse
 from rest_framework import status
 
 from ralph.api.tests._base import RalphAPITestCase
-from ralph.assets.models.assets import ServiceEnvironment
 from ralph.assets.models.choices import ComponentType
-from ralph.assets.models.components import ComponentModel
 from ralph.assets.tests.factories import (
+    ComponentModelFactory,
     EnvironmentFactory,
     EthernetFactory,
     ServiceFactory,
+    ServiceEnvironmentFactory,
 )
 from ralph.data_center.tests.factories import ClusterFactory, DataCenterAssetFactory
-from ralph.lib.custom_fields.models import CustomField, CustomFieldTypes
+from ralph.lib.custom_fields.models import CustomFieldTypes
+from ralph.lib.custom_fields.tests.factories import CustomFieldFactory
 from ralph.networks.tests.factories import IPAddressFactory
 from ralph.virtual.models import (
     CloudFlavor,
     CloudHost,
     CloudProject,
     CloudProvider,
-    VirtualComponent,
     VirtualServer,
-    VirtualServerType,
 )
 from ralph.virtual.tests.factories import (
     CloudFlavorFactory,
@@ -31,7 +30,9 @@ from ralph.virtual.tests.factories import (
     CloudHostFullFactory,
     CloudProjectFactory,
     CloudProviderFactory,
+    VirtualComponentFactory,
     VirtualServerFullFactory,
+    VirtualServerTypeFactory,
 )
 
 
@@ -44,7 +45,7 @@ class OpenstackModelsTestCase(RalphAPITestCase):
         self.service_env = []
         for i in range(0, 2):
             self.service_env.append(
-                ServiceEnvironment.objects.create(
+                ServiceEnvironmentFactory(
                     service=self.services[i], environment=self.envs[i]
                 )
             )
@@ -59,32 +60,32 @@ class OpenstackModelsTestCase(RalphAPITestCase):
         )
         self.cloud_host2 = CloudHostFactory()
 
-        self.test_cpu = ComponentModel.objects.create(
+        self.test_cpu = ComponentModelFactory(
             name="vcpu1",
             cores=5,
             family="vCPU",
             type=ComponentType.processor,
         )
-        self.test_mem = ComponentModel.objects.create(
+        self.test_mem = ComponentModelFactory(
             name="2000 MiB vMEM",
             size="2000",
             type=ComponentType.memory,
         )
-        self.test_disk = ComponentModel.objects.create(
+        self.test_disk = ComponentModelFactory(
             name="4 GiB vDISK",
             size="4096",
             type=ComponentType.disk,
         )
 
-        VirtualComponent.objects.create(
+        VirtualComponentFactory(
             base_object=self.cloud_flavor,
             model=self.test_cpu,
         )
-        VirtualComponent.objects.create(
+        VirtualComponentFactory(
             base_object=self.cloud_flavor,
             model=self.test_mem,
         )
-        VirtualComponent.objects.create(
+        VirtualComponentFactory(
             base_object=self.cloud_flavor,
             model=self.test_disk,
         )
@@ -132,8 +133,12 @@ class OpenstackModelsTestCase(RalphAPITestCase):
         )
         self.assertEqual(response.data["cloudflavor"]["disk"], self.cloud_flavor.disk)
         self.assertEqual(response.data["cloudflavor"]["name"], self.cloud_flavor.name)
-        self.assertEqual(response.data["business_owners"][0]["username"], "user1")
-        self.assertEqual(response.data["technical_owners"][0]["username"], "user2")
+        self.assertEqual(
+            response.data["business_owners"][0]["username"], self.user1.username
+        )
+        self.assertEqual(
+            response.data["technical_owners"][0]["username"], self.user2.username
+        )
 
     def test_filter_cloudhost_by_service_uid(self):
         cloud_host = CloudHostFactory()
@@ -424,7 +429,7 @@ class OpenstackModelsTestCase(RalphAPITestCase):
         """?fields= should use no more SQL queries than a full response."""
         self.cloud_host.tags.add("test_tag")
         self.cloud_host.ip_addresses = ["10.20.30.40"]
-        CustomField.objects.create(name="test_cf", use_as_configuration_variable=True)
+        CustomFieldFactory(name="test_cf", use_as_configuration_variable=True)
         self.cloud_host.update_custom_field("test_cf", "cloud_value")
 
         url_base = reverse("cloudhost-list") + "?limit=100"
@@ -455,7 +460,7 @@ class VirtualServerAPITestCase(RalphAPITestCase):
         self.hypervisor = DataCenterAssetFactory()
         self.cloud_hypervisor = CloudHostFactory()
         self.cluster = ClusterFactory()
-        self.type = VirtualServerType.objects.create(name="XEN")
+        self.type = VirtualServerTypeFactory(name="XEN")
         self.virtual_server = VirtualServerFullFactory(
             service_env__environment__name="some_env",
         )
@@ -494,8 +499,12 @@ class VirtualServerAPITestCase(RalphAPITestCase):
         self.assertEqual(len(response.data["memory"]), 2)
         self.assertEqual(response.data["memory"][0]["speed"], 1600)
         self.assertEqual(response.data["memory"][0]["size"], 8192)
-        self.assertEqual(response.data["business_owners"][0]["username"], "user1")
-        self.assertEqual(response.data["technical_owners"][0]["username"], "user2")
+        self.assertEqual(
+            response.data["business_owners"][0]["username"], self.user1.username
+        )
+        self.assertEqual(
+            response.data["technical_owners"][0]["username"], self.user2.username
+        )
 
     def test_create_virtual_server(self):
         virtual_server_count = VirtualServer.objects.count()
@@ -540,7 +549,7 @@ class VirtualServerAPITestCase(RalphAPITestCase):
         self.assertEqual(self.virtual_server.hostname, "s111111.local")
 
     def test_add_custom_field_to_virtual_server(self):
-        cf = CustomField.objects.create(
+        cf = CustomFieldFactory(
             name="test str", type=CustomFieldTypes.STRING, default_value="xyz"
         )
         url = (
@@ -656,7 +665,7 @@ class VirtualServerAPITestCase(RalphAPITestCase):
 
     def test_fields_query_count_no_worse_than_without(self):
         """?fields= should use no more SQL queries than a full response."""
-        CustomField.objects.create(name="test_cf", use_as_configuration_variable=True)
+        CustomFieldFactory(name="test_cf", use_as_configuration_variable=True)
         self.virtual_server.update_custom_field("test_cf", "vs_value")
 
         url_base = reverse("virtualserver-list") + "?limit=100"

--- a/src/ralph/virtual/tests/test_models.py
+++ b/src/ralph/virtual/tests/test_models.py
@@ -1,12 +1,11 @@
 from ddt import data, ddt, unpack
 
-from ralph.assets.models.assets import ServiceEnvironment
 from ralph.assets.models.choices import ComponentType
-from ralph.assets.models.components import ComponentModel
 from ralph.assets.tests.factories import (
     EnvironmentFactory,
     ServiceEnvironmentFactory,
     ServiceFactory,
+    ComponentModelFactory,
 )
 from ralph.data_center.tests.factories import DataCenterAssetFullFactory, RackFactory
 from ralph.lib.custom_fields.models import (
@@ -24,6 +23,7 @@ from ralph.virtual.tests.factories import (
     CloudProjectFactory,
     CloudProviderFactory,
     VirtualServerFullFactory,
+    VirtualComponentFactory,
 )
 
 
@@ -58,37 +58,36 @@ class OpenstackModelsTestCase(RalphTestCase):
     def setUp(self):
         self.envs = EnvironmentFactory.create_batch(2)
         self.services = ServiceFactory.create_batch(2)
-        self.service_env = []
-        for i in range(0, 2):
-            self.service_env.append(
-                ServiceEnvironment.objects.create(
-                    service=self.services[i], environment=self.envs[i]
-                )
+        self.service_env = [
+            ServiceEnvironmentFactory(
+                service=self.services[i], environment=self.envs[i]
             )
+            for i in range(2)
+        ]
 
         self.cloud_provider = CloudProviderFactory(name="openstack")
         self.cloud_flavor = CloudFlavorFactory()
         self.cloud_project = CloudProjectFactory()
         self.cloud_host = CloudHostFactory(parent=self.cloud_project)
 
-        self.test_cpu = ComponentModel.objects.create(
+        self.test_cpu = ComponentModelFactory(
             name="vcpu1",
             cores=4,
             family="vCPU",
             type=ComponentType.processor,
         )
-        self.test_mem = ComponentModel.objects.create(
+        self.test_mem = ComponentModelFactory(
             name="1024 MiB vMEM",
             size="1024",
             type=ComponentType.memory,
         )
-        self.test_disk = ComponentModel.objects.create(
+        self.test_disk = ComponentModelFactory(
             name="4 GiB vDISK",
             size="4096",
             type=ComponentType.disk,
         )
 
-        VirtualComponent.objects.create(
+        VirtualComponentFactory(
             base_object=self.cloud_flavor,
             model=self.test_cpu,
         )


### PR DESCRIPTION
Factories now initialize more fields (still some work to do).
Removed some 3-item iterators (this would prevent tests from detecting N+1 queries).
Factories are now used where .objects.create was used before.
Now tests are better at detecting problems with SQL queries and are less flaky.